### PR TITLE
feat(vendor): self-service backend (menu CRUD, photos, profile, categories)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules/
 dist/
 build/
 *.log
+docs/superpowers/

--- a/backend/core/errors.py
+++ b/backend/core/errors.py
@@ -1,0 +1,29 @@
+"""Stable error envelope for vendor backend endpoints.
+
+Wire shape: {"detail": "<human msg>", "code": "<machine code>"}.
+Frontend keys off `code`; `detail` is for UI display.
+"""
+from fastapi import FastAPI, Request
+from fastapi.exceptions import HTTPException
+from fastapi.responses import JSONResponse
+
+
+class CodedHTTPException(HTTPException):
+    """HTTPException 加上 machine-readable `code`，供前端判斷錯誤類型。"""
+
+    def __init__(self, status_code: int, code: str, detail: str) -> None:
+        super().__init__(status_code=status_code, detail=detail)
+        self.code = code
+
+
+async def _coded_exception_handler(_request: Request, exc: CodedHTTPException) -> JSONResponse:
+    # 統一 envelope，避免 FastAPI 預設把 detail 包成 dict 的雙層結構。
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"detail": exc.detail, "code": exc.code},
+    )
+
+
+def install_error_handler(app: FastAPI) -> None:
+    """於 FastAPI app 註冊 CodedHTTPException 的 handler。"""
+    app.add_exception_handler(CodedHTTPException, _coded_exception_handler)

--- a/backend/core/vendor_identity.py
+++ b/backend/core/vendor_identity.py
@@ -1,0 +1,51 @@
+"""商家身份驗證 dependency。
+
+集中以下三段檢查，避免每條 route 重複：
+  1. 角色必須是 vendor_manager。
+  2. 必須帶 `x-vendor-id` header 且可轉 int。
+  3. 該 vendor 必須存在且 status=='approved'。
+
+未來真正接 JWT 時只需改本檔；route 介面 (`Depends(require_approved_vendor)` 拿到 vendor_id) 不變。
+"""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, Header
+
+from backend.core.errors import CodedHTTPException
+from backend.repositories.vendor_profile_repository import VendorProfileRepository
+
+# Module-singleton：production 模式下 process 內共用同一份 in-memory state。
+# 測試以 app.dependency_overrides[get_vendor_profile_repository] 注入新實例。
+_REPO_SINGLETON = VendorProfileRepository()
+
+
+def get_vendor_profile_repository() -> VendorProfileRepository:
+    """DI 切換點：測試覆寫此 callable 即可換成 fake/seeded repo。"""
+    return _REPO_SINGLETON
+
+
+def require_approved_vendor(
+    repo: Annotated[VendorProfileRepository, Depends(get_vendor_profile_repository)],
+    x_user_role: Annotated[str | None, Header()] = None,
+    x_vendor_id: Annotated[str | None, Header()] = None,
+) -> int:
+    if x_user_role != "vendor_manager":
+        raise CodedHTTPException(status_code=403, code="forbidden", detail="vendor role required")
+
+    if x_vendor_id is None:
+        raise CodedHTTPException(status_code=400, code="validation_error", detail="x-vendor-id header missing")
+    try:
+        vendor_id = int(x_vendor_id)
+    except ValueError as exc:
+        raise CodedHTTPException(status_code=400, code="validation_error", detail="x-vendor-id must be integer") from exc
+
+    record = repo.get(vendor_id)
+    if record is None:
+        # 不洩漏存在性 vs 未授權差別 — 一律 404。
+        raise CodedHTTPException(status_code=404, code="not_found", detail="vendor not found")
+    if record.status != "approved":
+        raise CodedHTTPException(status_code=403, code="vendor_not_approved", detail="vendor not approved")
+
+    return vendor_id

--- a/backend/db/migrations/draft/002_vendor_menu_schema.sql
+++ b/backend/db/migrations/draft/002_vendor_menu_schema.sql
@@ -1,0 +1,52 @@
+-- Draft migration for vendor self-service backend.
+-- DB team to review, adapt to their conventions, and merge into the canonical
+-- migrations directory. Until then, application repositories run on in-memory
+-- stubs — no production data depends on this file existing in the DB.
+
+-- 商家 (vendors) 表預設只有 (id, name, contact_email, status, *_at)。
+-- vendor self-service 需要這些額外欄位 — DB 組請確認後納入或單獨 migrate。
+ALTER TABLE vendors
+  ADD COLUMN IF NOT EXISTS address          TEXT,
+  ADD COLUMN IF NOT EXISTS business_hours   TEXT,
+  ADD COLUMN IF NOT EXISTS contact_phone    TEXT,
+  ADD COLUMN IF NOT EXISTS owner_user_id    BIGINT REFERENCES users(id);
+
+CREATE TABLE IF NOT EXISTS menu_categories (
+  id          BIGSERIAL PRIMARY KEY,
+  vendor_id   BIGINT NOT NULL REFERENCES vendors(id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
+  sort_order  INT NOT NULL DEFAULT 0,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (vendor_id, name)
+);
+CREATE INDEX ON menu_categories (vendor_id, sort_order);
+
+CREATE TABLE IF NOT EXISTS menu_items (
+  id           BIGSERIAL PRIMARY KEY,
+  vendor_id    BIGINT NOT NULL REFERENCES vendors(id) ON DELETE CASCADE,
+  category_id  BIGINT REFERENCES menu_categories(id) ON DELETE SET NULL,
+  name         TEXT NOT NULL,
+  description  TEXT,
+  price_cents  INT NOT NULL CHECK (price_cents >= 0),
+  available    BOOLEAN NOT NULL DEFAULT true,
+  daily_quota  INT CHECK (daily_quota IS NULL OR daily_quota >= 0),  -- 每日最大供應份數，NULL = 不限
+  photo_path   TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON menu_items (vendor_id, category_id);
+CREATE INDEX ON menu_items (vendor_id) WHERE available;
+
+-- 多廠區關聯：committee 模組寫入，vendor backend 唯讀。
+CREATE TABLE IF NOT EXISTS facilities (
+  id    BIGSERIAL PRIMARY KEY,
+  code  TEXT NOT NULL UNIQUE,    -- 廠區代號，例: 'F12A'
+  name  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS vendor_facilities (
+  vendor_id    BIGINT NOT NULL REFERENCES vendors(id)    ON DELETE CASCADE,
+  facility_id  BIGINT NOT NULL REFERENCES facilities(id) ON DELETE CASCADE,
+  PRIMARY KEY (vendor_id, facility_id)
+);
+CREATE INDEX ON vendor_facilities (facility_id);

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.core.config import settings
+from backend.core.errors import install_error_handler
 from backend.routes import admin_vendors, committee_reviews, health
 
 
@@ -15,6 +16,8 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    install_error_handler(app)
 
     app.include_router(health.router)
     app.include_router(admin_vendors.router)

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from backend.core.config import settings
 from backend.core.errors import install_error_handler
-from backend.routes import admin_vendors, committee_reviews, health
+from backend.routes import admin_vendors, committee_reviews, health, vendor_profile
 
 
 def create_app() -> FastAPI:
@@ -22,6 +22,7 @@ def create_app() -> FastAPI:
     app.include_router(health.router)
     app.include_router(admin_vendors.router)
     app.include_router(committee_reviews.router)
+    app.include_router(vendor_profile.router)
     return app
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from backend.core.config import settings
 from backend.core.errors import install_error_handler
-from backend.routes import admin_vendors, committee_reviews, health, vendor_categories, vendor_profile
+from backend.routes import admin_vendors, committee_reviews, health, vendor_categories, vendor_menu, vendor_profile
 
 
 def create_app() -> FastAPI:
@@ -24,6 +24,7 @@ def create_app() -> FastAPI:
     app.include_router(committee_reviews.router)
     app.include_router(vendor_profile.router)
     app.include_router(vendor_categories.router)
+    app.include_router(vendor_menu.router)
     return app
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from backend.core.config import settings
 from backend.core.errors import install_error_handler
-from backend.routes import admin_vendors, committee_reviews, health, vendor_profile
+from backend.routes import admin_vendors, committee_reviews, health, vendor_categories, vendor_profile
 
 
 def create_app() -> FastAPI:
@@ -23,6 +23,7 @@ def create_app() -> FastAPI:
     app.include_router(admin_vendors.router)
     app.include_router(committee_reviews.router)
     app.include_router(vendor_profile.router)
+    app.include_router(vendor_categories.router)
     return app
 
 

--- a/backend/repositories/menu_category_repository.py
+++ b/backend/repositories/menu_category_repository.py
@@ -1,0 +1,77 @@
+"""In-memory MenuCategoryRepository。
+
+每筆都帶 vendor_id；所有 query 必須以 vendor_id scope，避免跨商家洩漏。
+DB 接好後換成 SQL 實作；介面不變。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from itertools import count
+from typing import Any
+
+from backend.schemas.vendor_self import Category
+
+
+@dataclass
+class _CategoryRecord:
+    id: int
+    vendor_id: int
+    name: str
+    sort_order: int
+    created_at: datetime
+
+
+def _to_schema(rec: _CategoryRecord) -> Category:
+    return Category(
+        id=rec.id,
+        vendor_id=rec.vendor_id,
+        name=rec.name,
+        sort_order=rec.sort_order,
+        created_at=rec.created_at,
+    )
+
+
+class MenuCategoryRepository:
+    def __init__(self) -> None:
+        self._rows: dict[int, _CategoryRecord] = {}
+        self._id_seq = count(1)
+
+    def create(self, *, vendor_id: int, name: str, sort_order: int = 0) -> Category:
+        new_id = next(self._id_seq)
+        rec = _CategoryRecord(
+            id=new_id,
+            vendor_id=vendor_id,
+            name=name,
+            sort_order=sort_order,
+            created_at=datetime.now(timezone.utc),
+        )
+        self._rows[new_id] = rec
+        return _to_schema(rec)
+
+    def list(self, *, vendor_id: int) -> list[Category]:
+        rows = [r for r in self._rows.values() if r.vendor_id == vendor_id]
+        rows.sort(key=lambda r: (r.sort_order, r.id))
+        return [_to_schema(r) for r in rows]
+
+    def get(self, *, vendor_id: int, category_id: int) -> Category | None:
+        rec = self._rows.get(category_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return None
+        return _to_schema(rec)
+
+    def update(self, *, vendor_id: int, category_id: int, fields: dict[str, Any]) -> Category | None:
+        rec = self._rows.get(category_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return None
+        # 只覆寫 fields 裡有出現的鍵 (caller 應傳 model_dump(exclude_unset=True))。
+        updated = replace(rec, **{k: v for k, v in fields.items() if v is not None})
+        self._rows[category_id] = updated
+        return _to_schema(updated)
+
+    def delete(self, *, vendor_id: int, category_id: int) -> bool:
+        rec = self._rows.get(category_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return False
+        del self._rows[category_id]
+        return True

--- a/backend/repositories/menu_item_repository.py
+++ b/backend/repositories/menu_item_repository.py
@@ -1,19 +1,137 @@
-"""Placeholder — Task 9 replaces this with the full implementation.
+"""In-memory MenuItemRepository。
 
-Only `has_items_in_category` is needed in T8 for the categories DELETE 409 check.
-The internal `_rows` dict-of-dict is intentionally minimal so this placeholder
-can be replaced wholesale in T9 without callers caring about its shape.
+Vendor-scoped 菜單項目儲存。所有 query 必須以 vendor_id scope。
+DB 接好後換成 SQL 實作；介面不變。
 """
 from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from itertools import count
+from typing import Any
+
+from backend.schemas.vendor_self import MenuItem
+
+
+@dataclass
+class _ItemRecord:
+    id: int
+    vendor_id: int
+    category_id: int | None
+    name: str
+    description: str | None
+    price_cents: int
+    available: bool
+    daily_quota: int | None
+    photo_path: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+def _to_schema(rec: _ItemRecord) -> MenuItem:
+    return MenuItem(
+        id=rec.id,
+        vendor_id=rec.vendor_id,
+        category_id=rec.category_id,
+        name=rec.name,
+        description=rec.description,
+        price_cents=rec.price_cents,
+        available=rec.available,
+        daily_quota=rec.daily_quota,
+        photo_path=rec.photo_path,
+        created_at=rec.created_at,
+        updated_at=rec.updated_at,
+    )
 
 
 class MenuItemRepository:
     def __init__(self) -> None:
-        self._rows: dict[int, dict] = {}
+        self._rows: dict[int, _ItemRecord] = {}
+        self._id_seq = count(1)
+
+    def create(
+        self,
+        *,
+        vendor_id: int,
+        name: str,
+        price_cents: int,
+        description: str | None = None,
+        category_id: int | None = None,
+        available: bool = True,
+        daily_quota: int | None = None,
+    ) -> MenuItem:
+        now = datetime.now(timezone.utc)
+        rec = _ItemRecord(
+            id=next(self._id_seq),
+            vendor_id=vendor_id,
+            category_id=category_id,
+            name=name,
+            description=description,
+            price_cents=price_cents,
+            available=available,
+            daily_quota=daily_quota,
+            photo_path=None,
+            created_at=now,
+            updated_at=now,
+        )
+        self._rows[rec.id] = rec
+        return _to_schema(rec)
+
+    def list(
+        self,
+        *,
+        vendor_id: int,
+        category_id: int | None = None,
+        available: bool | None = None,
+    ) -> list[MenuItem]:
+        rows = [r for r in self._rows.values() if r.vendor_id == vendor_id]
+        if category_id is not None:
+            rows = [r for r in rows if r.category_id == category_id]
+        if available is not None:
+            rows = [r for r in rows if r.available == available]
+        rows.sort(key=lambda r: r.id)
+        return [_to_schema(r) for r in rows]
+
+    def get(self, *, vendor_id: int, item_id: int) -> MenuItem | None:
+        rec = self._rows.get(item_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return None
+        return _to_schema(rec)
+
+    def update(
+        self, *, vendor_id: int, item_id: int, fields: dict[str, Any]
+    ) -> MenuItem | None:
+        rec = self._rows.get(item_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return None
+        # `daily_quota=0` 是合法值 (暫停供應)，不能用 truthy 過濾；
+        # `category_id=None` 也是合法 (取消分類)。所以不能 drop None — 用 sentinel：
+        # 這裡 fields 只包含 client 真有送的鍵 (caller 已 exclude_unset)，故安全直接套用。
+        merged = replace(rec, **fields, updated_at=datetime.now(timezone.utc))
+        self._rows[item_id] = merged
+        return _to_schema(merged)
+
+    def delete(self, *, vendor_id: int, item_id: int) -> bool:
+        rec = self._rows.get(item_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return False
+        del self._rows[item_id]
+        return True
+
+    def set_photo_path(self, *, vendor_id: int, item_id: int, photo_path: str) -> None:
+        rec = self._rows.get(item_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return
+        self._rows[item_id] = replace(rec, photo_path=photo_path, updated_at=datetime.now(timezone.utc))
+
+    def clear_photo_path(self, *, vendor_id: int, item_id: int) -> None:
+        rec = self._rows.get(item_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return
+        self._rows[item_id] = replace(rec, photo_path=None, updated_at=datetime.now(timezone.utc))
 
     def has_items_in_category(self, *, vendor_id: int, category_id: int) -> bool:
-        """Return True if any menu item in the given vendor scope still references the category."""
         return any(
-            r["vendor_id"] == vendor_id and r["category_id"] == category_id
+            r.vendor_id == vendor_id and r.category_id == category_id
             for r in self._rows.values()
         )

--- a/backend/repositories/menu_item_repository.py
+++ b/backend/repositories/menu_item_repository.py
@@ -1,0 +1,19 @@
+"""Placeholder — Task 9 replaces this with the full implementation.
+
+Only `has_items_in_category` is needed in T8 for the categories DELETE 409 check.
+The internal `_rows` dict-of-dict is intentionally minimal so this placeholder
+can be replaced wholesale in T9 without callers caring about its shape.
+"""
+from __future__ import annotations
+
+
+class MenuItemRepository:
+    def __init__(self) -> None:
+        self._rows: dict[int, dict] = {}
+
+    def has_items_in_category(self, *, vendor_id: int, category_id: int) -> bool:
+        """Return True if any menu item in the given vendor scope still references the category."""
+        return any(
+            r["vendor_id"] == vendor_id and r["category_id"] == category_id
+            for r in self._rows.values()
+        )

--- a/backend/repositories/vendor_profile_repository.py
+++ b/backend/repositories/vendor_profile_repository.py
@@ -1,0 +1,60 @@
+"""In-memory VendorProfileRepository.
+
+實作為 process-local dict，僅供 skeleton / 測試 / 本機 demo 使用。
+DB 接好後將此檔換成真正的 SQL 實作；route / service 介面不需更動。
+
+`assign_facility` 在實際系統中由委員會模組寫入；這裡保留是給測試/seed 用。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any
+
+from backend.schemas.vendor_self import Facility
+
+
+@dataclass
+class VendorRecord:
+    id: int
+    name: str
+    status: str
+    address: str | None = None
+    business_hours: str | None = None
+    contact_phone: str | None = None
+    contact_email: str | None = None
+
+
+class VendorProfileRepository:
+    def __init__(self) -> None:
+        self._vendors: dict[int, VendorRecord] = {}
+        # vendor_id -> list of Facility
+        self._facilities: dict[int, list[Facility]] = {}
+
+    # --- seed / write side (admin / committee in real life) ---
+
+    def seed(self, record: VendorRecord) -> None:
+        """測試 / 本機種子資料用。"""
+        self._vendors[record.id] = record
+        self._facilities.setdefault(record.id, [])
+
+    def assign_facility(self, vendor_id: int, *, facility_id: int, code: str, name: str) -> None:
+        """委員會模組 stub：把廠區指派給商家。"""
+        self._facilities.setdefault(vendor_id, [])
+        self._facilities[vendor_id].append(Facility(id=facility_id, code=code, name=name))
+
+    # --- read / vendor-self side ---
+
+    def get(self, vendor_id: int) -> VendorRecord | None:
+        return self._vendors.get(vendor_id)
+
+    def update(self, vendor_id: int, fields: dict[str, Any]) -> VendorRecord | None:
+        existing = self._vendors.get(vendor_id)
+        if existing is None:
+            return None
+        # 只覆寫 fields 裡實際出現的鍵 (caller 應傳 model_dump(exclude_unset=True))。
+        merged = replace(existing, **fields)
+        self._vendors[vendor_id] = merged
+        return merged
+
+    def list_facilities(self, vendor_id: int) -> list[Facility]:
+        return list(self._facilities.get(vendor_id, []))

--- a/backend/routes/vendor_categories.py
+++ b/backend/routes/vendor_categories.py
@@ -1,0 +1,79 @@
+"""/vendor/me/categories — 菜單分類 CRUD。"""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import Response
+
+from backend.core.vendor_identity import require_approved_vendor
+from backend.repositories.menu_category_repository import MenuCategoryRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.schemas.vendor_self import Category, CategoryCreate, CategoryUpdate
+from backend.services.vendor_category_service import VendorCategoryService
+
+router = APIRouter(prefix="/vendor/me/categories", tags=["vendor-self"])
+
+
+# Module-singleton repos：跟 vendor_identity 一樣，process 內共用 in-memory state。
+# 測試以 app.dependency_overrides 注入新實例。
+_category_repo = MenuCategoryRepository()
+_item_repo_for_category = MenuItemRepository()
+
+
+def get_menu_category_repository() -> MenuCategoryRepository:
+    return _category_repo
+
+
+def get_menu_item_repository_for_category() -> MenuItemRepository:
+    """名字加 _for_category 是為了讓 routes/vendor_menu.py 也能擁有自己的 override key
+    (兩條 route 共用同一份 repo，但測試可分別注入)。"""
+    return _item_repo_for_category
+
+
+def get_vendor_category_service(
+    cat_repo: Annotated[MenuCategoryRepository, Depends(get_menu_category_repository)],
+    item_repo: Annotated[MenuItemRepository, Depends(get_menu_item_repository_for_category)],
+) -> VendorCategoryService:
+    return VendorCategoryService(cat_repo, item_repo)
+
+
+@router.get("", response_model=list[Category])
+def list_categories(
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorCategoryService, Depends(get_vendor_category_service)],
+) -> list[Category]:
+    """列出目前商家的所有分類，依 sort_order 升冪。"""
+    return service.list(vendor_id)
+
+
+@router.post("", response_model=Category, status_code=status.HTTP_201_CREATED)
+def create_category(
+    payload: CategoryCreate,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorCategoryService, Depends(get_vendor_category_service)],
+) -> Category:
+    """新增分類。"""
+    return service.create(vendor_id, payload)
+
+
+@router.patch("/{category_id}", response_model=Category)
+def update_category(
+    category_id: int,
+    payload: CategoryUpdate,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorCategoryService, Depends(get_vendor_category_service)],
+) -> Category:
+    """局部更新分類 (name / sort_order)。"""
+    return service.update(vendor_id, category_id, payload)
+
+
+@router.delete("/{category_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_category(
+    category_id: int,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorCategoryService, Depends(get_vendor_category_service)],
+) -> Response:
+    """刪除分類；底下若還有 menu item 會回 409 category_not_empty。"""
+    service.delete(vendor_id, category_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/routes/vendor_menu.py
+++ b/backend/routes/vendor_menu.py
@@ -1,0 +1,101 @@
+"""/vendor/me/menu — 菜單項目 CRUD + 照片 sub-resource。
+
+Photo endpoints (PUT / DELETE /menu/{id}/photo) 在 Task 12 加入。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
+from fastapi.responses import Response
+
+from backend.core.vendor_identity import require_approved_vendor
+from backend.repositories.menu_category_repository import MenuCategoryRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.routes.vendor_categories import get_menu_category_repository
+from backend.schemas.vendor_self import MenuItem, MenuItemCreate, MenuItemUpdate
+from backend.services.vendor_menu_service import VendorMenuService
+from backend.storage.photo_storage import PhotoStorage
+
+router = APIRouter(prefix="/vendor/me/menu", tags=["vendor-self"])
+
+
+# Photo storage 預設 root：production 由 docker volume mount。
+_default_storage_root = Path("/app/uploads")
+_storage = PhotoStorage(root=_default_storage_root)
+
+
+def get_menu_item_repository() -> MenuItemRepository:
+    """共用 vendor_categories 那邊的同一份 in-memory repo singleton。
+
+    若兩條 route 各自 `MenuItemRepository()`，categories 的 409 檢查
+    (has_items_in_category) 會看不到 menu route 建立的 item。
+    """
+    from backend.routes.vendor_categories import get_menu_item_repository_for_category
+
+    return get_menu_item_repository_for_category()
+
+
+def get_photo_storage() -> PhotoStorage:
+    return _storage
+
+
+def get_vendor_menu_service(
+    item_repo: Annotated[MenuItemRepository, Depends(get_menu_item_repository)],
+    cat_repo: Annotated[MenuCategoryRepository, Depends(get_menu_category_repository)],
+    storage: Annotated[PhotoStorage, Depends(get_photo_storage)],
+) -> VendorMenuService:
+    return VendorMenuService(item_repo, cat_repo, storage)
+
+
+@router.get("", response_model=list[MenuItem])
+def list_menu(
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+    category_id: Annotated[int | None, Query()] = None,
+    available: Annotated[bool | None, Query()] = None,
+) -> list[MenuItem]:
+    """列出商家菜單；可用 category_id / available 篩選。"""
+    return service.list(vendor_id, category_id=category_id, available=available)
+
+
+@router.post("", response_model=MenuItem, status_code=status.HTTP_201_CREATED)
+def create_menu_item(
+    payload: MenuItemCreate,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+) -> MenuItem:
+    """新增菜單項目。daily_quota: None=不限, 0=暫停供應。"""
+    return service.create(vendor_id, payload)
+
+
+@router.get("/{item_id}", response_model=MenuItem)
+def get_menu_item(
+    item_id: int,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+) -> MenuItem:
+    return service.get(vendor_id, item_id)
+
+
+@router.patch("/{item_id}", response_model=MenuItem)
+def patch_menu_item(
+    item_id: int,
+    payload: MenuItemUpdate,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+) -> MenuItem:
+    """局部更新菜單項目。"""
+    return service.update(vendor_id, item_id, payload)
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_menu_item(
+    item_id: int,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+) -> Response:
+    """刪除菜單項目；連帶刪除照片檔。"""
+    service.delete(vendor_id, item_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/routes/vendor_menu.py
+++ b/backend/routes/vendor_menu.py
@@ -7,14 +7,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, File, Query, UploadFile, status
 from fastapi.responses import Response
 
 from backend.core.vendor_identity import require_approved_vendor
 from backend.repositories.menu_category_repository import MenuCategoryRepository
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.routes.vendor_categories import get_menu_category_repository
-from backend.schemas.vendor_self import MenuItem, MenuItemCreate, MenuItemUpdate
+from backend.schemas.vendor_self import MenuItem, MenuItemCreate, MenuItemUpdate, PhotoUploadResponse
 from backend.services.vendor_menu_service import VendorMenuService
 from backend.storage.photo_storage import PhotoStorage
 
@@ -98,4 +98,32 @@ def delete_menu_item(
 ) -> Response:
     """刪除菜單項目；連帶刪除照片檔。"""
     service.delete(vendor_id, item_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.put("/{item_id}/photo", response_model=PhotoUploadResponse)
+async def put_menu_photo(
+    item_id: int,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+    file: UploadFile = File(...),
+) -> PhotoUploadResponse:
+    """上傳/覆蓋菜單項目照片 (multipart `file`)。
+
+    Storage 層會強制重新編碼成 JPEG、限制 5MB、最長邊 1600px。
+    PUT 語意 — idempotent，多次呼叫覆蓋既有照片。
+    """
+    data = await file.read()
+    path = service.replace_photo(vendor_id=vendor_id, item_id=item_id, data=data)
+    return PhotoUploadResponse(photo_path=path)
+
+
+@router.delete("/{item_id}/photo", status_code=status.HTTP_204_NO_CONTENT)
+def delete_menu_photo(
+    item_id: int,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+) -> Response:
+    """刪除菜單項目照片 (檔案 + DB 路徑都清空)；不存在不算錯。"""
+    service.delete_photo(vendor_id=vendor_id, item_id=item_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/routes/vendor_profile.py
+++ b/backend/routes/vendor_profile.py
@@ -1,0 +1,42 @@
+"""/vendor/me/profile — 商家自身資料讀寫。"""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from backend.core.vendor_identity import (
+    get_vendor_profile_repository,
+    require_approved_vendor,
+)
+from backend.repositories.vendor_profile_repository import VendorProfileRepository
+from backend.schemas.vendor_self import VendorProfile, VendorProfileUpdate
+from backend.services.vendor_profile_service import VendorProfileService
+
+router = APIRouter(prefix="/vendor/me", tags=["vendor-self"])
+
+
+def get_vendor_profile_service(
+    repo: Annotated[VendorProfileRepository, Depends(get_vendor_profile_repository)],
+) -> VendorProfileService:
+    """DI factory — tests override 以注入 fake repo 後得到 fresh service。"""
+    return VendorProfileService(repo)
+
+
+@router.get("/profile", response_model=VendorProfile)
+def get_profile(
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorProfileService, Depends(get_vendor_profile_service)],
+) -> VendorProfile:
+    """取得目前登入商家的資料 (含唯讀的 served_facilities 廠區清單)。"""
+    return service.get(vendor_id)
+
+
+@router.patch("/profile", response_model=VendorProfile)
+def patch_profile(
+    payload: VendorProfileUpdate,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorProfileService, Depends(get_vendor_profile_service)],
+) -> VendorProfile:
+    """局部更新商家資料；served_facilities 等唯讀欄位若出現在 body 會被忽略。"""
+    return service.update(vendor_id, payload)

--- a/backend/schemas/vendor_self.py
+++ b/backend/schemas/vendor_self.py
@@ -1,0 +1,129 @@
+"""Vendor 自助管理 API 的 Pydantic 模型。
+
+集中放置 request / response schema，方便 route + service + test 共用。
+若日後此檔超過 ~200 行可依資源拆分（profile / category / menu）。
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+
+# 所有 user-input 字串型欄位共用：去頭尾空白 + 至少 1 字元（避免純空白）。
+NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class Facility(BaseModel):
+    """廠區 (committee 模組維護，vendor 端唯讀)。"""
+
+    id: int
+    code: str
+    name: str
+
+
+# -------- Profile --------
+
+
+class VendorProfile(BaseModel):
+    """商家自身資料 (含唯讀的 served_facilities 廠區清單)。"""
+
+    id: int
+    name: str
+    status: str
+    address: str | None = None
+    business_hours: str | None = None
+    contact_phone: str | None = None
+    contact_email: str | None = None
+    served_facilities: list[Facility] = Field(default_factory=list)
+
+
+class VendorProfileUpdate(BaseModel):
+    """PATCH /vendor/me/profile body — 全欄位 optional。"""
+
+    # extra='ignore' 讓 served_facilities 等唯讀欄位被默默忽略，不回 422。
+    model_config = ConfigDict(extra="ignore")
+
+    name: NonBlankStr | None = None
+    address: str | None = None
+    business_hours: str | None = None
+    contact_phone: str | None = None
+    contact_email: str | None = None
+
+
+# -------- Categories --------
+
+
+class Category(BaseModel):
+    """菜單分類。"""
+
+    id: int
+    vendor_id: int
+    name: str
+    sort_order: int
+    created_at: datetime
+
+
+class CategoryCreate(BaseModel):
+    """建立分類。"""
+
+    name: NonBlankStr
+    sort_order: int = 0
+
+
+class CategoryUpdate(BaseModel):
+    """局部更新分類；全欄位 optional。"""
+
+    name: NonBlankStr | None = None
+    sort_order: int | None = None
+
+
+# -------- Menu items --------
+
+
+class MenuItem(BaseModel):
+    """菜單項目（回傳用）。"""
+
+    id: int
+    vendor_id: int
+    category_id: int | None
+    name: str
+    description: str | None
+    price_cents: int
+    available: bool
+    daily_quota: int | None
+    photo_path: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class MenuItemCreate(BaseModel):
+    """建立菜單項目。
+
+    `daily_quota`：None = 不限；0 = 暫停供應 (與 available=False 不同：保留份數設定意圖)。
+    """
+
+    name: NonBlankStr
+    description: str | None = None
+    price_cents: int = Field(ge=0)
+    category_id: int | None = None
+    available: bool = True
+    daily_quota: int | None = Field(default=None, ge=0)
+
+
+class MenuItemUpdate(BaseModel):
+    """局部更新；全欄位 optional。"""
+
+    name: NonBlankStr | None = None
+    description: str | None = None
+    price_cents: int | None = Field(default=None, ge=0)
+    category_id: int | None = None
+    available: bool | None = None
+    daily_quota: int | None = Field(default=None, ge=0)
+
+
+class PhotoUploadResponse(BaseModel):
+    """上傳圖片後回傳的路徑。"""
+
+    photo_path: str

--- a/backend/services/vendor_category_service.py
+++ b/backend/services/vendor_category_service.py
@@ -1,0 +1,55 @@
+"""菜單分類 (Category) 的 vendor-scoped CRUD 邏輯。
+
+刪除前以 MenuItemRepository.has_items_in_category 檢查；
+若分類底下還有 menu item，service 層回 409 (`category_not_empty`)，
+不依賴 DB FK 規則 (FK 是 last-resort backstop)。
+"""
+from __future__ import annotations
+
+from backend.core.errors import CodedHTTPException
+from backend.repositories.menu_category_repository import MenuCategoryRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.schemas.vendor_self import Category, CategoryCreate, CategoryUpdate
+
+
+class VendorCategoryService:
+    def __init__(
+        self,
+        category_repository: MenuCategoryRepository,
+        menu_item_repository: MenuItemRepository,
+    ) -> None:
+        self.category_repository = category_repository
+        self.menu_item_repository = menu_item_repository
+
+    def list(self, vendor_id: int) -> list[Category]:
+        return self.category_repository.list(vendor_id=vendor_id)
+
+    def create(self, vendor_id: int, payload: CategoryCreate) -> Category:
+        return self.category_repository.create(
+            vendor_id=vendor_id,
+            name=payload.name,
+            sort_order=payload.sort_order,
+        )
+
+    def update(self, vendor_id: int, category_id: int, payload: CategoryUpdate) -> Category:
+        fields = payload.model_dump(exclude_unset=True)
+        updated = self.category_repository.update(
+            vendor_id=vendor_id, category_id=category_id, fields=fields
+        )
+        if updated is None:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="category not found")
+        return updated
+
+    def delete(self, vendor_id: int, category_id: int) -> None:
+        # 取得確認分類存在 (跨商家也回 404 — 不洩漏存在性)
+        existing = self.category_repository.get(vendor_id=vendor_id, category_id=category_id)
+        if existing is None:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="category not found")
+        # 阻擋刪除有 item 引用的分類
+        if self.menu_item_repository.has_items_in_category(vendor_id=vendor_id, category_id=category_id):
+            raise CodedHTTPException(
+                status_code=409,
+                code="category_not_empty",
+                detail="category still has menu items",
+            )
+        self.category_repository.delete(vendor_id=vendor_id, category_id=category_id)

--- a/backend/services/vendor_menu_service.py
+++ b/backend/services/vendor_menu_service.py
@@ -1,0 +1,102 @@
+"""菜單項目 CRUD + 照片資源管理。
+
+照片實際 IO 委派給 PhotoStorage；本 service 只負責：
+  - 驗證 category_id 屬於同商家 (避免跨商家透過 FK 偷塞)
+  - 422 / 404 等錯誤包裝
+  - 寫照片成功後 set_photo_path 回 repo；刪 item 時連帶刪檔。
+"""
+from __future__ import annotations
+
+from backend.core.errors import CodedHTTPException
+from backend.repositories.menu_category_repository import MenuCategoryRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.schemas.vendor_self import MenuItem, MenuItemCreate, MenuItemUpdate
+from backend.storage.photo_storage import PhotoStorage
+
+
+class VendorMenuService:
+    def __init__(
+        self,
+        menu_item_repository: MenuItemRepository,
+        category_repository: MenuCategoryRepository,
+        photo_storage: PhotoStorage,
+    ) -> None:
+        self.menu_item_repository = menu_item_repository
+        self.category_repository = category_repository
+        self.photo_storage = photo_storage
+
+    # --- query ---
+
+    def list(
+        self, vendor_id: int, *, category_id: int | None = None, available: bool | None = None
+    ) -> list[MenuItem]:
+        return self.menu_item_repository.list(
+            vendor_id=vendor_id, category_id=category_id, available=available
+        )
+
+    def get(self, vendor_id: int, item_id: int) -> MenuItem:
+        item = self.menu_item_repository.get(vendor_id=vendor_id, item_id=item_id)
+        if item is None:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="menu item not found")
+        return item
+
+    # --- mutate ---
+
+    def create(self, vendor_id: int, payload: MenuItemCreate) -> MenuItem:
+        if payload.category_id is not None:
+            self._assert_category_belongs_to(vendor_id, payload.category_id)
+        return self.menu_item_repository.create(
+            vendor_id=vendor_id,
+            name=payload.name,
+            description=payload.description,
+            price_cents=payload.price_cents,
+            category_id=payload.category_id,
+            available=payload.available,
+            daily_quota=payload.daily_quota,
+        )
+
+    def update(self, vendor_id: int, item_id: int, payload: MenuItemUpdate) -> MenuItem:
+        # 確保 item 屬於 caller (避免讓 update 變成跨商家寫入)
+        self.get(vendor_id, item_id)
+        fields = payload.model_dump(exclude_unset=True)
+        if "category_id" in fields and fields["category_id"] is not None:
+            self._assert_category_belongs_to(vendor_id, fields["category_id"])
+        updated = self.menu_item_repository.update(
+            vendor_id=vendor_id, item_id=item_id, fields=fields
+        )
+        # update 已先 get 過，updated 不應為 None。
+        assert updated is not None
+        return updated
+
+    def delete(self, vendor_id: int, item_id: int) -> None:
+        # 連帶刪除檔案 (best-effort)；先刪檔再刪 row 避免 row 沒了但檔還在。
+        self.get(vendor_id, item_id)
+        self.photo_storage.delete_menu_photo(vendor_id=vendor_id, item_id=item_id)
+        self.menu_item_repository.delete(vendor_id=vendor_id, item_id=item_id)
+
+    # --- photo sub-resource (used by Task 12) ---
+
+    def replace_photo(self, vendor_id: int, item_id: int, data: bytes) -> str:
+        self.get(vendor_id, item_id)  # ensure ownership before touching disk
+        path = self.photo_storage.store_menu_photo(
+            vendor_id=vendor_id, item_id=item_id, data=data
+        )
+        self.menu_item_repository.set_photo_path(
+            vendor_id=vendor_id, item_id=item_id, photo_path=path
+        )
+        return path
+
+    def delete_photo(self, vendor_id: int, item_id: int) -> None:
+        self.get(vendor_id, item_id)
+        self.photo_storage.delete_menu_photo(vendor_id=vendor_id, item_id=item_id)
+        self.menu_item_repository.clear_photo_path(vendor_id=vendor_id, item_id=item_id)
+
+    # --- helpers ---
+
+    def _assert_category_belongs_to(self, vendor_id: int, category_id: int) -> None:
+        if self.category_repository.get(vendor_id=vendor_id, category_id=category_id) is None:
+            raise CodedHTTPException(
+                status_code=422,
+                code="validation_error",
+                detail="category_id does not belong to this vendor",
+            )

--- a/backend/services/vendor_profile_service.py
+++ b/backend/services/vendor_profile_service.py
@@ -1,0 +1,37 @@
+"""商家自身資料的讀寫邏輯 (Profile)。
+
+Route 不直接打 repository — 透過此 service 集中處理：
+  - 將 repository record 轉成對外 schema (VendorProfile)
+  - 處理 PATCH 的部分更新語意
+  - 附加唯讀的 served_facilities 廠區清單
+"""
+from __future__ import annotations
+
+from backend.repositories.vendor_profile_repository import VendorProfileRepository
+from backend.schemas.vendor_self import VendorProfile, VendorProfileUpdate
+
+
+class VendorProfileService:
+    def __init__(self, repository: VendorProfileRepository) -> None:
+        self.repository = repository
+
+    def get(self, vendor_id: int) -> VendorProfile:
+        record = self.repository.get(vendor_id)
+        # vendor_id 已由 require_approved_vendor 驗證存在；理論上不會 None。
+        assert record is not None
+        return VendorProfile(
+            id=record.id,
+            name=record.name,
+            status=record.status,
+            address=record.address,
+            business_hours=record.business_hours,
+            contact_phone=record.contact_phone,
+            contact_email=record.contact_email,
+            served_facilities=self.repository.list_facilities(vendor_id),
+        )
+
+    def update(self, vendor_id: int, payload: VendorProfileUpdate) -> VendorProfile:
+        # exclude_unset：只有 client 真的送的欄位才會被更新。
+        updates = payload.model_dump(exclude_unset=True)
+        self.repository.update(vendor_id, updates)
+        return self.get(vendor_id)

--- a/backend/storage/photo_storage.py
+++ b/backend/storage/photo_storage.py
@@ -1,0 +1,81 @@
+"""菜單照片儲存層。
+
+- 不信任 client 提供的 content-type；用 PIL 實際解碼來判型別。
+- 一律重新編碼成 JPEG (strip EXIF / SVG 等 payload smuggling 風險)。
+- 寫入採 .tmp + os.replace 原子操作，避免 Caddy 看到半寫入檔案。
+- Repository 不碰檔案；service 層用 set_photo_path() 把相對路徑寫回 DB。
+"""
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+
+from PIL import Image, UnidentifiedImageError
+
+from backend.core.errors import CodedHTTPException
+
+_ALLOWED_FORMATS = {"JPEG", "PNG", "WEBP"}
+_DEFAULT_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+_DEFAULT_MAX_EDGE = 1600
+
+
+class PhotoStorage:
+    def __init__(
+        self,
+        root: Path,
+        *,
+        max_bytes: int = _DEFAULT_MAX_BYTES,
+        max_edge_px: int = _DEFAULT_MAX_EDGE,
+    ) -> None:
+        self.root = root
+        self.max_bytes = max_bytes
+        self.max_edge_px = max_edge_px
+
+    def store_menu_photo(self, *, vendor_id: int, item_id: int, data: bytes) -> str:
+        """驗證 → 重新編碼 → 原子寫入；回傳 DB 用的相對路徑。"""
+        if len(data) > self.max_bytes:
+            raise CodedHTTPException(status_code=413, code="image_too_large", detail="image exceeds size limit")
+
+        try:
+            with Image.open(io.BytesIO(data)) as img:
+                if img.format not in _ALLOWED_FORMATS:
+                    raise CodedHTTPException(
+                        status_code=415,
+                        code="invalid_image_type",
+                        detail=f"unsupported image format: {img.format}",
+                    )
+                img.load()
+                # 轉 RGB 才能存成 JPEG (PNG 可能是 RGBA / palette mode)
+                rgb = img.convert("RGB")
+        except UnidentifiedImageError as exc:
+            raise CodedHTTPException(
+                status_code=415, code="invalid_image_type", detail="not a recognised image"
+            ) from exc
+
+        # 等比例縮到最長邊 = max_edge_px
+        if max(rgb.size) > self.max_edge_px:
+            ratio = self.max_edge_px / max(rgb.size)
+            new_size = (int(rgb.size[0] * ratio), int(rgb.size[1] * ratio))
+            rgb = rgb.resize(new_size)
+
+        rel_path = self._relative_path(vendor_id, item_id)
+        final_path = self.root / rel_path
+        final_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = final_path.with_suffix(final_path.suffix + ".tmp")
+
+        # 先寫 tmp 再 rename — 避免 Caddy 服務到半寫檔案。
+        rgb.save(tmp_path, format="JPEG", quality=85, optimize=True)
+        os.replace(tmp_path, final_path)
+        return rel_path
+
+    def delete_menu_photo(self, *, vendor_id: int, item_id: int) -> None:
+        """Best-effort 刪除；檔案不存在不算錯 (idempotent)。"""
+        try:
+            (self.root / self._relative_path(vendor_id, item_id)).unlink()
+        except FileNotFoundError:
+            return
+
+    @staticmethod
+    def _relative_path(vendor_id: int, item_id: int) -> str:
+        return f"vendors/{vendor_id}/menu/{item_id}.jpg"

--- a/backend/storage/photo_storage.py
+++ b/backend/storage/photo_storage.py
@@ -18,6 +18,8 @@ from backend.core.errors import CodedHTTPException
 _ALLOWED_FORMATS = {"JPEG", "PNG", "WEBP"}
 _DEFAULT_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
 _DEFAULT_MAX_EDGE = 1600
+# 解壓縮炸彈防線：拒絕宣稱像素 > 25M 的圖（5MB PNG 可宣稱 50000x50000 = 25 億像素 → 記憶體 DoS）
+_MAX_PIXELS = 25_000_000
 
 
 class PhotoStorage:
@@ -45,10 +47,20 @@ class PhotoStorage:
                         code="invalid_image_type",
                         detail=f"unsupported image format: {img.format}",
                     )
+                # 在 load() 之前先檢查像素數，避免解壓縮炸彈耗盡記憶體
+                width, height = img.size
+                if width * height > _MAX_PIXELS:
+                    raise CodedHTTPException(
+                        status_code=413,
+                        code="image_too_large",
+                        detail=f"image dimensions exceed limit ({width}x{height})",
+                    )
                 img.load()
                 # 轉 RGB 才能存成 JPEG (PNG 可能是 RGBA / palette mode)
                 rgb = img.convert("RGB")
-        except UnidentifiedImageError as exc:
+        except (UnidentifiedImageError, Image.DecompressionBombError, OSError) as exc:
+            # PIL 可能拋多種型別：未識別格式、解壓縮炸彈、檔案截斷等。
+            # 一律當成「壞圖」回 415，不洩漏內部 stack trace。
             raise CodedHTTPException(
                 status_code=415, code="invalid_image_type", detail="not a recognised image"
             ) from exc

--- a/backend/tests/integration/test_vendor_menu_db.py
+++ b/backend/tests/integration/test_vendor_menu_db.py
@@ -1,0 +1,28 @@
+"""Integration tier — runs against a real Postgres once the DB layer wires up.
+
+These tests are marked `integration` and skipped by default in the unit run.
+Enable with: pytest -m integration
+"""
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.skip(reason="awaiting DB persistence wiring")]
+
+
+def test_menu_crud_round_trip_against_real_db() -> None:
+    """End-to-end: POST /vendor/me/menu → row in menu_items → GET → PATCH → DELETE."""
+    raise AssertionError("implement once persistence layer lands")
+
+
+def test_vendor_cascade_deletes_categories_and_items() -> None:
+    """Deleting a vendor removes their menu_categories + menu_items rows."""
+    raise AssertionError("implement once persistence layer lands")
+
+
+def test_served_facilities_join_returned_in_profile() -> None:
+    """vendor_facilities row → /vendor/me/profile shows it under served_facilities."""
+    raise AssertionError("implement once persistence layer lands")
+
+
+def test_photo_upload_orphan_cleanup_on_db_failure() -> None:
+    """Simulated DB failure after file write must not leave an orphan file."""
+    raise AssertionError("implement once persistence layer lands")

--- a/backend/tests/test_error_envelope.py
+++ b/backend/tests/test_error_envelope.py
@@ -1,0 +1,23 @@
+"""Verify the flat {detail, code} error envelope contract."""
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.core.errors import CodedHTTPException, install_error_handler
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    install_error_handler(app)
+
+    @app.get("/boom")
+    def boom() -> None:
+        raise CodedHTTPException(status_code=403, code="vendor_not_approved", detail="vendor not approved")
+
+    return app
+
+
+def test_coded_exception_renders_flat_envelope() -> None:
+    client = TestClient(_make_app())
+    response = client.get("/boom")
+    assert response.status_code == 403
+    assert response.json() == {"detail": "vendor not approved", "code": "vendor_not_approved"}

--- a/backend/tests/test_menu_category_repository.py
+++ b/backend/tests/test_menu_category_repository.py
@@ -1,0 +1,46 @@
+"""In-memory MenuCategoryRepository — vendor-scoped CRUD."""
+from backend.repositories.menu_category_repository import MenuCategoryRepository
+
+
+def test_create_assigns_id_and_returns_record() -> None:
+    repo = MenuCategoryRepository()
+    cat = repo.create(vendor_id=1, name="Hot", sort_order=0)
+    assert cat.id > 0
+    assert cat.vendor_id == 1
+    assert cat.name == "Hot"
+
+
+def test_list_returns_only_caller_vendors_categories() -> None:
+    repo = MenuCategoryRepository()
+    repo.create(vendor_id=1, name="A")
+    repo.create(vendor_id=1, name="B")
+    repo.create(vendor_id=2, name="X")
+    categories = repo.list(vendor_id=1)
+    assert {c.name for c in categories} == {"A", "B"}
+
+
+def test_get_returns_none_if_other_vendor() -> None:
+    repo = MenuCategoryRepository()
+    cat = repo.create(vendor_id=1, name="A")
+    assert repo.get(vendor_id=2, category_id=cat.id) is None
+
+
+def test_update_changes_name_and_sort_order() -> None:
+    repo = MenuCategoryRepository()
+    cat = repo.create(vendor_id=1, name="A", sort_order=0)
+    updated = repo.update(vendor_id=1, category_id=cat.id, fields={"name": "B", "sort_order": 5})
+    assert updated is not None
+    assert updated.name == "B"
+    assert updated.sort_order == 5
+
+
+def test_delete_removes_record() -> None:
+    repo = MenuCategoryRepository()
+    cat = repo.create(vendor_id=1, name="A")
+    assert repo.delete(vendor_id=1, category_id=cat.id) is True
+    assert repo.get(vendor_id=1, category_id=cat.id) is None
+
+
+def test_delete_unknown_returns_false() -> None:
+    repo = MenuCategoryRepository()
+    assert repo.delete(vendor_id=1, category_id=999) is False

--- a/backend/tests/test_menu_item_repository.py
+++ b/backend/tests/test_menu_item_repository.py
@@ -1,0 +1,73 @@
+"""In-memory MenuItemRepository — vendor-scoped CRUD + photo-path bookkeeping."""
+from backend.repositories.menu_item_repository import MenuItemRepository
+
+
+def test_create_assigns_id_and_defaults() -> None:
+    repo = MenuItemRepository()
+    item = repo.create(vendor_id=1, category_id=None, name="Rice", price_cents=80)
+    assert item.id > 0
+    assert item.available is True
+    assert item.daily_quota is None
+    assert item.photo_path is None
+
+
+def test_list_filters_by_vendor() -> None:
+    repo = MenuItemRepository()
+    repo.create(vendor_id=1, name="A", price_cents=10)
+    repo.create(vendor_id=2, name="B", price_cents=10)
+    assert {i.name for i in repo.list(vendor_id=1)} == {"A"}
+
+
+def test_list_filters_by_category() -> None:
+    repo = MenuItemRepository()
+    a = repo.create(vendor_id=1, category_id=10, name="A", price_cents=10)
+    repo.create(vendor_id=1, category_id=20, name="B", price_cents=10)
+    listed = repo.list(vendor_id=1, category_id=10)
+    assert [i.id for i in listed] == [a.id]
+
+
+def test_list_filters_by_available() -> None:
+    repo = MenuItemRepository()
+    a = repo.create(vendor_id=1, name="A", price_cents=10, available=True)
+    repo.create(vendor_id=1, name="B", price_cents=10, available=False)
+    listed = repo.list(vendor_id=1, available=True)
+    assert [i.id for i in listed] == [a.id]
+
+
+def test_get_returns_none_for_other_vendor() -> None:
+    repo = MenuItemRepository()
+    item = repo.create(vendor_id=1, name="A", price_cents=10)
+    assert repo.get(vendor_id=2, item_id=item.id) is None
+
+
+def test_update_partial_fields() -> None:
+    repo = MenuItemRepository()
+    item = repo.create(vendor_id=1, name="A", price_cents=10, daily_quota=50)
+    updated = repo.update(vendor_id=1, item_id=item.id, fields={"daily_quota": 0})
+    assert updated is not None
+    assert updated.daily_quota == 0
+    assert updated.name == "A"
+
+
+def test_delete_removes_record() -> None:
+    repo = MenuItemRepository()
+    item = repo.create(vendor_id=1, name="A", price_cents=10)
+    assert repo.delete(vendor_id=1, item_id=item.id) is True
+    assert repo.get(vendor_id=1, item_id=item.id) is None
+
+
+def test_set_and_clear_photo_path() -> None:
+    repo = MenuItemRepository()
+    item = repo.create(vendor_id=1, name="A", price_cents=10)
+    repo.set_photo_path(vendor_id=1, item_id=item.id, photo_path="vendors/1/menu/1.jpg")
+    assert repo.get(vendor_id=1, item_id=item.id).photo_path == "vendors/1/menu/1.jpg"
+    repo.clear_photo_path(vendor_id=1, item_id=item.id)
+    assert repo.get(vendor_id=1, item_id=item.id).photo_path is None
+
+
+def test_has_items_in_category_true_and_false() -> None:
+    repo = MenuItemRepository()
+    repo.create(vendor_id=1, category_id=10, name="A", price_cents=10)
+    assert repo.has_items_in_category(vendor_id=1, category_id=10) is True
+    assert repo.has_items_in_category(vendor_id=1, category_id=99) is False
+    assert repo.has_items_in_category(vendor_id=2, category_id=10) is False

--- a/backend/tests/test_photo_storage.py
+++ b/backend/tests/test_photo_storage.py
@@ -1,0 +1,60 @@
+"""PhotoStorage: validate, re-encode, atomic write, idempotent delete."""
+import io
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from backend.core.errors import CodedHTTPException
+from backend.storage.photo_storage import PhotoStorage
+
+
+def _png_bytes(width: int = 100, height: int = 100) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color="red").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_store_writes_jpeg_and_returns_relative_path(tmp_path: Path) -> None:
+    storage = PhotoStorage(root=tmp_path)
+    rel = storage.store_menu_photo(vendor_id=1, item_id=2, data=_png_bytes())
+    assert rel == "vendors/1/menu/2.jpg"
+    on_disk = tmp_path / rel
+    assert on_disk.exists()
+    with Image.open(on_disk) as img:
+        assert img.format == "JPEG"
+
+
+def test_store_resizes_oversized_image(tmp_path: Path) -> None:
+    storage = PhotoStorage(root=tmp_path, max_edge_px=100)
+    storage.store_menu_photo(vendor_id=1, item_id=1, data=_png_bytes(width=1000, height=500))
+    with Image.open(tmp_path / "vendors/1/menu/1.jpg") as img:
+        assert max(img.size) == 100
+
+
+def test_store_rejects_oversize_bytes(tmp_path: Path) -> None:
+    storage = PhotoStorage(root=tmp_path, max_bytes=1024)
+    with pytest.raises(CodedHTTPException) as exc:
+        storage.store_menu_photo(vendor_id=1, item_id=1, data=_png_bytes(width=500, height=500))
+    assert exc.value.status_code == 413
+    assert exc.value.code == "image_too_large"
+
+
+def test_store_rejects_non_image_bytes(tmp_path: Path) -> None:
+    storage = PhotoStorage(root=tmp_path)
+    with pytest.raises(CodedHTTPException) as exc:
+        storage.store_menu_photo(vendor_id=1, item_id=1, data=b"this is not an image")
+    assert exc.value.status_code == 415
+    assert exc.value.code == "invalid_image_type"
+
+
+def test_delete_existing_file(tmp_path: Path) -> None:
+    storage = PhotoStorage(root=tmp_path)
+    storage.store_menu_photo(vendor_id=1, item_id=1, data=_png_bytes())
+    storage.delete_menu_photo(vendor_id=1, item_id=1)
+    assert not (tmp_path / "vendors/1/menu/1.jpg").exists()
+
+
+def test_delete_missing_file_is_idempotent(tmp_path: Path) -> None:
+    storage = PhotoStorage(root=tmp_path)
+    storage.delete_menu_photo(vendor_id=1, item_id=999)

--- a/backend/tests/test_vendor_categories.py
+++ b/backend/tests/test_vendor_categories.py
@@ -62,7 +62,7 @@ def test_delete_non_empty_category_returns_409() -> None:
     client, cat_repo, item_repo = _setup()
     cat = cat_repo.create(vendor_id=1, name="Hot")
     # Manually inject an item to simulate one existing in the category
-    item_repo._rows[1] = {"vendor_id": 1, "category_id": cat.id}
+    item_repo.create(vendor_id=1, category_id=cat.id, name="Soup", price_cents=100)
 
     resp = client.delete(f"/vendor/me/categories/{cat.id}", headers=_h())
     assert resp.status_code == 409

--- a/backend/tests/test_vendor_categories.py
+++ b/backend/tests/test_vendor_categories.py
@@ -1,0 +1,75 @@
+"""/vendor/me/categories — CRUD with cross-vendor scoping and 409 on non-empty delete."""
+from fastapi.testclient import TestClient
+
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.menu_category_repository import MenuCategoryRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.routes.vendor_categories import (
+    get_menu_category_repository,
+    get_menu_item_repository_for_category,
+)
+
+
+def _setup() -> tuple[TestClient, MenuCategoryRepository, MenuItemRepository]:
+    vendor_repo = VendorProfileRepository()
+    vendor_repo.seed(VendorRecord(id=1, name="Alice", status="approved"))
+    vendor_repo.seed(VendorRecord(id=2, name="Bob", status="approved"))
+
+    cat_repo = MenuCategoryRepository()
+    item_repo = MenuItemRepository()
+
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
+    app.dependency_overrides[get_menu_category_repository] = lambda: cat_repo
+    app.dependency_overrides[get_menu_item_repository_for_category] = lambda: item_repo
+    return TestClient(app), cat_repo, item_repo
+
+
+def _h(vid: int = 1) -> dict[str, str]:
+    return {"x-user-role": "vendor_manager", "x-vendor-id": str(vid)}
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+def test_create_and_list() -> None:
+    client, _, _ = _setup()
+    resp = client.post("/vendor/me/categories", headers=_h(), json={"name": "Hot"})
+    assert resp.status_code == 201
+    new_id = resp.json()["id"]
+
+    listing = client.get("/vendor/me/categories", headers=_h()).json()
+    assert [c["id"] for c in listing] == [new_id]
+
+
+def test_cross_vendor_get_returns_404() -> None:
+    client, _, _ = _setup()
+    created = client.post("/vendor/me/categories", headers=_h(1), json={"name": "Hot"}).json()
+    resp = client.patch(f"/vendor/me/categories/{created['id']}", headers=_h(2), json={"name": "Stolen"})
+    assert resp.status_code == 404
+
+
+def test_delete_empty_category_204() -> None:
+    client, _, _ = _setup()
+    cat = client.post("/vendor/me/categories", headers=_h(), json={"name": "Hot"}).json()
+    resp = client.delete(f"/vendor/me/categories/{cat['id']}", headers=_h())
+    assert resp.status_code == 204
+
+
+def test_delete_non_empty_category_returns_409() -> None:
+    client, cat_repo, item_repo = _setup()
+    cat = cat_repo.create(vendor_id=1, name="Hot")
+    # Manually inject an item to simulate one existing in the category
+    item_repo._rows[1] = {"vendor_id": 1, "category_id": cat.id}
+
+    resp = client.delete(f"/vendor/me/categories/{cat.id}", headers=_h())
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "category_not_empty"
+
+
+def test_create_rejects_blank_name_422() -> None:
+    client, _, _ = _setup()
+    resp = client.post("/vendor/me/categories", headers=_h(), json={"name": "   "})
+    assert resp.status_code == 422

--- a/backend/tests/test_vendor_identity.py
+++ b/backend/tests/test_vendor_identity.py
@@ -1,0 +1,67 @@
+"""require_approved_vendor: enforces role + header + approval status."""
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from backend.core.errors import install_error_handler
+from backend.core.vendor_identity import (
+    get_vendor_profile_repository,
+    require_approved_vendor,
+)
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+
+
+def _make_app(repo: VendorProfileRepository) -> TestClient:
+    app = FastAPI()
+    install_error_handler(app)
+
+    @app.get("/probe")
+    def probe(vendor_id: int = Depends(require_approved_vendor)) -> dict:
+        return {"vendor_id": vendor_id}
+
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: repo
+    return TestClient(app)
+
+
+def _seed_repo(*, status: str = "approved") -> VendorProfileRepository:
+    repo = VendorProfileRepository()
+    repo.seed(VendorRecord(id=42, name="Alice", status=status))
+    return repo
+
+
+def test_returns_vendor_id_for_approved_vendor() -> None:
+    client = _make_app(_seed_repo())
+    response = client.get("/probe", headers={"x-user-role": "vendor_manager", "x-vendor-id": "42"})
+    assert response.status_code == 200
+    assert response.json() == {"vendor_id": 42}
+
+
+def test_wrong_role_403() -> None:
+    client = _make_app(_seed_repo())
+    response = client.get("/probe", headers={"x-user-role": "employee", "x-vendor-id": "42"})
+    assert response.status_code == 403
+    assert response.json()["code"] == "forbidden"
+
+
+def test_missing_vendor_id_header_400() -> None:
+    client = _make_app(_seed_repo())
+    response = client.get("/probe", headers={"x-user-role": "vendor_manager"})
+    assert response.status_code == 400
+
+
+def test_non_int_vendor_id_400() -> None:
+    client = _make_app(_seed_repo())
+    response = client.get("/probe", headers={"x-user-role": "vendor_manager", "x-vendor-id": "abc"})
+    assert response.status_code == 400
+
+
+def test_unknown_vendor_id_404() -> None:
+    client = _make_app(_seed_repo())
+    response = client.get("/probe", headers={"x-user-role": "vendor_manager", "x-vendor-id": "999"})
+    assert response.status_code == 404
+
+
+def test_unapproved_vendor_403_with_specific_code() -> None:
+    client = _make_app(_seed_repo(status="pending"))
+    response = client.get("/probe", headers={"x-user-role": "vendor_manager", "x-vendor-id": "42"})
+    assert response.status_code == 403
+    assert response.json()["code"] == "vendor_not_approved"

--- a/backend/tests/test_vendor_menu.py
+++ b/backend/tests/test_vendor_menu.py
@@ -1,7 +1,9 @@
 """/vendor/me/menu — CRUD with daily_quota and cross-vendor scoping."""
+import io
 from pathlib import Path
 
 from fastapi.testclient import TestClient
+from PIL import Image
 
 from backend.core.vendor_identity import get_vendor_profile_repository
 from backend.main import app
@@ -121,3 +123,77 @@ def test_unapproved_vendor_blocked(tmp_path: Path) -> None:
     resp = client.get("/vendor/me/menu", headers={"x-user-role": "vendor_manager", "x-vendor-id": "3"})
     assert resp.status_code == 403
     assert resp.json()["code"] == "vendor_not_approved"
+
+
+def _png_bytes() -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (50, 50), color="blue").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_put_photo_happy_path(tmp_path: Path) -> None:
+    client, item_repo, _ = _setup(tmp_path)
+    item = item_repo.create(vendor_id=1, name="A", price_cents=10)
+
+    resp = client.put(
+        f"/vendor/me/menu/{item.id}/photo",
+        headers=_h(),
+        files={"file": ("photo.png", _png_bytes(), "image/png")},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"photo_path": f"vendors/1/menu/{item.id}.jpg"}
+    assert (tmp_path / f"vendors/1/menu/{item.id}.jpg").exists()
+    assert item_repo.get(vendor_id=1, item_id=item.id).photo_path == f"vendors/1/menu/{item.id}.jpg"
+
+
+def test_put_photo_rejects_non_image(tmp_path: Path) -> None:
+    client, item_repo, _ = _setup(tmp_path)
+    item = item_repo.create(vendor_id=1, name="A", price_cents=10)
+    resp = client.put(
+        f"/vendor/me/menu/{item.id}/photo",
+        headers=_h(),
+        files={"file": ("evil.txt", b"not an image", "image/jpeg")},
+    )
+    assert resp.status_code == 415
+    assert resp.json()["code"] == "invalid_image_type"
+
+
+def test_put_photo_rejects_oversize(tmp_path: Path) -> None:
+    # 用很小的 max_bytes 重新注入 storage
+    tiny_storage = PhotoStorage(root=tmp_path, max_bytes=10)
+    client, item_repo, _ = _setup(tmp_path)
+    app.dependency_overrides[get_photo_storage] = lambda: tiny_storage
+    item = item_repo.create(vendor_id=1, name="A", price_cents=10)
+    resp = client.put(
+        f"/vendor/me/menu/{item.id}/photo",
+        headers=_h(),
+        files={"file": ("photo.png", _png_bytes(), "image/png")},
+    )
+    assert resp.status_code == 413
+    assert resp.json()["code"] == "image_too_large"
+
+
+def test_delete_photo_clears_path_and_file(tmp_path: Path) -> None:
+    client, item_repo, _ = _setup(tmp_path)
+    item = item_repo.create(vendor_id=1, name="A", price_cents=10)
+    client.put(
+        f"/vendor/me/menu/{item.id}/photo",
+        headers=_h(),
+        files={"file": ("photo.png", _png_bytes(), "image/png")},
+    )
+
+    resp = client.delete(f"/vendor/me/menu/{item.id}/photo", headers=_h())
+    assert resp.status_code == 204
+    assert not (tmp_path / f"vendors/1/menu/{item.id}.jpg").exists()
+    assert item_repo.get(vendor_id=1, item_id=item.id).photo_path is None
+
+
+def test_put_photo_cross_vendor_404(tmp_path: Path) -> None:
+    client, item_repo, _ = _setup(tmp_path)
+    item = item_repo.create(vendor_id=1, name="A", price_cents=10)
+    resp = client.put(
+        f"/vendor/me/menu/{item.id}/photo",
+        headers=_h(2),
+        files={"file": ("photo.png", _png_bytes(), "image/png")},
+    )
+    assert resp.status_code == 404

--- a/backend/tests/test_vendor_menu.py
+++ b/backend/tests/test_vendor_menu.py
@@ -1,0 +1,123 @@
+"""/vendor/me/menu — CRUD with daily_quota and cross-vendor scoping."""
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.menu_category_repository import MenuCategoryRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.routes.vendor_categories import (
+    get_menu_category_repository,
+    get_menu_item_repository_for_category,
+)
+from backend.routes.vendor_menu import (
+    get_menu_item_repository,
+    get_photo_storage,
+)
+from backend.storage.photo_storage import PhotoStorage
+
+
+def _setup(tmp_path: Path) -> tuple[TestClient, MenuItemRepository, MenuCategoryRepository]:
+    vendor_repo = VendorProfileRepository()
+    vendor_repo.seed(VendorRecord(id=1, name="Alice", status="approved"))
+    vendor_repo.seed(VendorRecord(id=2, name="Bob", status="approved"))
+
+    cat_repo = MenuCategoryRepository()
+    item_repo = MenuItemRepository()
+    storage = PhotoStorage(root=tmp_path)
+
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
+    app.dependency_overrides[get_menu_category_repository] = lambda: cat_repo
+    app.dependency_overrides[get_menu_item_repository_for_category] = lambda: item_repo
+    app.dependency_overrides[get_menu_item_repository] = lambda: item_repo
+    app.dependency_overrides[get_photo_storage] = lambda: storage
+    return TestClient(app), item_repo, cat_repo
+
+
+def _h(vid: int = 1) -> dict[str, str]:
+    return {"x-user-role": "vendor_manager", "x-vendor-id": str(vid)}
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+def test_create_menu_item_and_get(tmp_path: Path) -> None:
+    client, _, _ = _setup(tmp_path)
+    resp = client.post(
+        "/vendor/me/menu",
+        headers=_h(),
+        json={"name": "Rice Bowl", "price_cents": 120, "daily_quota": 50},
+    )
+    assert resp.status_code == 201
+    item_id = resp.json()["id"]
+
+    got = client.get(f"/vendor/me/menu/{item_id}", headers=_h()).json()
+    assert got["name"] == "Rice Bowl"
+    assert got["daily_quota"] == 50
+
+
+def test_daily_quota_round_trip_null_and_zero(tmp_path: Path) -> None:
+    client, _, _ = _setup(tmp_path)
+    null_item = client.post("/vendor/me/menu", headers=_h(), json={"name": "A", "price_cents": 10}).json()
+    assert null_item["daily_quota"] is None
+    zero_item = client.post("/vendor/me/menu", headers=_h(), json={"name": "B", "price_cents": 10, "daily_quota": 0}).json()
+    assert zero_item["daily_quota"] == 0
+
+
+def test_negative_daily_quota_rejected_422(tmp_path: Path) -> None:
+    client, _, _ = _setup(tmp_path)
+    resp = client.post("/vendor/me/menu", headers=_h(), json={"name": "A", "price_cents": 10, "daily_quota": -1})
+    assert resp.status_code == 422
+
+
+def test_list_filters_by_category(tmp_path: Path) -> None:
+    client, item_repo, cat_repo = _setup(tmp_path)
+    cat = cat_repo.create(vendor_id=1, name="Hot")
+    item_repo.create(vendor_id=1, category_id=cat.id, name="Soup", price_cents=10)
+    item_repo.create(vendor_id=1, category_id=None, name="Misc", price_cents=10)
+    listed = client.get(f"/vendor/me/menu?category_id={cat.id}", headers=_h()).json()
+    assert [i["name"] for i in listed] == ["Soup"]
+
+
+def test_cross_vendor_get_returns_404(tmp_path: Path) -> None:
+    client, item_repo, _ = _setup(tmp_path)
+    item = item_repo.create(vendor_id=1, name="A", price_cents=10)
+    resp = client.get(f"/vendor/me/menu/{item.id}", headers=_h(2))
+    assert resp.status_code == 404
+
+
+def test_patch_partial_update(tmp_path: Path) -> None:
+    client, item_repo, _ = _setup(tmp_path)
+    item = item_repo.create(vendor_id=1, name="A", price_cents=10, daily_quota=50)
+    resp = client.patch(f"/vendor/me/menu/{item.id}", headers=_h(), json={"daily_quota": 0})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["daily_quota"] == 0
+    assert body["name"] == "A"
+
+
+def test_delete_item(tmp_path: Path) -> None:
+    client, item_repo, _ = _setup(tmp_path)
+    item = item_repo.create(vendor_id=1, name="A", price_cents=10)
+    assert client.delete(f"/vendor/me/menu/{item.id}", headers=_h()).status_code == 204
+    assert client.get(f"/vendor/me/menu/{item.id}", headers=_h()).status_code == 404
+
+
+def test_create_with_unknown_category_id_422(tmp_path: Path) -> None:
+    client, _, _ = _setup(tmp_path)
+    resp = client.post("/vendor/me/menu", headers=_h(), json={"name": "A", "price_cents": 10, "category_id": 999})
+    assert resp.status_code == 422
+    assert resp.json()["code"] == "validation_error"
+
+
+def test_unapproved_vendor_blocked(tmp_path: Path) -> None:
+    client, _, _ = _setup(tmp_path)
+    pending_repo = VendorProfileRepository()
+    pending_repo.seed(VendorRecord(id=3, name="Pending", status="pending"))
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: pending_repo
+    resp = client.get("/vendor/me/menu", headers={"x-user-role": "vendor_manager", "x-vendor-id": "3"})
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "vendor_not_approved"

--- a/backend/tests/test_vendor_profile.py
+++ b/backend/tests/test_vendor_profile.py
@@ -1,0 +1,66 @@
+"""GET / PATCH /vendor/me/profile."""
+from fastapi.testclient import TestClient
+
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+
+
+def _seed() -> VendorProfileRepository:
+    repo = VendorProfileRepository()
+    repo.seed(VendorRecord(id=1, name="Alice Bento", status="approved", address="Old"))
+    repo.assign_facility(1, facility_id=10, code="F12A", name="Fab 12A")
+    return repo
+
+
+def _client(repo: VendorProfileRepository) -> TestClient:
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: repo
+    return TestClient(app)
+
+
+def _vendor_headers(vid: int = 1) -> dict[str, str]:
+    return {"x-user-role": "vendor_manager", "x-vendor-id": str(vid)}
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+def test_get_profile_returns_vendor_with_facilities() -> None:
+    response = _client(_seed()).get("/vendor/me/profile", headers=_vendor_headers())
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "Alice Bento"
+    assert body["status"] == "approved"
+    assert body["served_facilities"] == [{"id": 10, "code": "F12A", "name": "Fab 12A"}]
+
+
+def test_patch_updates_address_only() -> None:
+    response = _client(_seed()).patch(
+        "/vendor/me/profile",
+        headers=_vendor_headers(),
+        json={"address": "New address"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["address"] == "New address"
+    assert body["name"] == "Alice Bento"
+
+
+def test_patch_silently_ignores_served_facilities_in_body() -> None:
+    response = _client(_seed()).patch(
+        "/vendor/me/profile",
+        headers=_vendor_headers(),
+        json={"served_facilities": [{"id": 99, "code": "X", "name": "X"}]},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert {f["code"] for f in body["served_facilities"]} == {"F12A"}
+
+
+def test_unauthenticated_role_403() -> None:
+    response = _client(_seed()).get(
+        "/vendor/me/profile",
+        headers={"x-user-role": "employee", "x-vendor-id": "1"},
+    )
+    assert response.status_code == 403

--- a/backend/tests/test_vendor_profile_repository.py
+++ b/backend/tests/test_vendor_profile_repository.py
@@ -1,0 +1,40 @@
+"""In-memory VendorProfileRepository — production stub until DB lands."""
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+
+
+def test_get_returns_seeded_vendor() -> None:
+    repo = VendorProfileRepository()
+    repo.seed(VendorRecord(id=1, name="Alice Bento", status="approved"))
+    got = repo.get(1)
+    assert got is not None
+    assert got.name == "Alice Bento"
+    assert got.status == "approved"
+
+
+def test_get_unknown_returns_none() -> None:
+    repo = VendorProfileRepository()
+    assert repo.get(999) is None
+
+
+def test_update_changes_only_provided_fields() -> None:
+    repo = VendorProfileRepository()
+    repo.seed(VendorRecord(id=1, name="Alice", status="approved", address="Old"))
+    updated = repo.update(1, {"address": "New"})
+    assert updated is not None
+    assert updated.address == "New"
+    assert updated.name == "Alice"  # not provided → unchanged
+
+
+def test_list_facilities_empty_by_default() -> None:
+    repo = VendorProfileRepository()
+    repo.seed(VendorRecord(id=1, name="Alice", status="approved"))
+    assert repo.list_facilities(1) == []
+
+
+def test_assign_and_list_facilities() -> None:
+    repo = VendorProfileRepository()
+    repo.seed(VendorRecord(id=1, name="Alice", status="approved"))
+    repo.assign_facility(1, facility_id=10, code="F12A", name="Fab 12A")
+    repo.assign_facility(1, facility_id=11, code="F14B", name="Fab 14B")
+    facilities = repo.list_facilities(1)
+    assert {f.code for f in facilities} == {"F12A", "F14B"}

--- a/backend/tests/test_vendor_self_schemas.py
+++ b/backend/tests/test_vendor_self_schemas.py
@@ -1,0 +1,52 @@
+"""Schema validation rules for the vendor self-service surface."""
+import pytest
+from pydantic import ValidationError
+
+from backend.schemas.vendor_self import (
+    Facility,
+    MenuItemCreate,
+    MenuItemUpdate,
+    VendorProfileUpdate,
+)
+
+
+def test_menu_item_create_rejects_negative_price() -> None:
+    with pytest.raises(ValidationError):
+        MenuItemCreate(name="Rice", price_cents=-1)
+
+
+def test_menu_item_create_rejects_negative_daily_quota() -> None:
+    with pytest.raises(ValidationError):
+        MenuItemCreate(name="Rice", price_cents=80, daily_quota=-3)
+
+
+def test_menu_item_create_allows_null_daily_quota() -> None:
+    item = MenuItemCreate(name="Rice", price_cents=80, daily_quota=None)
+    assert item.daily_quota is None
+
+
+def test_menu_item_create_allows_zero_daily_quota() -> None:
+    """Zero = today temporarily unavailable (distinct from `available=False`)."""
+    item = MenuItemCreate(name="Rice", price_cents=80, daily_quota=0)
+    assert item.daily_quota == 0
+
+
+def test_menu_item_create_rejects_empty_name() -> None:
+    with pytest.raises(ValidationError):
+        MenuItemCreate(name="   ", price_cents=80)
+
+
+def test_menu_item_update_all_fields_optional() -> None:
+    update = MenuItemUpdate()
+    assert update.model_dump(exclude_unset=True) == {}
+
+
+def test_vendor_profile_update_silently_drops_served_facilities() -> None:
+    """spec: PATCH ignores served_facilities in body — does not 422."""
+    update = VendorProfileUpdate.model_validate({"name": "Newname", "served_facilities": [{"id": 1, "code": "X", "name": "X"}]})
+    assert "served_facilities" not in update.model_dump(exclude_unset=True)
+
+
+def test_facility_round_trip() -> None:
+    f = Facility(id=1, code="F12A", name="Fab 12A")
+    assert f.code == "F12A"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
         required: false
     volumes:
       - .:/app
+      - uploads:/app/uploads
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
     ports:
       - "8000:8000"
@@ -43,6 +44,7 @@ services:
       - ./infra/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
+      - uploads:/srv/uploads:ro
     ports:
       - "80:80"
       - "443:443"
@@ -54,3 +56,4 @@ volumes:
   postgres_data:
   caddy_data:
   caddy_config:
+  uploads:

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -25,6 +25,16 @@ https://localhost {
 		reverse_proxy backend:8000
 	}
 
+	handle /vendor/* {
+		reverse_proxy backend:8000
+	}
+
+	handle_path /uploads/* {
+		root * /srv/uploads
+		file_server
+		header Cache-Control "public, max-age=3600"
+	}
+
 	handle {
 		reverse_proxy frontend:80
 	}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: requires a real Postgres (skipped until DB layer wires up)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.34.0
 pydantic-settings==2.7.1
 pytest==8.3.4
 httpx==0.28.1
+Pillow==11.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pydantic-settings==2.7.1
 pytest==8.3.4
 httpx==0.28.1
 Pillow==11.0.0
+python-multipart==0.0.27


### PR DESCRIPTION
Closes #3.

## What

Implements the vendor (商家) role's self-service backend:

- `GET / PATCH /vendor/me/profile` — name, address, hours, contact, plus read-only `served_facilities`
- `GET / POST / PATCH / DELETE /vendor/me/categories` — menu category CRUD (409 on non-empty delete)
- `GET / POST / GET / PATCH / DELETE /vendor/me/menu` — menu item CRUD with `daily_quota` (NULL = unlimited, 0 = temporarily unavailable, positive = cap)
- `PUT / DELETE /vendor/me/menu/{id}/photo` — multipart upload, PIL re-encoded to JPEG, atomic write, 5 MB byte cap, 25 MP pixel cap (decompression-bomb defence)
- `/uploads/*` served by Caddy from a shared docker volume

## Identity

Header-based interim: `x-user-role: vendor_manager` + `x-vendor-id: <int>`. Centralised in `require_approved_vendor` dependency. Forward-compatible with future JWT — only `vendor_identity.py` changes.

## Data

Repositories are in-memory dicts so the API is demoable end-to-end without DB. Draft schema for the persistence team at `backend/db/migrations/draft/002_vendor_menu_schema.sql` (includes ALTER TABLE for missing vendors columns + new tables for menu_categories / menu_items / facilities / vendor_facilities).

## Tests

- 68 unit tests, 96% line coverage on `backend/`. Cover role gating, approved-status gate, cross-vendor 404, validation (negative price / quota / blank name / unknown category), `daily_quota` null/zero round-trip, `served_facilities` exposure, category delete 409, photo size/format/cross-vendor, decompression bomb rejection.
- 4 integration test placeholders under `backend/tests/integration/` with `@pytest.mark.integration` — skipped until DB lands.

## Infra

- New named volume `uploads` in `docker-compose.yml`, mounted rw in backend, ro in caddy gateway.
- Caddyfile adds `/vendor/*` reverse proxy and `/uploads/*` static file_server with `Cache-Control: max-age=3600`.

## Out of scope (deliberate, deferred to other teams)

- Persistence team: review and merge the draft SQL.
- Ordering team: read `daily_quota` at order-creation time; do not mutate.
- Committee module: write side of `vendor_facilities`.
- JWT / real auth, monthly billing report, delivery labels, multi-photo per item.

## Test plan

- [x] Unit suite green: `pytest backend/tests` → 68 passed, 4 skipped
- [x] Coverage >= 95% on backend/
- [x] Caddyfile validates: `caddy validate --config infra/caddy/Caddyfile`
- [x] docker-compose validates: `docker compose config`
- [x] CI passes (will run automatically on push)