### PR TITLE
Add employee ordering APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ venv/
 __pycache__/
 *.py[cod]
 .pytest_cache/
+pytest-cache-files-*/
 .mypy_cache/
 .ruff_cache/
 htmlcov/

--- a/backend/core/employee_identity.py
+++ b/backend/core/employee_identity.py
@@ -1,0 +1,29 @@
+"""Employee identity dependencies for employee-facing ordering APIs."""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Header
+
+from backend.core.errors import CodedHTTPException
+
+
+def require_employee_role(
+    x_user_role: Annotated[str | None, Header()] = None,
+) -> None:
+    if x_user_role != "employee":
+        raise CodedHTTPException(status_code=403, code="forbidden", detail="employee role required")
+
+
+def require_employee(
+    x_user_role: Annotated[str | None, Header()] = None,
+    x_user_id: Annotated[str | None, Header()] = None,
+) -> int:
+    require_employee_role(x_user_role)
+
+    if x_user_id is None:
+        raise CodedHTTPException(status_code=400, code="validation_error", detail="x-user-id header missing")
+    try:
+        return int(x_user_id)
+    except ValueError as exc:
+        raise CodedHTTPException(status_code=400, code="validation_error", detail="x-user-id must be integer") from exc

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,15 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from backend.core.config import settings
 from backend.core.errors import install_error_handler
-from backend.routes import admin_vendors, committee_reviews, health, vendor_categories, vendor_menu, vendor_profile
+from backend.routes import (
+    admin_vendors,
+    committee_reviews,
+    employee_ordering,
+    health,
+    vendor_categories,
+    vendor_menu,
+    vendor_profile,
+)
 
 
 def create_app() -> FastAPI:
@@ -25,6 +33,7 @@ def create_app() -> FastAPI:
     app.include_router(vendor_profile.router)
     app.include_router(vendor_categories.router)
     app.include_router(vendor_menu.router)
+    app.include_router(employee_ordering.router)
     return app
 
 

--- a/backend/repositories/employee_selection_repository.py
+++ b/backend/repositories/employee_selection_repository.py
@@ -1,0 +1,68 @@
+"""In-memory employee meal selection repository."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from itertools import count
+
+from backend.schemas.employee import MealSelection
+
+
+@dataclass
+class _SelectionRecord:
+    id: int
+    employee_id: int
+    vendor_id: int
+    item_id: int
+    item_name: str
+    quantity: int
+    unit_price_cents: int
+    created_at: datetime
+
+
+def _to_schema(rec: _SelectionRecord) -> MealSelection:
+    return MealSelection(
+        id=rec.id,
+        employee_id=rec.employee_id,
+        vendor_id=rec.vendor_id,
+        item_id=rec.item_id,
+        item_name=rec.item_name,
+        quantity=rec.quantity,
+        unit_price_cents=rec.unit_price_cents,
+        total_price_cents=rec.quantity * rec.unit_price_cents,
+        created_at=rec.created_at,
+    )
+
+
+class EmployeeSelectionRepository:
+    def __init__(self) -> None:
+        self._rows: dict[int, _SelectionRecord] = {}
+        self._id_seq = count(1)
+
+    def create(
+        self,
+        *,
+        employee_id: int,
+        vendor_id: int,
+        item_id: int,
+        item_name: str,
+        quantity: int,
+        unit_price_cents: int,
+    ) -> MealSelection:
+        rec = _SelectionRecord(
+            id=next(self._id_seq),
+            employee_id=employee_id,
+            vendor_id=vendor_id,
+            item_id=item_id,
+            item_name=item_name,
+            quantity=quantity,
+            unit_price_cents=unit_price_cents,
+            created_at=datetime.now(timezone.utc),
+        )
+        self._rows[rec.id] = rec
+        return _to_schema(rec)
+
+    def list(self, *, employee_id: int) -> list[MealSelection]:
+        rows = [r for r in self._rows.values() if r.employee_id == employee_id]
+        rows.sort(key=lambda r: r.id)
+        return [_to_schema(r) for r in rows]

--- a/backend/repositories/vendor_profile_repository.py
+++ b/backend/repositories/vendor_profile_repository.py
@@ -47,6 +47,13 @@ class VendorProfileRepository:
     def get(self, vendor_id: int) -> VendorRecord | None:
         return self._vendors.get(vendor_id)
 
+    def list(self, *, status: str | None = None) -> list[VendorRecord]:
+        vendors = list(self._vendors.values())
+        if status is not None:
+            vendors = [vendor for vendor in vendors if vendor.status == status]
+        vendors.sort(key=lambda vendor: vendor.id)
+        return vendors
+
     def update(self, vendor_id: int, fields: dict[str, Any]) -> VendorRecord | None:
         existing = self._vendors.get(vendor_id)
         if existing is None:

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -1,0 +1,77 @@
+"""Employee-facing vendor browsing, menu browsing, and meal selection APIs."""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, status
+
+from backend.core.employee_identity import require_employee, require_employee_role
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository
+from backend.routes.vendor_menu import get_menu_item_repository
+from backend.schemas.employee import EmployeeMenuItem, EmployeeVendor, MealSelection, MealSelectionCreate
+from backend.services.employee_ordering_service import EmployeeOrderingService
+
+router = APIRouter(prefix="/employee", tags=["employee"])
+
+_selection_repo = EmployeeSelectionRepository()
+
+
+def get_employee_selection_repository() -> EmployeeSelectionRepository:
+    return _selection_repo
+
+
+def get_employee_ordering_service(
+    vendor_repo: Annotated[VendorProfileRepository, Depends(get_vendor_profile_repository)],
+    item_repo: Annotated[MenuItemRepository, Depends(get_menu_item_repository)],
+    selection_repo: Annotated[EmployeeSelectionRepository, Depends(get_employee_selection_repository)],
+) -> EmployeeOrderingService:
+    return EmployeeOrderingService(vendor_repo, item_repo, selection_repo)
+
+
+@router.get("/vendors", response_model=list[EmployeeVendor])
+def list_vendors(
+    _employee_role: Annotated[None, Depends(require_employee_role)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> list[EmployeeVendor]:
+    return service.list_vendors()
+
+
+@router.get("/vendors/{vendor_id}", response_model=EmployeeVendor)
+def get_vendor(
+    vendor_id: int,
+    _employee_role: Annotated[None, Depends(require_employee_role)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> EmployeeVendor:
+    return service.get_vendor(vendor_id)
+
+
+@router.get("/vendors/{vendor_id}/menu", response_model=list[EmployeeMenuItem])
+def list_menu(
+    vendor_id: int,
+    _employee_role: Annotated[None, Depends(require_employee_role)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+    category_id: Annotated[int | None, Query()] = None,
+    available: Annotated[bool | None, Query()] = True,
+) -> list[EmployeeMenuItem]:
+    return service.list_menu(vendor_id, category_id=category_id, available=available)
+
+
+@router.post("/vendors/{vendor_id}/selections", response_model=MealSelection, status_code=status.HTTP_201_CREATED)
+def select_meal(
+    vendor_id: int,
+    payload: MealSelectionCreate,
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> MealSelection:
+    return service.select_meal(employee_id, vendor_id, payload)
+
+
+@router.get("/me/selections", response_model=list[MealSelection])
+def list_my_selections(
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> list[MealSelection]:
+    return service.list_my_selections(employee_id)

--- a/backend/schemas/employee.py
+++ b/backend/schemas/employee.py
@@ -1,0 +1,47 @@
+"""Employee-facing vendor, menu, and meal selection schemas."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+from backend.schemas.vendor_self import Facility
+
+
+class EmployeeVendor(BaseModel):
+    id: int
+    name: str
+    address: str | None = None
+    business_hours: str | None = None
+    contact_phone: str | None = None
+    contact_email: str | None = None
+    served_facilities: list[Facility] = Field(default_factory=list)
+
+
+class EmployeeMenuItem(BaseModel):
+    id: int
+    vendor_id: int
+    category_id: int | None
+    name: str
+    description: str | None
+    price_cents: int
+    available: bool
+    daily_quota: int | None
+    photo_path: str | None
+
+
+class MealSelectionCreate(BaseModel):
+    item_id: int
+    quantity: int = Field(ge=1)
+
+
+class MealSelection(BaseModel):
+    id: int
+    employee_id: int
+    vendor_id: int
+    item_id: int
+    item_name: str
+    quantity: int
+    unit_price_cents: int
+    total_price_cents: int
+    created_at: datetime

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -1,0 +1,97 @@
+"""Employee-facing read and meal selection workflow."""
+from __future__ import annotations
+
+from backend.core.errors import CodedHTTPException
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.schemas.employee import EmployeeMenuItem, EmployeeVendor, MealSelection, MealSelectionCreate
+from backend.schemas.vendor_self import MenuItem as VendorMenuItem
+
+
+class EmployeeOrderingService:
+    def __init__(
+        self,
+        vendor_repository: VendorProfileRepository,
+        menu_item_repository: MenuItemRepository,
+        selection_repository: EmployeeSelectionRepository,
+    ) -> None:
+        self.vendor_repository = vendor_repository
+        self.menu_item_repository = menu_item_repository
+        self.selection_repository = selection_repository
+
+    def list_vendors(self) -> list[EmployeeVendor]:
+        return [self._vendor_to_schema(vendor) for vendor in self.vendor_repository.list(status="approved")]
+
+    def get_vendor(self, vendor_id: int) -> EmployeeVendor:
+        return self._vendor_to_schema(self._get_approved_vendor(vendor_id))
+
+    def list_menu(
+        self, vendor_id: int, *, category_id: int | None = None, available: bool | None = True
+    ) -> list[EmployeeMenuItem]:
+        self._get_approved_vendor(vendor_id)
+        return [
+            self._menu_item_to_schema(item)
+            for item in self.menu_item_repository.list(
+                vendor_id=vendor_id, category_id=category_id, available=available
+            )
+        ]
+
+    def select_meal(
+        self, employee_id: int, vendor_id: int, payload: MealSelectionCreate
+    ) -> MealSelection:
+        self._get_approved_vendor(vendor_id)
+        item = self.menu_item_repository.get(vendor_id=vendor_id, item_id=payload.item_id)
+        if item is None:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="menu item not found")
+        if not item.available:
+            raise CodedHTTPException(status_code=409, code="item_unavailable", detail="menu item unavailable")
+        if item.daily_quota is not None and payload.quantity > item.daily_quota:
+            raise CodedHTTPException(
+                status_code=409,
+                code="quantity_exceeds_daily_quota",
+                detail="quantity exceeds daily quota",
+            )
+
+        return self.selection_repository.create(
+            employee_id=employee_id,
+            vendor_id=vendor_id,
+            item_id=item.id,
+            item_name=item.name,
+            quantity=payload.quantity,
+            unit_price_cents=item.price_cents,
+        )
+
+    def list_my_selections(self, employee_id: int) -> list[MealSelection]:
+        return self.selection_repository.list(employee_id=employee_id)
+
+    def _get_approved_vendor(self, vendor_id: int) -> VendorRecord:
+        vendor = self.vendor_repository.get(vendor_id)
+        if vendor is None or vendor.status != "approved":
+            raise CodedHTTPException(status_code=404, code="not_found", detail="vendor not found")
+        return vendor
+
+    def _vendor_to_schema(self, vendor: VendorRecord) -> EmployeeVendor:
+        return EmployeeVendor(
+            id=vendor.id,
+            name=vendor.name,
+            address=vendor.address,
+            business_hours=vendor.business_hours,
+            contact_phone=vendor.contact_phone,
+            contact_email=vendor.contact_email,
+            served_facilities=self.vendor_repository.list_facilities(vendor.id),
+        )
+
+    @staticmethod
+    def _menu_item_to_schema(item: VendorMenuItem) -> EmployeeMenuItem:
+        return EmployeeMenuItem(
+            id=item.id,
+            vendor_id=item.vendor_id,
+            category_id=item.category_id,
+            name=item.name,
+            description=item.description,
+            price_cents=item.price_cents,
+            available=item.available,
+            daily_quota=item.daily_quota,
+            photo_path=item.photo_path,
+        )

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -1,0 +1,178 @@
+"""Employee-facing vendor browsing, menu browsing, and meal selection APIs."""
+from fastapi.testclient import TestClient
+
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.routes.employee_ordering import get_employee_selection_repository
+from backend.routes.vendor_menu import get_menu_item_repository
+
+
+def _setup() -> tuple[TestClient, MenuItemRepository, EmployeeSelectionRepository]:
+    vendor_repo = VendorProfileRepository()
+    vendor_repo.seed(
+        VendorRecord(
+            id=1,
+            name="Alice Bento",
+            status="approved",
+            address="No. 1",
+            business_hours="11:00-14:00",
+            contact_phone="0912-000-000",
+            contact_email="alice@example.com",
+        )
+    )
+    vendor_repo.seed(VendorRecord(id=2, name="Pending Bento", status="pending"))
+    vendor_repo.assign_facility(1, facility_id=10, code="F12A", name="Fab 12A")
+
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
+    app.dependency_overrides[get_menu_item_repository] = lambda: item_repo
+    app.dependency_overrides[get_employee_selection_repository] = lambda: selection_repo
+    return TestClient(app), item_repo, selection_repo
+
+
+def _h(user_id: int = 100) -> dict[str, str]:
+    return {"x-user-role": "employee", "x-user-id": str(user_id)}
+
+
+def _browse_h() -> dict[str, str]:
+    return {"x-user-role": "employee"}
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+def test_list_vendors_returns_approved_vendors_only() -> None:
+    client, _, _ = _setup()
+
+    resp = client.get("/employee/vendors", headers=_browse_h())
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [vendor["name"] for vendor in body] == ["Alice Bento"]
+    assert body[0]["served_facilities"] == [{"id": 10, "code": "F12A", "name": "Fab 12A"}]
+
+
+def test_get_vendor_returns_public_vendor_information() -> None:
+    client, _, _ = _setup()
+
+    resp = client.get("/employee/vendors/1", headers=_browse_h())
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "Alice Bento"
+    assert body["address"] == "No. 1"
+    assert body["business_hours"] == "11:00-14:00"
+    assert body["contact_phone"] == "0912-000-000"
+
+
+def test_pending_vendor_is_hidden_from_employee() -> None:
+    client, _, _ = _setup()
+
+    resp = client.get("/employee/vendors/2", headers=_browse_h())
+
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"
+
+
+def test_list_menu_defaults_to_available_items() -> None:
+    client, item_repo, _ = _setup()
+    item_repo.create(vendor_id=1, category_id=7, name="Rice Bowl", price_cents=120, available=True)
+    item_repo.create(vendor_id=1, category_id=7, name="Sold Out Soup", price_cents=80, available=False)
+    item_repo.create(vendor_id=1, category_id=8, name="Tea", price_cents=40, available=True)
+
+    resp = client.get("/employee/vendors/1/menu?category_id=7", headers=_browse_h())
+
+    assert resp.status_code == 200
+    assert [item["name"] for item in resp.json()] == ["Rice Bowl"]
+
+
+def test_select_meal_records_quantity_and_total_price() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=5)
+
+    resp = client.post(
+        "/employee/vendors/1/selections",
+        headers=_h(100),
+        json={"item_id": item.id, "quantity": 2},
+    )
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["employee_id"] == 100
+    assert body["vendor_id"] == 1
+    assert body["item_id"] == item.id
+    assert body["item_name"] == "Rice Bowl"
+    assert body["quantity"] == 2
+    assert body["unit_price_cents"] == 120
+    assert body["total_price_cents"] == 240
+
+    selections = client.get("/employee/me/selections", headers=_h(100)).json()
+    assert [selection["id"] for selection in selections] == [body["id"]]
+
+
+def test_my_selections_are_scoped_by_employee() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+    client.post("/employee/vendors/1/selections", headers=_h(100), json={"item_id": item.id, "quantity": 1})
+
+    resp = client.get("/employee/me/selections", headers=_h(200))
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_select_unavailable_item_returns_409() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Sold Out Soup", price_cents=80, available=False)
+
+    resp = client.post(
+        "/employee/vendors/1/selections",
+        headers=_h(),
+        json={"item_id": item.id, "quantity": 1},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "item_unavailable"
+
+
+def test_select_quantity_over_daily_quota_returns_409() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=1)
+
+    resp = client.post(
+        "/employee/vendors/1/selections",
+        headers=_h(),
+        json={"item_id": item.id, "quantity": 2},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "quantity_exceeds_daily_quota"
+
+
+def test_employee_endpoints_require_employee_role() -> None:
+    client, _, _ = _setup()
+
+    resp = client.get("/employee/vendors", headers={"x-user-role": "vendor_manager"})
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "forbidden"
+
+
+def test_select_meal_requires_employee_id() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+
+    resp = client.post(
+        "/employee/vendors/1/selections",
+        headers={"x-user-role": "employee"},
+        json={"item_id": item.id, "quantity": 1},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"


### PR DESCRIPTION
## Summary
- Add employee-facing APIs for browsing approved vendors and vendor menu items
- Add meal selection flow with quantity, price snapshot, and employee-scoped history
- Add employee ordering schemas, service, repository, route, and tests

## Tests
- .venv\\Scripts\\python -m pytest backend\\tests -p no:cacheprovider --basetemp=.venv\\pytest-final-pr