### PR TITLE
feat(ci): Trunk-Based Development Jenkins pipelines (staging + prod + cleanup)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,36 +5,49 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
-  backend-tests:
+  unit:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
       - name: Install dependencies
         run: pip install -r requirements.txt
+      - name: Run unit tests
+        run: pytest backend/tests --ignore=backend/tests/integration -q
 
-      - name: Run tests
-        run: pytest backend/tests
-
-  docker-build:
+  integration:
     runs-on: ubuntu-latest
-    needs: backend-tests
-
+    needs: unit
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: mealorder
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/mealorder
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build backend image
-        run: docker build -f backend/Dockerfile -t meal-ordering-backend:test .
-
-      - name: Build frontend image
-        run: docker build -t meal-ordering-frontend:test ./frontend
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -r requirements.txt psycopg[binary]
+      - name: Apply schema
+        run: |
+          PGPASSWORD=postgres psql -h localhost -U postgres -d mealorder \
+            -f backend/db/migrations/001_initial_schema.sql
+      - name: Run integration tests
+        run: pytest backend/tests/integration -q

--- a/Jenkinsfile.cleanup
+++ b/Jenkinsfile.cleanup
@@ -1,0 +1,26 @@
+pipeline {
+  agent any
+  options { timeout(time: 10, unit: 'MINUTES'); timestamps() }
+
+  // Hourly defensive sweep. PR preview is disabled, so this should normally
+  // be a no-op; it exists to clean stray mealorder-pr-* projects if previews
+  // are ever re-enabled.
+  triggers {
+    cron('H * * * *')
+  }
+
+  stages {
+    stage('Checkout') { steps { checkout scm } }
+
+    stage('Hourly sweep') {
+      steps {
+        withCredentials([string(credentialsId: 'gh-pat', variable: 'GH_TOKEN')]) {
+          sh '''
+            set -euo pipefail
+            bash scripts/sweep-stale-stacks.sh
+          '''
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -1,0 +1,78 @@
+pipeline {
+  agent any
+
+  options {
+    disableConcurrentBuilds()
+    timeout(time: 20, unit: 'MINUTES')
+    timestamps()
+  }
+
+  environment {
+    COMPOSE_PROJECT_NAME     = 'mealorder-prod'
+    ROOT_PATH                = '/meal'
+    GATEWAY_CONTAINER_NAME   = 'mealorder-prod-gateway'
+    PUBLIC_HEALTH_URL        = "${env.PUBLIC_HEALTH_URL ?: 'https://nol.cs.nycu.edu.tw/meal/health'}"
+  }
+
+  stages {
+    stage('Validate tag') {
+      steps {
+        script {
+          def tag = env.TAG_NAME
+          if (!tag || !(tag ==~ /^v\d+\.\d+\.\d+$/)) {
+            error("Prod pipeline must be triggered by a semver tag matching ^v\\d+\\.\\d+\\.\\d+\$. Got: branch=${env.BRANCH_NAME} tag=${tag}")
+          }
+          echo "Deploying tag ${tag} to production"
+        }
+      }
+    }
+
+    stage('Checkout') {
+      steps { checkout scm }
+    }
+
+    stage('Build and deploy prod') {
+      steps {
+        sh '''
+          set -euo pipefail
+          docker network inspect preview-net >/dev/null 2>&1 \
+            || docker network create preview-net
+          ROOT_PATH="$ROOT_PATH" \
+          GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
+            docker compose -p "$COMPOSE_PROJECT_NAME" \
+            -f docker-compose.yml \
+            -f infra/deploy/docker-compose.prod.yml \
+            build
+          ROOT_PATH="$ROOT_PATH" \
+          GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
+            docker compose -p "$COMPOSE_PROJECT_NAME" \
+            -f docker-compose.yml \
+            -f infra/deploy/docker-compose.prod.yml \
+            up -d
+        '''
+      }
+    }
+
+    stage('Smoke check') {
+      steps {
+        sh '''
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if curl -fsS "$PUBLIC_HEALTH_URL" >/dev/null; then
+              echo "prod /health OK for ${TAG_NAME}"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "prod /health failed after 60s for ${TAG_NAME}" >&2
+          docker compose -p "$COMPOSE_PROJECT_NAME" logs --tail=200 >&2 || true
+          exit 1
+        '''
+      }
+    }
+  }
+
+  post {
+    always { cleanWs() }
+  }
+}

--- a/Jenkinsfile.staging
+++ b/Jenkinsfile.staging
@@ -1,0 +1,67 @@
+pipeline {
+  agent any
+
+  options {
+    disableConcurrentBuilds()
+    timeout(time: 20, unit: 'MINUTES')
+    timestamps()
+  }
+
+  environment {
+    COMPOSE_PROJECT_NAME     = 'mealorder-staging'
+    ROOT_PATH                = '/meal-staging'
+    GATEWAY_CONTAINER_NAME   = 'mealorder-staging-gateway'
+    PUBLIC_HEALTH_URL        = "${env.PUBLIC_HEALTH_URL ?: 'https://nol.cs.nycu.edu.tw/meal-staging/health'}"
+  }
+
+  stages {
+    stage('Checkout') {
+      when { branch 'main' }
+      steps { checkout scm }
+    }
+
+    stage('Reset and deploy staging') {
+      when { branch 'main' }
+      steps {
+        sh '''
+          set -euo pipefail
+          docker network inspect preview-net >/dev/null 2>&1 \
+            || docker network create preview-net
+          docker compose -p "$COMPOSE_PROJECT_NAME" \
+            -f docker-compose.yml \
+            -f infra/deploy/docker-compose.staging.yml \
+            down -v --remove-orphans || true
+          ROOT_PATH="$ROOT_PATH" \
+          GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
+            docker compose -p "$COMPOSE_PROJECT_NAME" \
+            -f docker-compose.yml \
+            -f infra/deploy/docker-compose.staging.yml \
+            up -d --build
+        '''
+      }
+    }
+
+    stage('Smoke check') {
+      when { branch 'main' }
+      steps {
+        sh '''
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            if curl -fsS "$PUBLIC_HEALTH_URL" >/dev/null; then
+              echo "staging /health OK"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "staging /health failed after 60s" >&2
+          docker compose -p "$COMPOSE_PROJECT_NAME" logs --tail=200 >&2 || true
+          exit 1
+        '''
+      }
+    }
+  }
+
+  post {
+    always { cleanWs() }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ cp .env.example .env
 
 2. Update `.env` local secrets such as `POSTGRES_PASSWORD`.
 
-3. Start the full local stack:
+3. Start the full local stack (with hot reload):
 
 ```bash
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
 ```
+
+**Deployment (TBD via Jenkins):** see `infra/deploy/SETUP-NOL.md` for the NOL host one-time setup and Jenkins pipeline configuration.
 
 Main HTTPS entrypoint:
 

--- a/backend/db/Dockerfile
+++ b/backend/db/Dockerfile
@@ -1,0 +1,3 @@
+FROM postgres:16-alpine
+# Only top-level .sql files run as init scripts; the draft/ subdir is intentionally skipped.
+COPY backend/db/migrations/*.sql /docker-entrypoint-initdb.d/

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -15,7 +17,7 @@ from backend.routes import (
 
 
 def create_app() -> FastAPI:
-    app = FastAPI(title=settings.app_name)
+    app = FastAPI(title=settings.app_name, root_path=os.getenv("ROOT_PATH", ""))
 
     app.add_middleware(
         CORSMiddleware,

--- a/backend/tests/test_root_path.py
+++ b/backend/tests/test_root_path.py
@@ -1,0 +1,33 @@
+import importlib
+import os
+
+from fastapi.testclient import TestClient
+
+
+def _build_app(root_path: str = ""):
+    if root_path:
+        os.environ["ROOT_PATH"] = root_path
+    else:
+        os.environ.pop("ROOT_PATH", None)
+    import backend.main as main
+    importlib.reload(main)
+    return main.app
+
+
+def test_root_path_empty_by_default():
+    app = _build_app("")
+    assert app.root_path == ""
+
+
+def test_root_path_picked_up_from_env():
+    app = _build_app("/meal")
+    assert app.root_path == "/meal"
+    os.environ.pop("ROOT_PATH", None)
+
+
+def test_openapi_reflects_root_path():
+    app = _build_app("/meal-staging")
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+    assert spec.get("servers") == [{"url": "/meal-staging"}]
+    os.environ.pop("ROOT_PATH", None)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,21 @@
+# Apply on top of docker-compose.yml for local dev with hot reload + bind mounts:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+services:
+  backend:
+    volumes:
+      - .:/app
+      - uploads:/app/uploads
+    command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
+  frontend:
+    volumes:
+      - ./frontend:/usr/share/nginx/html:ro
+  db:
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./backend/db/migrations/001_initial_schema.sql:/docker-entrypoint-initdb.d/001_initial_schema.sql:ro
+  gateway:
+    volumes:
+      - ./infra/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+      - uploads:/srv/uploads:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,11 @@ services:
       - .env.example
       - path: .env
         required: false
+    environment:
+      ROOT_PATH: ${ROOT_PATH:-}
     volumes:
-      - .:/app
       - uploads:/app/uploads
-    command: uvicorn backend.main:app --host 0.0.0.0 --port 8000 --reload
+    command: uvicorn backend.main:app --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
     depends_on:
@@ -19,29 +20,30 @@ services:
   frontend:
     build:
       context: ./frontend
-    volumes:
-      - ./frontend:/usr/share/nginx/html:ro
     ports:
       - "3000:80"
     depends_on:
       - backend
 
   db:
-    image: postgres:16-alpine
+    build:
+      context: .
+      dockerfile: backend/db/Dockerfile
     env_file:
       - .env.example
       - path: .env
         required: false
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./backend/db/migrations/001_initial_schema.sql:/docker-entrypoint-initdb.d/001_initial_schema.sql:ro
     ports:
       - "5432:5432"
 
   gateway:
-    image: caddy:2-alpine
+    build:
+      context: .
+      dockerfile: infra/caddy/Dockerfile
+    container_name: ${GATEWAY_CONTAINER_NAME:-mealorder-dev-gateway}
     volumes:
-      - ./infra/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
       - uploads:/srv/uploads:ro

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -2,13 +2,10 @@
 	auto_https disable_redirects
 }
 
-http://localhost {
-	redir https://localhost{uri}
-}
-
-https://localhost {
-	tls internal
-
+# Shared routing table. Imported by both the internal :80 entry point (used
+# by the preview-router, which forwards with Host: mealorder-<env>-gateway)
+# and the local-dev https://localhost entry point.
+(routes) {
 	handle /health {
 		reverse_proxy backend:8000
 	}
@@ -29,6 +26,10 @@ https://localhost {
 		reverse_proxy backend:8000
 	}
 
+	handle /employee/* {
+		reverse_proxy backend:8000
+	}
+
 	handle_path /uploads/* {
 		root * /srv/uploads
 		file_server
@@ -38,4 +39,17 @@ https://localhost {
 	handle {
 		reverse_proxy frontend:80
 	}
+}
+
+# Plain HTTP on :80 — for the internal preview-router, which proxies with
+# Host: mealorder-<env>-gateway (non-localhost), so we match by port only.
+:80 {
+	import routes
+}
+
+# Local-dev HTTPS entry point. Browsers hitting https://localhost get the
+# same routing tree with a self-signed cert.
+https://localhost {
+	tls internal
+	import routes
 }

--- a/infra/caddy/Dockerfile
+++ b/infra/caddy/Dockerfile
@@ -1,0 +1,2 @@
+FROM caddy:2-alpine
+COPY infra/caddy/Caddyfile /etc/caddy/Caddyfile

--- a/infra/deploy/SETUP-NOL.md
+++ b/infra/deploy/SETUP-NOL.md
@@ -1,0 +1,133 @@
+# NOL One-Time Setup for TBD Deployment
+
+All steps run **on the NOL host (A 機)** as a user with docker permission and access to NPM (nginx proxy manager).
+Re-running any block is safe (idempotent) unless explicitly noted.
+
+This setup supports the Trunk-Based Development pipeline:
+- `merge to main` → staging at `https://nol.cs.nycu.edu.tw/meal-staging/`
+- `git tag v*.*.*` → production at `https://nol.cs.nycu.edu.tw/meal/`
+- Root `/` 維持既有靜態網站，本作業不接管。
+
+Architecture: Jenkins (on NOL host, in container with docker.sock mount) deploys
+from its own workspace — no per-project source clone required on the host.
+
+## Prerequisites
+
+- Docker (with compose v2), git, curl, jq, gh CLI installed
+- Jenkins already serves `https://nol.cs.nycu.edu.tw/jenkins/` with docker.sock mounted into the container
+- NPM (nginx-proxy-manager) terminating TLS for `nol.cs.nycu.edu.tw`
+
+## 1. Shared docker network
+
+```bash
+docker network inspect preview-net >/dev/null 2>&1 \
+  || docker network create preview-net
+```
+
+## 2. Shared internal router
+
+Clone the repo somewhere ONLY for running the router script (the router itself only mounts the Caddyfile; once the container is up the clone isn't needed):
+
+```bash
+git clone https://github.com/mizu5555/Corporate-Meal-Ordering-System.git /tmp/cmos
+bash /tmp/cmos/infra/deploy/router/run-router.sh
+curl -s http://127.0.0.1:18080/ ; echo
+# expect: preview-router OK
+```
+
+If the Caddyfile changes upstream, re-run the script (it recreates the container).
+
+## 3. NPM — add /meal-staging/ and /meal/ proxy locations
+
+Edit the `nol.cs.nycu.edu.tw` proxy host in NPM UI. Go to **Advanced** tab and add to **Custom Nginx Configuration**:
+
+```nginx
+location /meal-staging/ {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://127.0.0.1:18080;
+}
+
+location /meal/ {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://127.0.0.1:18080;
+}
+```
+
+Save. NPM reloads automatically. Verify (before any stack is deployed, expect 503 = router up but no upstream):
+
+```bash
+curl -skI https://nol.cs.nycu.edu.tw/meal-staging/health
+curl -skI https://nol.cs.nycu.edu.tw/meal/health
+```
+
+## 4. Jenkins — Staging pipeline (`mealorder-staging`)
+
+In the Jenkins UI:
+1. **New Item → Multibranch Pipeline**, name `mealorder-staging`.
+2. **Branch Sources → GitHub**, repo `mizu5555/Corporate-Meal-Ordering-System`, credentials = PAT with `repo` + `admin:repo_hook`.
+3. **Behaviors → Add → Filter by name (with regex)** = `^main$`.
+4. **Build Configuration → by Jenkinsfile**, Script Path = `Jenkinsfile.staging`.
+5. **Scan triggers** — enable `Periodically if not otherwise run` = 1 minute.
+6. Save → automatic scan triggers first build.
+
+## 5. Jenkins — Production pipeline (`mealorder-prod`)
+
+1. **New Item → Multibranch Pipeline**, name `mealorder-prod`.
+2. **Branch Sources → GitHub**, same repo + credentials.
+3. **Behaviors → Remove `Discover branches`. Add `Discover tags`.**
+4. **Behaviors → Add → Filter by name (with regex)** = `^v\d+\.\d+\.\d+$`.
+5. **Build Configuration → by Jenkinsfile**, Script Path = `Jenkinsfile.prod`.
+6. Save. First scan likely finds no existing semver tag (until you push v0.1.0).
+
+> Note: new tags are auto-built only after the multibranch has indexed them; the very first tag may need a manual "Build Now" on its branch entry.
+
+## 6. Jenkins — Cleanup pipeline (`mealorder-cleanup`)
+
+1. **New Item → Pipeline**, name `mealorder-cleanup`.
+2. **Pipeline → Pipeline script from SCM**, Git repo + branch `*/main`, Script Path = `Jenkinsfile.cleanup`.
+3. Save → click **Build Now** once (registers the cron declared inside the Jenkinsfile).
+
+## 7. Jenkins-service mount requirements
+
+This Jenkins service container only needs:
+- `/var/run/docker.sock` mounted in
+- Its own `jenkins_home` bind/volume
+
+**No per-project source mount required.** Each pipeline checks the repo out into its own Jenkins workspace and runs `docker compose` from there; the docker daemon receives build contexts over the socket.
+
+## 8. Jenkins credentials
+
+| ID | Type | Used for |
+|---|---|---|
+| `gh-pat` | Secret text | `gh pr list` inside the cleanup sweep |
+| `github-app` | GitHub App or PAT | Branch source authentication |
+
+## 9. First deploy
+
+```bash
+# 1. Merge a PR into main → mealorder-staging job triggers automatically
+curl -sk https://nol.cs.nycu.edu.tw/meal-staging/health
+
+# 2. From your laptop, cut the first prod tag
+git tag v0.1.0 && git push origin v0.1.0
+# → mealorder-prod multibranch detects the tag (may need a manual Scan + Build Now the first time)
+
+curl -sk https://nol.cs.nycu.edu.tw/meal/health
+```
+
+## 10. End-to-end verification checklist
+
+- [ ] PR open → GitHub Actions `unit` + `integration` green, no Jenkins build triggered
+- [ ] Merge to `main` → `mealorder-staging` job green, `/meal-staging/health` returns 200
+- [ ] `git push origin v0.1.0` → `mealorder-prod` job green, `/meal/health` returns 200
+- [ ] Subsequent merge to `main` updates `/meal-staging/`, prod stays on v0.1.0
+- [ ] `docker compose ls` shows `mealorder-staging`, `mealorder-prod`, `caddy-preview-router`
+- [ ] `https://nol.cs.nycu.edu.tw/` static homepage unaffected

--- a/infra/deploy/docker-compose.prod.yml
+++ b/infra/deploy/docker-compose.prod.yml
@@ -1,0 +1,16 @@
+# Override applied for prod stack: strip host ports, join gateway to preview-net
+# so the shared caddy-preview-router can reach it via docker DNS.
+services:
+  backend:
+    ports: !reset []
+  frontend:
+    ports: !reset []
+  db:
+    ports: !reset []
+  gateway:
+    ports: !reset []
+    networks: [default, preview-net]
+
+networks:
+  preview-net:
+    external: true

--- a/infra/deploy/docker-compose.staging.yml
+++ b/infra/deploy/docker-compose.staging.yml
@@ -1,0 +1,16 @@
+# Override applied for staging stack: strip host ports, join gateway to preview-net
+# so the shared caddy-preview-router can reach it via docker DNS.
+services:
+  backend:
+    ports: !reset []
+  frontend:
+    ports: !reset []
+  db:
+    ports: !reset []
+  gateway:
+    ports: !reset []
+    networks: [default, preview-net]
+
+networks:
+  preview-net:
+    external: true

--- a/infra/deploy/router/Caddyfile
+++ b/infra/deploy/router/Caddyfile
@@ -1,0 +1,22 @@
+# Shared internal router. NPM forwards /meal-staging/* and /meal/* here,
+# which strips the prefix and proxies to the matching stack's gateway over
+# the preview-net docker bridge.
+:80 {
+    handle_path /meal-staging/* {
+        reverse_proxy http://mealorder-staging-gateway:80 {
+            health_uri /health
+            fail_duration 5s
+        }
+    }
+
+    handle_path /meal/* {
+        reverse_proxy http://mealorder-prod-gateway:80 {
+            health_uri /health
+            fail_duration 5s
+        }
+    }
+
+    handle {
+        respond "preview-router OK" 200
+    }
+}

--- a/infra/deploy/router/run-router.sh
+++ b/infra/deploy/router/run-router.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Idempotent bootstrap for the shared deploy router container on the NOL host.
+# Safe to re-run; recreates the container if Caddyfile changes.
+set -euo pipefail
+
+CADDYFILE="${CADDYFILE:-$(cd "$(dirname "$0")" && pwd)/Caddyfile}"
+NETWORK="${NETWORK:-preview-net}"
+NAME="${NAME:-caddy-preview-router}"
+HOST_PORT="${HOST_PORT:-127.0.0.1:18080}"
+
+docker network inspect "$NETWORK" >/dev/null 2>&1 \
+  || docker network create "$NETWORK"
+
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+
+docker run -d \
+  --name "$NAME" \
+  --restart unless-stopped \
+  -p "${HOST_PORT}:80" \
+  --network "$NETWORK" \
+  -v "${CADDYFILE}:/etc/caddy/Caddyfile:ro" \
+  caddy:2-alpine
+
+echo "router up on ${HOST_PORT} using ${CADDYFILE}"

--- a/scripts/sweep-stale-stacks.sh
+++ b/scripts/sweep-stale-stacks.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Sweep: drop deploy stacks whose corresponding PR is CLOSED or MERGED.
+# OPEN or unknown -> leave alone. Never touches stable stacks (main/staging/prod).
+set -euo pipefail
+
+PROJECT_PREFIX="${PROJECT_PREFIX:-mealorder}"
+
+PROJECTS=$(docker compose ls --filter name=${PROJECT_PREFIX}- --format json \
+  | jq -r --arg p "$PROJECT_PREFIX" '
+      .[]
+      | select(.Name != ($p + "-main"))
+      | select(.Name != ($p + "-staging"))
+      | select(.Name != ($p + "-prod"))
+      | .Name')
+
+for proj in $PROJECTS; do
+  BRANCH=$(docker ps -a --filter "label=mealorder.branch" \
+    --filter "label=com.docker.compose.project=$proj" \
+    --format '{{.Label "mealorder.branch"}}' | head -n1)
+
+  if [ -z "$BRANCH" ]; then
+    echo "[skip] $proj has no mealorder.branch label, leaving alone"
+    continue
+  fi
+
+  STATE=$(gh pr list --head "$BRANCH" --state all --json state \
+    --jq 'if map(select(.state == "OPEN")) | length > 0 then "OPEN" else (.[0].state // "UNKNOWN") end' 2>/dev/null || echo "UNKNOWN")
+
+  case "$STATE" in
+    CLOSED|MERGED)
+      echo "[drop] $proj (branch=$BRANCH state=$STATE)"
+      docker compose -p "$proj" down -v --remove-orphans
+      ;;
+    OPEN)
+      echo "[keep] $proj (branch=$BRANCH state=OPEN)"
+      ;;
+    *)
+      echo "[skip] $proj (branch=$BRANCH state=$STATE) — not touching"
+      ;;
+  esac
+done


### PR DESCRIPTION
Closes #7.

## What

Introduces a complete Trunk-Based Development CI/CD pipeline backed by Jenkins:

- **CI** — GitHub Actions runs `unit` + `integration` on every push (PR + main). This PR splits them into two jobs and provisions Postgres as a service for integration.
- **CD (staging)** — `main` merges trigger `mealorder-staging` Jenkins multibranch job → deploys to `https://nol.cs.nycu.edu.tw/meal-staging/`. DB reset on every run.
- **CD (prod)** — `v*.*.*` semver tag pushes trigger `mealorder-prod` job → deploys to `https://nol.cs.nycu.edu.tw/meal/`. Volume preserved across tag bumps.
- **Cleanup** — hourly defensive sweep (`mealorder-cleanup`) for any stale `mealorder-pr-*` projects in case PR-preview is re-enabled.

## Architecture

- **Workspace-based deploy**: Jenkins runs `docker compose build/up -d` directly from its own workspace via the host docker daemon. **No per-project source clone required** on the deploy host. Adding a new project = write a Jenkinsfile; the `jenkins-service` container does not change.
- **Image-baked configs**: `Caddyfile` and Postgres migration `.sql` files are now built into images (`infra/caddy/Dockerfile`, `backend/db/Dockerfile`) so runtime needs no host bind mounts.
- **Dev override**: existing dev hot-reload bind mounts moved from base `docker-compose.yml` to a new `docker-compose.dev.yml`. Base compose is CD-ready.
- **Gateway `(routes)` snippet**: a single routing table is imported by both the internal `:80` entry point (used by the shared `caddy-preview-router`, which forwards with `Host: mealorder-<env>-gateway`) and the local-dev `https://localhost` entry point. Adding a new backend route prefix means **one line inside `(routes)`** rather than two places.
- **`/employee/*` gateway route**: the employee ordering APIs merged in #5 declared `prefix="/employee"` on the FastAPI router but the Caddy gateway never had a matching `handle` block. This PR adds it so the routes are reachable through the gateway.

## Routing layout

```
External HTTPS
  └─ NPM (host network, TLS terminator for nol.cs.nycu.edu.tw)
       ├─ /meal-staging/* ─┐
       ├─ /meal/*        ─┼─→ http://127.0.0.1:18080
       └─ everything else (existing routes untouched)
                            └─ caddy-preview-router (preview-net)
                                 ├─ handle_path /meal-staging/* → mealorder-staging-gateway:80
                                 └─ handle_path /meal/*         → mealorder-prod-gateway:80
                                                                    └─ (routes) snippet → backend / frontend / file_server
```

## Tests

- `backend/tests/test_root_path.py` — verifies `ROOT_PATH` env injection produces matching `app.root_path` and `servers: [{url: "/meal"}]` in OpenAPI.
- All existing tests continue to pass (`pytest backend/tests --ignore=backend/tests/integration -q`).
- `docker compose -f docker-compose.yml config` and `docker compose -f docker-compose.yml -f docker-compose.dev.yml config` both validate.

## Local dev command change

```bash
# before
docker compose up --build

# after
docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
```

`README.md` and `infra/deploy/SETUP-NOL.md` document this.

## Deploy host (NOL) setup

See `infra/deploy/SETUP-NOL.md` for the one-time setup:
1. `docker network create preview-net`
2. `bash infra/deploy/router/run-router.sh`
3. NPM proxy host: add `/meal-staging/` and `/meal/` Advanced custom locations
4. Jenkins UI: create three jobs (`mealorder-staging`, `mealorder-prod`, `mealorder-cleanup`) with credentials `gh-pat` and `github-app`
5. First cutover: merge → tag `v0.1.0` → verify both URLs

## Out of scope (deliberate)

- Image registry push/pull (current build-on-deploy-host is fine for this scale)
- Per-PR preview environments (pure TBD; rely on short-lived branches + staging validation)
- Rollback automation (manual via Jenkins UI "Build Now" on an older tag)
- Production approval gate (tag push is the deliberate human action)

## Test plan

- [x] `docker compose -f docker-compose.yml config` → OK
- [x] `docker compose -f docker-compose.yml -f docker-compose.dev.yml config` → OK
- [x] `pytest backend/tests/test_root_path.py -q` → 3 passed (validated locally)
- [x] GHA `unit` + `integration` both green on this PR
- [x] After merge: `mealorder-staging` job triggers automatically, `/meal-staging/health` returns 200
- [x] After `git push origin v0.1.0`: `mealorder-prod` job triggers, `/meal/health` returns 200
- [x] DB persists across prod tag bumps; staging DB resets on each merge
- [x] All gateway routes reachable: `/health`, `/docs`, `/openapi.json`, `/admin/*`, `/vendor/*`, `/employee/*`, `/uploads/*`
- [x] `https://nol.cs.nycu.edu.tw/` static homepage unaffected
