### PR TITLE
feat(ci): per-PR preview environments at /preview/<slug>/

### DIFF
--- a/Jenkinsfile.preview
+++ b/Jenkinsfile.preview
@@ -1,0 +1,113 @@
+pipeline {
+  agent any
+
+  options {
+    disableConcurrentBuilds()
+    timeout(time: 20, unit: 'MINUTES')
+    timestamps()
+  }
+
+  environment {
+    PROJECT_PREFIX  = 'mealorder'
+    PREVIEW_LIMIT   = '3'
+    PUBLIC_BASE     = 'https://nol.cs.nycu.edu.tw'
+  }
+
+  stages {
+    stage('Checkout') {
+      when { changeRequest() }
+      steps { checkout scm }
+    }
+
+    stage('Deploy preview') {
+      when { changeRequest() }
+      environment {
+        BRANCH_RAW = "${env.CHANGE_BRANCH}"
+      }
+      steps {
+        withCredentials([string(credentialsId: 'gh-pat', variable: 'GH_TOKEN')]) {
+          sh '''
+            set -euo pipefail
+
+            if [ -z "${BRANCH_RAW:-}" ]; then
+              echo "BRANCH_RAW empty; refusing to deploy" >&2
+              exit 2
+            fi
+
+            SLUG=$(bash scripts/preview-sanitize-branch.sh "$BRANCH_RAW")
+            if [ -z "$SLUG" ]; then
+              gh pr comment "$CHANGE_ID" --repo "$CHANGE_URL" --body "Preview deploy aborted: branch name '$BRANCH_RAW' produces empty slug." || true
+              echo "empty SLUG from sanitize" >&2
+              exit 2
+            fi
+
+            PROJECT="${PROJECT_PREFIX}-${SLUG}"
+            ROOT_PATH="/preview/${SLUG}"
+
+            docker network inspect preview-net >/dev/null 2>&1 \
+              || docker network create preview-net
+
+            # Slot check — count active preview stacks excluding stable ones.
+            COUNT=$(docker compose ls --filter name=${PROJECT_PREFIX}- --format json \
+              | jq --arg p "$PROJECT_PREFIX" --arg this "$PROJECT" '
+                  [.[]
+                    | select(.Name != $this)
+                    | select(.Name != ($p + "-main"))
+                    | select(.Name != ($p + "-staging"))
+                    | select(.Name != ($p + "-prod"))
+                  ] | length')
+            if [ "$COUNT" -ge "$PREVIEW_LIMIT" ]; then
+              gh pr comment "$CHANGE_ID" --body "Preview slot full ($COUNT/$PREVIEW_LIMIT). Will retry on next push." || true
+              echo "preview slot full" >&2
+              exit 0
+            fi
+
+            BRANCH_RAW="$BRANCH_RAW" \
+            ROOT_PATH="$ROOT_PATH" \
+            SLUG="$SLUG" \
+            GATEWAY_CONTAINER_NAME="mealorder-${SLUG}-gateway" \
+              docker compose \
+                -p "$PROJECT" \
+                -f docker-compose.yml \
+                -f infra/deploy/docker-compose.preview.yml \
+                down -v --remove-orphans || true
+
+            BRANCH_RAW="$BRANCH_RAW" \
+            ROOT_PATH="$ROOT_PATH" \
+            SLUG="$SLUG" \
+            GATEWAY_CONTAINER_NAME="mealorder-${SLUG}-gateway" \
+              docker compose \
+                -p "$PROJECT" \
+                -f docker-compose.yml \
+                -f infra/deploy/docker-compose.preview.yml \
+                up -d --build
+
+            URL="${PUBLIC_BASE}/preview/${SLUG}/"
+
+            # Smoke check — retry health up to 60s.
+            ok=0
+            for i in $(seq 1 30); do
+              if curl -fsS "${URL}health" >/dev/null; then
+                ok=1
+                break
+              fi
+              sleep 2
+            done
+
+            if [ "$ok" -eq 1 ]; then
+              gh pr comment "$CHANGE_ID" --body "Preview ready: ${URL} (health: ${URL}health)" || true
+            else
+              gh pr comment "$CHANGE_ID" --body "Preview deploy reached but /health failed after 60s. Check Jenkins console for ${PROJECT}." || true
+              docker compose -p "$PROJECT" logs --tail=200 >&2 || true
+              exit 1
+            fi
+          '''
+        }
+      }
+    }
+  }
+
+  post {
+    always { cleanWs() }
+  }
+}

--- a/Jenkinsfile.preview
+++ b/Jenkinsfile.preview
@@ -42,7 +42,7 @@ pipeline {
             fi
 
             PROJECT="${PROJECT_PREFIX}-${SLUG}"
-            ROOT_PATH="/preview/${SLUG}"
+            ROOT_PATH="/meal-preview/${SLUG}"
 
             docker network inspect preview-net >/dev/null 2>&1 \
               || docker network create preview-net
@@ -82,7 +82,7 @@ pipeline {
                 -f infra/deploy/docker-compose.preview.yml \
                 up -d --build
 
-            URL="${PUBLIC_BASE}/preview/${SLUG}/"
+            URL="${PUBLIC_BASE}/meal-preview/${SLUG}/"
 
             # Smoke check — retry health up to 60s.
             ok=0

--- a/infra/deploy/SETUP.md
+++ b/infra/deploy/SETUP.md
@@ -95,6 +95,35 @@ In the Jenkins UI:
 2. **Pipeline → Pipeline script from SCM**, Git repo + branch `*/main`, Script Path = `Jenkinsfile.cleanup`.
 3. Save → click **Build Now** once (registers the cron declared inside the Jenkinsfile).
 
+## 6.5 Jenkins — PR preview pipeline (`mealorder-preview`)
+
+1. **New Item → Multibranch Pipeline**, name `mealorder-preview`.
+2. **Branch Sources → GitHub**, repo `mizu5555/Corporate-Meal-Ordering-System`, credentials = your PAT.
+3. **Behaviors** — adjust:
+   - **Remove** `Discover branches` (PR-only pipeline).
+   - **Add** `Discover pull requests from origin` (strategy: "Merging the pull request with the current target branch revision").
+   - Optionally `Discover pull requests from forks` if you want fork-PR previews (security caveat: forked PRs can execute your Jenkinsfile).
+4. **Build Configuration → by Jenkinsfile**, Script Path = `Jenkinsfile.preview`.
+5. **Scan triggers** — enable `Periodically if not otherwise run` = 1 minute (or rely on webhook).
+6. Save.
+
+Then add a Custom Nginx location to the existing `nol.cs.nycu.edu.tw` proxy host in NPM:
+
+```nginx
+location /preview/ {
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://127.0.0.1:18080;
+}
+```
+
+(`/meal-staging/` and `/meal/` lines stay as-is — `/preview/` is additive.)
+
+Preview slot cap is hard-coded to 3 in `Jenkinsfile.preview` (`PREVIEW_LIMIT`); adjust if NOL resources allow more.
+
 ## 7. Jenkins-service mount requirements
 
 This Jenkins service container only needs:
@@ -131,3 +160,6 @@ curl -sk https://nol.cs.nycu.edu.tw/meal/health
 - [ ] Subsequent merge to `main` updates `/meal-staging/`, prod stays on v0.1.0
 - [ ] `docker compose ls` shows `mealorder-staging`, `mealorder-prod`, `caddy-preview-router`
 - [ ] `https://nol.cs.nycu.edu.tw/` static homepage unaffected
+- [ ] Opening a PR triggers `mealorder-preview`; PR receives a comment with the preview URL
+- [ ] `https://nol.cs.nycu.edu.tw/preview/<slug>/health` returns 200 for the open PR
+- [ ] Closing the PR → within 1 hour, the preview stack is gone (`docker compose ls`)

--- a/infra/deploy/SETUP.md
+++ b/infra/deploy/SETUP.md
@@ -110,7 +110,7 @@ In the Jenkins UI:
 Then add a Custom Nginx location to the existing `nol.cs.nycu.edu.tw` proxy host in NPM:
 
 ```nginx
-location /preview/ {
+location /meal-preview/ {
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -120,7 +120,7 @@ location /preview/ {
 }
 ```
 
-(`/meal-staging/` and `/meal/` lines stay as-is — `/preview/` is additive.)
+(`/meal-staging/` and `/meal/` lines stay as-is — `/meal-preview/` is additive and keeps the `meal-*` namespace consistent with the other two.)
 
 Preview slot cap is hard-coded to 3 in `Jenkinsfile.preview` (`PREVIEW_LIMIT`); adjust if NOL resources allow more.
 

--- a/infra/deploy/docker-compose.preview.yml
+++ b/infra/deploy/docker-compose.preview.yml
@@ -1,0 +1,29 @@
+# Override applied for per-PR preview stacks.
+# - Strips host ports so multiple stacks coexist with staging/prod on the same host.
+# - Gives the gateway a stable, slug-derived container_name so the shared
+#   caddy-preview-router can dispatch /preview/<slug>/* via docker DNS.
+# - Tags every container with the originating branch name so the hourly
+#   sweep can map a stack back to a PR via the GitHub API.
+services:
+  backend:
+    ports: !reset []
+    labels:
+      mealorder.branch: ${BRANCH_RAW:-}
+  frontend:
+    ports: !reset []
+    labels:
+      mealorder.branch: ${BRANCH_RAW:-}
+  db:
+    ports: !reset []
+    labels:
+      mealorder.branch: ${BRANCH_RAW:-}
+  gateway:
+    ports: !reset []
+    container_name: mealorder-${SLUG:-default}-gateway
+    networks: [default, preview-net]
+    labels:
+      mealorder.branch: ${BRANCH_RAW:-}
+
+networks:
+  preview-net:
+    external: true

--- a/infra/deploy/router/Caddyfile
+++ b/infra/deploy/router/Caddyfile
@@ -1,6 +1,6 @@
-# Shared internal router. NPM forwards /meal-staging/* and /meal/* here,
-# which strips the prefix and proxies to the matching stack's gateway over
-# the preview-net docker bridge.
+# Shared internal router. NPM forwards /meal-staging/*, /meal/*, and
+# /meal-preview/* here, which strip the prefix and proxy to the matching
+# stack's gateway over the preview-net docker bridge.
 :80 {
     handle_path /meal-staging/* {
         reverse_proxy http://mealorder-staging-gateway:80 {
@@ -14,6 +14,13 @@
             health_uri /health
             fail_duration 5s
         }
+    }
+
+    # Per-PR preview dispatcher: /meal-preview/<slug>/... -> mealorder-<slug>-gateway
+    @preview path_regexp br ^/meal-preview/([a-z0-9-]+)(/.*)?$
+    handle @preview {
+        uri strip_prefix /meal-preview/{re.br.1}
+        reverse_proxy mealorder-{re.br.1}-gateway:80
     }
 
     handle {

--- a/scripts/preview-sanitize-branch.sh
+++ b/scripts/preview-sanitize-branch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Turn a raw branch name into a DNS-/compose-safe slug for preview stacks.
+#   feature/foo/bar-baz  -> foo-bar-baz
+#   chore/RENAME_THIS    -> rename-this
+#   ALLCAPS              -> allcaps
+# Empty input or input that sanitises to empty exits non-zero.
+set -euo pipefail
+
+raw="${1:-}"
+if [ -z "$raw" ]; then
+  echo "" >&2
+  exit 2
+fi
+
+slug=$(printf '%s' "$raw" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's#^(feature|fix|chore|docs|refactor|test|ci|build|perf)/##' \
+  | sed -E 's#[^a-z0-9-]+#-#g' \
+  | sed -E 's#^-+##; s#-+$##' \
+  | cut -c1-40)
+
+if [ -z "$slug" ]; then
+  exit 2
+fi
+
+printf '%s\n' "$slug"

--- a/scripts/test_preview_sanitize_branch.sh
+++ b/scripts/test_preview_sanitize_branch.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Minimal unit-style test for preview-sanitize-branch.sh.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/preview-sanitize-branch.sh"
+
+pass=0; fail=0
+expect() {
+  local input="$1" want="$2"
+  local got
+  got=$(bash "$SCRIPT" "$input" 2>/dev/null || true)
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1))
+  else
+    fail=$((fail+1))
+    printf 'FAIL: input=%q want=%q got=%q\n' "$input" "$want" "$got" >&2
+  fi
+}
+
+expect "feature/foo/bar-baz"            "foo-bar-baz"
+expect "chore/RENAME_THIS"               "rename-this"
+expect "ALLCAPS"                         "allcaps"
+expect "feature/jenkins-cicd/preview"    "jenkins-cicd-preview"
+expect "fix/abc_def"                     "abc-def"
+
+# Empty / pathological inputs
+got=$(bash "$SCRIPT" "" 2>/dev/null || echo "<error>")
+if [ "$got" = "<error>" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: empty input should error" >&2; fi
+got=$(bash "$SCRIPT" "////" 2>/dev/null || echo "<error>")
+if [ "$got" = "<error>" ]; then pass=$((pass+1)); else fail=$((fail+1)); echo "FAIL: slashes-only should error" >&2; fi
+
+echo "$pass passed, $fail failed"
+exit $fail


### PR DESCRIPTION
Closes #8.

## What

Adds per-PR preview environments without breaking the TBD architecture from #6:
- `main` merges still auto-deploy to `/meal-staging/`
- `v*.*.*` tags still deploy to `/meal/`
- **New**: every open PR auto-deploys a short-lived stack to `/meal-preview/<slug>/`
- The existing `mealorder-cleanup` hourly sweep now has real work — it drops preview stacks whose PR is CLOSED or MERGED

The `meal-preview` prefix is chosen to stay inside the same `meal-*` namespace as `/meal-staging/` and `/meal/`, so the three deploy tiers are consistently named.

## Pipeline

`Jenkinsfile.preview` gated by `when { changeRequest() }`:
1. Sanitize source branch name → `<slug>` (via `scripts/preview-sanitize-branch.sh`)
2. Cap check: at most `PREVIEW_LIMIT=3` concurrent preview stacks; over the cap the build comments "slot full" on the PR and exits cleanly (no crash)
3. `docker compose -p mealorder-<slug>` with `infra/deploy/docker-compose.preview.yml` override → host ports stripped, gateway gets `container_name=mealorder-<slug>-gateway` and joins `preview-net`, labels record the branch name for sweep
4. Smoke check at `/meal-preview/<slug>/health`
5. Comments the URL on the PR via `gh pr comment` (uses existing `gh-pat` credential)

## Routing

- `infra/deploy/router/Caddyfile` adds a dynamic dispatcher for `/meal-preview/<slug>/*` → `mealorder-<slug>-gateway:80`. The two stable routes (`/meal-staging/*`, `/meal/*`) are unchanged.
- NPM needs one additional Custom Nginx location for `/meal-preview/` → `127.0.0.1:18080` (documented in `infra/deploy/SETUP.md` §6.5).

## Cleanup

`Jenkinsfile.cleanup` already calls `scripts/sweep-stale-stacks.sh` hourly; the script already knows to skip `-main`/`-staging`/`-prod`. Once preview is live, the sweep starts dropping stacks whose PR is `CLOSED` or `MERGED`. Optional: wire a GitHub `pull_request.closed` webhook into Jenkins for immediate drop instead of waiting up to 1 hour.

## Out of scope (deliberate)

- Cross-fork PR previews (security — fork PRs running our Jenkinsfile)
- Preserving preview state across pushes (DB reset each time; matches staging)
- Image-registry-based preview (still build on the host daemon)

## Test plan

- [x] `bash scripts/test_preview_sanitize_branch.sh` — 7 passed, 0 failed
- [x] `docker compose -f docker-compose.yml -f infra/deploy/docker-compose.preview.yml config` — validates
- [x] PR open against this branch → `mealorder-preview` runs → PR comment with `/meal-preview/<slug>/` URL appears
- [x] `/meal-preview/<slug>/health` returns 200
- [x] 4th concurrent PR → slot-full comment, no crash
- [x] Closing a preview PR → within 1 hour `docker compose ls` no longer shows that stack
- [x] `mealorder-staging` / `mealorder-prod` untouched throughout
