### PR TITLE
fix(ci): sweep-stale-stacks finds PRs by API when branch deleted

### DIFF
--- a/scripts/sweep-stale-stacks.sh
+++ b/scripts/sweep-stale-stacks.sh
@@ -5,6 +5,13 @@ set -euo pipefail
 
 PROJECT_PREFIX="${PROJECT_PREFIX:-mealorder}"
 
+# Resolve owner/repo once so we can query the PR API by branch name.
+# `gh api ... ?head=owner:branch` finds PRs even after the branch has been
+# deleted (which happens automatically on `gh pr merge --delete-branch`).
+# `gh pr list --head <deleted-branch>` returns empty and breaks cleanup.
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+OWNER="${REPO%%/*}"
+
 PROJECTS=$(docker compose ls --filter name=${PROJECT_PREFIX}- --format json \
   | jq -r --arg p "$PROJECT_PREFIX" '
       .[]
@@ -23,8 +30,14 @@ for proj in $PROJECTS; do
     continue
   fi
 
-  STATE=$(gh pr list --head "$BRANCH" --state all --json state \
-    --jq 'if map(select(.state == "OPEN")) | length > 0 then "OPEN" else (.[0].state // "UNKNOWN") end' 2>/dev/null || echo "UNKNOWN")
+  STATE="UNKNOWN"
+  if [ -n "$REPO" ] && [ -n "$OWNER" ]; then
+    STATE=$(gh api "repos/${REPO}/pulls?state=all&head=${OWNER}:${BRANCH}&per_page=100" \
+      --jq 'if length == 0 then "UNKNOWN"
+            elif any(.state == "open") then "OPEN"
+            else (.[0] | if .merged_at then "MERGED" else "CLOSED" end)
+            end' 2>/dev/null || echo "UNKNOWN")
+  fi
 
   case "$STATE" in
     CLOSED|MERGED)


### PR DESCRIPTION
## Summary
Fixes the production bug where preview stacks leaked after PR merge when `gh pr merge --delete-branch` removed the source branch ref.

## Root cause
`sweep-stale-stacks.sh` used `gh pr list --head "$BRANCH" --state all`. When the branch is deleted, this filter returns an empty list (it queries live refs, not historical PR records). The jq fallback then yields `UNKNOWN`, the case statement matches the conservative `*) skip` branch, and the stack survives forever.

## Fix
Switch to the underlying GitHub REST API:

```bash
gh api "repos/${REPO}/pulls?state=all&head=${OWNER}:${BRANCH}&per_page=100"
```

The `head=owner:branch` query parameter searches PR records by their stored head metadata, which persists after the branch ref is deleted. Also normalises state detection: merged PRs are `state="closed"` with `merged_at` set, so we distinguish MERGED vs CLOSED explicitly.

## Verification
Tested against the deleted branch `feature/monitoring/http-metrics-grafana` (PR #11). Old query returns empty → UNKNOWN. New query returns `MERGED`. The next `mealorder-cleanup` build will correctly tear down any stack still labeled with a merged PR's branch.

## Testing
- Local: `gh api ...` query against deleted branch returns `MERGED` as expected
- Production verification: trigger `mealorder-cleanup` after merge and confirm log shows `[drop]` for any merged-branch stacks (currently none, since the stuck `mealorder-monitoring-http-metrics-grafana` stack was manually torn down)

Refs #8