### PR TITLE
test(ci): smoke test cleanup pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,4 @@ git checkout -b feature/<name>/<short-task>
 - Logs are written to stdout.
 - The FastAPI app is stateless.
 - PostgreSQL is treated as an external backing service.
+


### PR DESCRIPTION
Trivial PR to verify cleanup pipeline now works after `gh` was installed in Jenkins container.

This branch will be merged with `--delete-branch` immediately, leaving a stale preview stack that the next cleanup run should detect as MERGED and tear down.

Refs #8