### PR TITLE
feat(db): add postgres migrations and vendor menu persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
 - Backend direct dev port: http://localhost:8000
 - PostgreSQL: localhost:5432
 
+## Database Migrations
+
+SQL migrations live in `backend/db/migrations/` and are applied by the backend
+startup hook when `DATABASE_URL` is configured. Applied filenames are tracked in
+the `schema_migrations` table.
+
+For local Docker Compose development, PostgreSQL is started first and the
+backend applies pending migrations automatically.
+
 ## Backend Skeleton
 
 - `GET /health`

--- a/backend/core/vendor_identity.py
+++ b/backend/core/vendor_identity.py
@@ -13,16 +13,21 @@ from typing import Annotated
 
 from fastapi import Depends, Header
 
+from backend.core.config import settings
 from backend.core.errors import CodedHTTPException
+from backend.repositories.postgres_vendor_profile_repository import PostgresVendorProfileRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
 
 # Module-singleton：production 模式下 process 內共用同一份 in-memory state。
 # 測試以 app.dependency_overrides[get_vendor_profile_repository] 注入新實例。
 _REPO_SINGLETON = VendorProfileRepository()
+_POSTGRES_REPO_SINGLETON = PostgresVendorProfileRepository()
 
 
 def get_vendor_profile_repository() -> VendorProfileRepository:
     """DI 切換點：測試覆寫此 callable 即可換成 fake/seeded repo。"""
+    if settings.database_url:
+        return _POSTGRES_REPO_SINGLETON
     return _REPO_SINGLETON
 
 

--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -1,0 +1,1 @@
+"""Database helpers for the backend application."""

--- a/backend/db/connection.py
+++ b/backend/db/connection.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
+from backend.core.config import settings
+
+
+def get_connection() -> Any:
+    """Open a PostgreSQL connection using DATABASE_URL.
+
+    The psycopg import is intentionally lazy so unit tests that keep using the
+    in-memory repositories do not need an active database connection.
+    """
+    if not settings.database_url:
+        raise RuntimeError("DATABASE_URL is not configured")
+
+    from psycopg import connect
+    from psycopg.rows import dict_row
+
+    return connect(settings.database_url, row_factory=dict_row)

--- a/backend/db/migrate.py
+++ b/backend/db/migrate.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from backend.core.config import settings
+from backend.db.connection import get_connection
+
+logger = logging.getLogger(__name__)
+
+MIGRATIONS_DIR = Path(__file__).parent / "migrations"
+
+
+def run_migrations() -> None:
+    """Apply SQL migrations that have not been recorded yet."""
+    if not settings.database_url:
+        logger.info("DATABASE_URL is empty; skipping database migrations")
+        return
+
+    migration_files = sorted(MIGRATIONS_DIR.glob("*.sql"))
+
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_migrations (
+                    filename TEXT PRIMARY KEY,
+                    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+            cur.execute("SELECT filename FROM schema_migrations")
+            applied = {row["filename"] for row in cur.fetchall()}
+
+            for path in migration_files:
+                if path.name in applied:
+                    continue
+
+                logger.info("Applying database migration %s", path.name)
+                cur.execute(path.read_text(encoding="utf-8"))
+                cur.execute(
+                    "INSERT INTO schema_migrations (filename) VALUES (%s)",
+                    (path.name,),
+                )
+
+        conn.commit()

--- a/backend/db/migrations/002_vendor_menu_schema.sql
+++ b/backend/db/migrations/002_vendor_menu_schema.sql
@@ -1,0 +1,53 @@
+ALTER TABLE vendors
+  ADD COLUMN IF NOT EXISTS address TEXT,
+  ADD COLUMN IF NOT EXISTS business_hours TEXT,
+  ADD COLUMN IF NOT EXISTS contact_phone TEXT,
+  ADD COLUMN IF NOT EXISTS owner_user_id BIGINT REFERENCES users(id);
+
+CREATE TABLE IF NOT EXISTS facilities (
+  id BIGSERIAL PRIMARY KEY,
+  code TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS vendor_facilities (
+  vendor_id BIGINT NOT NULL REFERENCES vendors(id) ON DELETE CASCADE,
+  facility_id BIGINT NOT NULL REFERENCES facilities(id) ON DELETE CASCADE,
+  PRIMARY KEY (vendor_id, facility_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vendor_facilities_facility_id
+  ON vendor_facilities (facility_id);
+
+CREATE TABLE IF NOT EXISTS menu_categories (
+  id BIGSERIAL PRIMARY KEY,
+  vendor_id BIGINT NOT NULL REFERENCES vendors(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  sort_order INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (vendor_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_menu_categories_vendor_sort
+  ON menu_categories (vendor_id, sort_order);
+
+CREATE TABLE IF NOT EXISTS menu_items (
+  id BIGSERIAL PRIMARY KEY,
+  vendor_id BIGINT NOT NULL REFERENCES vendors(id) ON DELETE CASCADE,
+  category_id BIGINT REFERENCES menu_categories(id) ON DELETE SET NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  price_cents INT NOT NULL CHECK (price_cents >= 0),
+  available BOOLEAN NOT NULL DEFAULT TRUE,
+  daily_quota INT CHECK (daily_quota IS NULL OR daily_quota >= 0),
+  photo_path TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_menu_items_vendor_category
+  ON menu_items (vendor_id, category_id);
+
+CREATE INDEX IF NOT EXISTS idx_menu_items_vendor_available
+  ON menu_items (vendor_id)
+  WHERE available;

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,13 +1,22 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.core.config import settings
+from backend.db.migrate import run_migrations
 from backend.core.errors import install_error_handler
 from backend.routes import admin_vendors, committee_reviews, health, vendor_categories, vendor_menu, vendor_profile
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    run_migrations()
+    yield
+
+
 def create_app() -> FastAPI:
-    app = FastAPI(title=settings.app_name)
+    app = FastAPI(title=settings.app_name, lifespan=lifespan)
 
     app.add_middleware(
         CORSMiddleware,

--- a/backend/repositories/postgres_menu_category_repository.py
+++ b/backend/repositories/postgres_menu_category_repository.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any
+
+from backend.db.connection import get_connection
+from backend.schemas.vendor_self import Category
+
+
+class PostgresMenuCategoryRepository:
+    def create(self, *, vendor_id: int, name: str, sort_order: int = 0) -> Category:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                INSERT INTO menu_categories (vendor_id, name, sort_order)
+                VALUES (%s, %s, %s)
+                RETURNING id, vendor_id, name, sort_order, created_at
+                """,
+                (vendor_id, name, sort_order),
+            ).fetchone()
+
+        return Category(**dict(row))
+
+    def list(self, *, vendor_id: int) -> list[Category]:
+        with get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, vendor_id, name, sort_order, created_at
+                FROM menu_categories
+                WHERE vendor_id = %s
+                ORDER BY sort_order, id
+                """,
+                (vendor_id,),
+            ).fetchall()
+
+        return [Category(**dict(row)) for row in rows]
+
+    def get(self, *, vendor_id: int, category_id: int) -> Category | None:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT id, vendor_id, name, sort_order, created_at
+                FROM menu_categories
+                WHERE vendor_id = %s AND id = %s
+                """,
+                (vendor_id, category_id),
+            ).fetchone()
+
+        if row is None:
+            return None
+        return Category(**dict(row))
+
+    def update(
+        self, *, vendor_id: int, category_id: int, fields: dict[str, Any]
+    ) -> Category | None:
+        allowed_columns = {
+            "name": "name",
+            "sort_order": "sort_order",
+        }
+        updates = [
+            (allowed_columns[key], value)
+            for key, value in fields.items()
+            if key in allowed_columns and value is not None
+        ]
+        if not updates:
+            return self.get(vendor_id=vendor_id, category_id=category_id)
+
+        assignments = [f"{column} = %s" for column, _ in updates]
+        values = [value for _, value in updates]
+        values.extend([vendor_id, category_id])
+
+        with get_connection() as conn:
+            row = conn.execute(
+                f"""
+                UPDATE menu_categories
+                SET {", ".join(assignments)}
+                WHERE vendor_id = %s AND id = %s
+                RETURNING id, vendor_id, name, sort_order, created_at
+                """,
+                values,
+            ).fetchone()
+
+        if row is None:
+            return None
+        return Category(**dict(row))
+
+    def delete(self, *, vendor_id: int, category_id: int) -> bool:
+        with get_connection() as conn:
+            result = conn.execute(
+                """
+                DELETE FROM menu_categories
+                WHERE vendor_id = %s AND id = %s
+                """,
+                (vendor_id, category_id),
+            )
+
+        return result.rowcount > 0

--- a/backend/repositories/postgres_menu_item_repository.py
+++ b/backend/repositories/postgres_menu_item_repository.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from typing import Any
+
+from backend.db.connection import get_connection
+from backend.schemas.vendor_self import MenuItem
+
+
+class PostgresMenuItemRepository:
+    def create(
+        self,
+        *,
+        vendor_id: int,
+        name: str,
+        price_cents: int,
+        description: str | None = None,
+        category_id: int | None = None,
+        available: bool = True,
+        daily_quota: int | None = None,
+    ) -> MenuItem:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                INSERT INTO menu_items (
+                    vendor_id, category_id, name, description,
+                    price_cents, available, daily_quota
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                RETURNING
+                    id, vendor_id, category_id, name, description,
+                    price_cents, available, daily_quota, photo_path,
+                    created_at, updated_at
+                """,
+                (
+                    vendor_id,
+                    category_id,
+                    name,
+                    description,
+                    price_cents,
+                    available,
+                    daily_quota,
+                ),
+            ).fetchone()
+
+        return MenuItem(**dict(row))
+
+    def list(
+        self,
+        *,
+        vendor_id: int,
+        category_id: int | None = None,
+        available: bool | None = None,
+    ) -> list[MenuItem]:
+        where = ["vendor_id = %s"]
+        values: list[Any] = [vendor_id]
+
+        if category_id is not None:
+            where.append("category_id = %s")
+            values.append(category_id)
+        if available is not None:
+            where.append("available = %s")
+            values.append(available)
+
+        with get_connection() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT
+                    id, vendor_id, category_id, name, description,
+                    price_cents, available, daily_quota, photo_path,
+                    created_at, updated_at
+                FROM menu_items
+                WHERE {" AND ".join(where)}
+                ORDER BY id
+                """,
+                values,
+            ).fetchall()
+
+        return [MenuItem(**dict(row)) for row in rows]
+
+    def get(self, *, vendor_id: int, item_id: int) -> MenuItem | None:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT
+                    id, vendor_id, category_id, name, description,
+                    price_cents, available, daily_quota, photo_path,
+                    created_at, updated_at
+                FROM menu_items
+                WHERE vendor_id = %s AND id = %s
+                """,
+                (vendor_id, item_id),
+            ).fetchone()
+
+        if row is None:
+            return None
+        return MenuItem(**dict(row))
+
+    def update(
+        self, *, vendor_id: int, item_id: int, fields: dict[str, Any]
+    ) -> MenuItem | None:
+        allowed_columns = {
+            "category_id": "category_id",
+            "name": "name",
+            "description": "description",
+            "price_cents": "price_cents",
+            "available": "available",
+            "daily_quota": "daily_quota",
+        }
+        updates = [
+            (allowed_columns[key], value)
+            for key, value in fields.items()
+            if key in allowed_columns
+        ]
+        if not updates:
+            return self.get(vendor_id=vendor_id, item_id=item_id)
+
+        assignments = [f"{column} = %s" for column, _ in updates]
+        values = [value for _, value in updates]
+        values.extend([vendor_id, item_id])
+
+        with get_connection() as conn:
+            row = conn.execute(
+                f"""
+                UPDATE menu_items
+                SET {", ".join(assignments)}, updated_at = NOW()
+                WHERE vendor_id = %s AND id = %s
+                RETURNING
+                    id, vendor_id, category_id, name, description,
+                    price_cents, available, daily_quota, photo_path,
+                    created_at, updated_at
+                """,
+                values,
+            ).fetchone()
+
+        if row is None:
+            return None
+        return MenuItem(**dict(row))
+
+    def delete(self, *, vendor_id: int, item_id: int) -> bool:
+        with get_connection() as conn:
+            result = conn.execute(
+                """
+                DELETE FROM menu_items
+                WHERE vendor_id = %s AND id = %s
+                """,
+                (vendor_id, item_id),
+            )
+
+        return result.rowcount > 0
+
+    def set_photo_path(self, *, vendor_id: int, item_id: int, photo_path: str) -> None:
+        with get_connection() as conn:
+            conn.execute(
+                """
+                UPDATE menu_items
+                SET photo_path = %s, updated_at = NOW()
+                WHERE vendor_id = %s AND id = %s
+                """,
+                (photo_path, vendor_id, item_id),
+            )
+
+    def clear_photo_path(self, *, vendor_id: int, item_id: int) -> None:
+        with get_connection() as conn:
+            conn.execute(
+                """
+                UPDATE menu_items
+                SET photo_path = NULL, updated_at = NOW()
+                WHERE vendor_id = %s AND id = %s
+                """,
+                (vendor_id, item_id),
+            )
+
+    def has_items_in_category(self, *, vendor_id: int, category_id: int) -> bool:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT 1
+                FROM menu_items
+                WHERE vendor_id = %s AND category_id = %s
+                LIMIT 1
+                """,
+                (vendor_id, category_id),
+            ).fetchone()
+
+        return row is not None

--- a/backend/repositories/postgres_vendor_profile_repository.py
+++ b/backend/repositories/postgres_vendor_profile_repository.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from typing import Any
+
+from backend.db.connection import get_connection
+from backend.repositories.vendor_profile_repository import VendorRecord
+from backend.schemas.vendor_self import Facility
+
+
+class PostgresVendorProfileRepository:
+    def seed(self, record: VendorRecord) -> None:
+        """Insert or update a vendor record.
+
+        This mirrors the in-memory repository helper and is useful for local
+        setup scripts or integration tests.
+        """
+        with get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO vendors (
+                    id, name, status, address, business_hours,
+                    contact_phone, contact_email
+                )
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (id) DO UPDATE SET
+                    name = EXCLUDED.name,
+                    status = EXCLUDED.status,
+                    address = EXCLUDED.address,
+                    business_hours = EXCLUDED.business_hours,
+                    contact_phone = EXCLUDED.contact_phone,
+                    contact_email = EXCLUDED.contact_email,
+                    updated_at = NOW()
+                """,
+                (
+                    record.id,
+                    record.name,
+                    record.status,
+                    record.address,
+                    record.business_hours,
+                    record.contact_phone,
+                    record.contact_email,
+                ),
+            )
+
+    def assign_facility(self, vendor_id: int, *, facility_id: int, code: str, name: str) -> None:
+        with get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO facilities (id, code, name)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (id) DO UPDATE SET
+                    code = EXCLUDED.code,
+                    name = EXCLUDED.name
+                """,
+                (facility_id, code, name),
+            )
+            conn.execute(
+                """
+                INSERT INTO vendor_facilities (vendor_id, facility_id)
+                VALUES (%s, %s)
+                ON CONFLICT DO NOTHING
+                """,
+                (vendor_id, facility_id),
+            )
+
+    def get(self, vendor_id: int) -> VendorRecord | None:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT
+                    id, name, status, address, business_hours,
+                    contact_phone, contact_email
+                FROM vendors
+                WHERE id = %s
+                """,
+                (vendor_id,),
+            ).fetchone()
+
+        if row is None:
+            return None
+        return VendorRecord(**dict(row))
+
+    def update(self, vendor_id: int, fields: dict[str, Any]) -> VendorRecord | None:
+        allowed_columns = {
+            "name": "name",
+            "address": "address",
+            "business_hours": "business_hours",
+            "contact_phone": "contact_phone",
+            "contact_email": "contact_email",
+        }
+        updates = [
+            (allowed_columns[key], value)
+            for key, value in fields.items()
+            if key in allowed_columns
+        ]
+        if not updates:
+            return self.get(vendor_id)
+
+        assignments = [f"{column} = %s" for column, _ in updates]
+        values = [value for _, value in updates]
+        values.append(vendor_id)
+
+        with get_connection() as conn:
+            row = conn.execute(
+                f"""
+                UPDATE vendors
+                SET {", ".join(assignments)}, updated_at = NOW()
+                WHERE id = %s
+                RETURNING
+                    id, name, status, address, business_hours,
+                    contact_phone, contact_email
+                """,
+                values,
+            ).fetchone()
+
+        if row is None:
+            return None
+        return VendorRecord(**dict(row))
+
+    def list_facilities(self, vendor_id: int) -> list[Facility]:
+        with get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT f.id, f.code, f.name
+                FROM facilities AS f
+                JOIN vendor_facilities AS vf ON vf.facility_id = f.id
+                WHERE vf.vendor_id = %s
+                ORDER BY f.code, f.id
+                """,
+                (vendor_id,),
+            ).fetchall()
+
+        return [Facility(**dict(row)) for row in rows]

--- a/backend/routes/vendor_categories.py
+++ b/backend/routes/vendor_categories.py
@@ -6,9 +6,12 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, status
 from fastapi.responses import Response
 
+from backend.core.config import settings
 from backend.core.vendor_identity import require_approved_vendor
 from backend.repositories.menu_category_repository import MenuCategoryRepository
 from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.postgres_menu_category_repository import PostgresMenuCategoryRepository
+from backend.repositories.postgres_menu_item_repository import PostgresMenuItemRepository
 from backend.schemas.vendor_self import Category, CategoryCreate, CategoryUpdate
 from backend.services.vendor_category_service import VendorCategoryService
 
@@ -19,15 +22,21 @@ router = APIRouter(prefix="/vendor/me/categories", tags=["vendor-self"])
 # 測試以 app.dependency_overrides 注入新實例。
 _category_repo = MenuCategoryRepository()
 _item_repo_for_category = MenuItemRepository()
+_postgres_category_repo = PostgresMenuCategoryRepository()
+_postgres_item_repo = PostgresMenuItemRepository()
 
 
 def get_menu_category_repository() -> MenuCategoryRepository:
+    if settings.database_url:
+        return _postgres_category_repo
     return _category_repo
 
 
 def get_menu_item_repository_for_category() -> MenuItemRepository:
     """名字加 _for_category 是為了讓 routes/vendor_menu.py 也能擁有自己的 override key
     (兩條 route 共用同一份 repo，但測試可分別注入)。"""
+    if settings.database_url:
+        return _postgres_item_repo
     return _item_repo_for_category
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   frontend:
     build:
@@ -32,6 +33,11 @@ services:
       - .env.example
       - path: .env
         required: false
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./backend/db/migrations/001_initial_schema.sql:/docker-entrypoint-initdb.d/001_initial_schema.sql:ro

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest==8.3.4
 httpx==0.28.1
 Pillow==11.0.0
 python-multipart==0.0.27
+psycopg[binary]==3.2.9


### PR DESCRIPTION
## Summary
- Add PostgreSQL connection helper and startup migration runner
- Track applied SQL migrations in `schema_migrations`
- Add vendor profile/menu schema migration
- Add PostgreSQL-backed repositories for vendor profile, menu categories, and menu items
- Make Docker Compose wait for PostgreSQL health before starting backend
- Document database migration behavior in README

## Why
This makes the database layer reproducible for every teammate. After pulling this branch and running Docker Compose, each developer can build the same local PostgreSQL schema through committed migrations instead of manually editing their local DB.

## Verification
- `python -m pytest backend/tests` -> 68 passed, 4 skipped
- `python -m compileall backend`
- `docker compose config`

## Notes
- This PR does not push or depend on shared database data.
- Each teammate still gets their own local PostgreSQL container and `postgres_data` Docker volume.
- Existing in-memory repositories are preserved for unit tests and local overrides.
