### PR TITLE
feat(gateway): route /committee/* to backend

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -30,6 +30,10 @@
 		reverse_proxy backend:8000
 	}
 
+	handle /committee/* {
+		reverse_proxy backend:8000
+	}
+
 	handle_path /uploads/* {
 		root * /srv/uploads
 		file_server


### PR DESCRIPTION
## Summary
- Add `handle /committee/*` block to the shared `(routes)` snippet in `infra/caddy/Caddyfile`, alongside `/vendor/*` and `/employee/*`.
- Without this, requests to the committee endpoints introduced in PR #15 fall through to the frontend nginx through the HTTPS gateway and return 404. Pytest does not catch the gap because it uses `TestClient(app)` and bypasses Caddy.

## Audit
Checked all `APIRouter(prefix=...)` declarations on `main`, PR #14 (`feature/database-persistence`), and PR #15 (`feature/committee-review`). `/committee/*` is the only prefix missing from the gateway. PR #14 reuses existing `/vendor/me/*` prefixes and needs no gateway change.

## Verification
Local stack via `docker compose up -d --build gateway backend` on this branch:

- `GET https://localhost/committee/reviews/pending` → `server: uvicorn`, JSON body. Reaches FastAPI (404 because the GET handler lives in PR #15 only; routing itself works).
- `POST https://localhost/committee/reviews/1/decision` (existing stub on `main`) → `202`, `server: uvicorn`, `via: 1.1 Caddy`.
- Negative control `GET https://localhost/not-a-real-path` → `server: nginx/1.27.5` (correctly falls through to frontend).

After PR #15 merges, the GET endpoint will return 200 through the gateway with no further changes.

## Test plan
- [x] CI green (`pytest backend/tests`).
- [x] Reviewer pulls branch, runs `docker compose up --build`, hits `https://localhost/committee/reviews/1/decision` with `x-user-role: committee_reviewer` and confirms 202 from uvicorn.

Closes #16