### PR TITLE
feat(employee): add vendor list query with optional status filter

### DIFF
--- a/backend/repositories/postgres_vendor_profile_repository.py
+++ b/backend/repositories/postgres_vendor_profile_repository.py
@@ -79,6 +79,24 @@ class PostgresVendorProfileRepository:
         if row is None:
             return None
         return VendorRecord(**dict(row))
+    
+    def list(self, *, status: str | None = None) -> list[VendorRecord]:
+        query = """
+            SELECT
+                id, name, status, address, business_hours,
+                contact_phone, contact_email
+            FROM vendors
+        """
+        params: list[str] = []
+        if status is not None:
+            query += " WHERE status = %s"
+            params.append(status)
+        query += " ORDER BY id"
+
+        with get_connection() as conn:
+            rows = conn.execute(query, params).fetchall()
+
+        return [VendorRecord(**dict(row)) for row in rows]
 
     def update(self, vendor_id: int, fields: dict[str, Any]) -> VendorRecord | None:
         allowed_columns = {


### PR DESCRIPTION
## Summary

  - Add `list()` method to `PostgresVendorProfileRepository` to query all vendors with optional status
  filtering
  - Required by `EmployeeOrderingService.list_vendors()` which filters by `status="approved"` to serve
  the employee menu browse feature

## Changes

  `backend/repositories/postgres_vendor_profile_repository.py`
  - New `list(*, status)` method: builds a parameterised query, applies `WHERE status = %s` only when
  status is provided, returns `list[VendorRecord]` ordered by id

## Test plan

  - [x] `pytest backend/tests -q` passes
  - [x] `GET /employee/vendors` returns only approved vendors when called via the employee ordering route 