### PR TITLE
fix(frontend): make build subpath-aware so /meal-staging/ renders

### DIFF
--- a/Jenkinsfile.preview
+++ b/Jenkinsfile.preview
@@ -74,6 +74,7 @@ pipeline {
 
             BRANCH_RAW="$BRANCH_RAW" \
             ROOT_PATH="$ROOT_PATH" \
+            BASE_PATH="${ROOT_PATH}/" \
             SLUG="$SLUG" \
             GATEWAY_CONTAINER_NAME="mealorder-${SLUG}-gateway" \
               docker compose \

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -38,12 +38,14 @@ pipeline {
           docker network inspect preview-net >/dev/null 2>&1 \
             || docker network create preview-net
           ROOT_PATH="$ROOT_PATH" \
+          BASE_PATH="${ROOT_PATH}/" \
           GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
             docker compose -p "$COMPOSE_PROJECT_NAME" \
             -f docker-compose.yml \
             -f infra/deploy/docker-compose.prod.yml \
             build
           ROOT_PATH="$ROOT_PATH" \
+          BASE_PATH="${ROOT_PATH}/" \
           GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
             docker compose -p "$COMPOSE_PROJECT_NAME" \
             -f docker-compose.yml \

--- a/Jenkinsfile.staging
+++ b/Jenkinsfile.staging
@@ -32,6 +32,7 @@ pipeline {
             -f infra/deploy/docker-compose.staging.yml \
             down -v --remove-orphans || true
           ROOT_PATH="$ROOT_PATH" \
+          BASE_PATH="${ROOT_PATH}/" \
           GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
             docker compose -p "$COMPOSE_PROJECT_NAME" \
             -f docker-compose.yml \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
   frontend:
     build:
       context: ./frontend
+      args:
+        BASE_PATH: ${BASE_PATH:-/}
     ports:
       - "3000:80"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
+ARG BASE_PATH=/
+ENV BASE_PATH=$BASE_PATH
+
 COPY package.json ./
 RUN npm install
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,5 +1,11 @@
 import { readStoredSession } from "../auth/authStorage";
 
+function withBase(path) {
+  if (/^https?:\/\//.test(path)) return path;
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  return base + (path.startsWith("/") ? path : `/${path}`);
+}
+
 export async function apiFetch(path, options = {}) {
   const session = readStoredSession();
   const headers = { ...options.headers };
@@ -14,7 +20,7 @@ export async function apiFetch(path, options = {}) {
     }
   }
 
-  const res = await fetch(path, { ...options, headers });
+  const res = await fetch(withBase(path), { ...options, headers });
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -9,7 +9,7 @@ import "./styles/global.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <AuthProvider>
         <CartProvider>
           <App />

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -12,5 +12,6 @@ export function quotaLabel(dailyQuota) {
 
 export function photoUrl(photoPath) {
   if (!photoPath) return null;
-  return `/uploads/${photoPath}`;
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  return `${base}/uploads/${photoPath}`;
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  base: process.env.BASE_PATH || "/",
   plugins: [react()],
   server: {
     host: "0.0.0.0",


### PR DESCRIPTION
## Summary

- Vite `base`, React Router `basename`, `apiFetch`, and `photoUrl` now all derive from a build-time `BASE_PATH`.
- `docker-compose.yml` forwards `BASE_PATH` to the frontend image as a build arg (defaults to `/` for local dev).
- `Jenkinsfile.staging` / `Jenkinsfile.prod` / `Jenkinsfile.preview` export `BASE_PATH=\${ROOT_PATH}/` so staging, prod, and per-PR preview stacks each build with the right subpath.

## Why

After #19 merged, `https://nol.cs.nycu.edu.tw/meal-staging/` rendered blank. The shared preview router (#9) strips the `/meal-staging/` prefix before forwarding, so the frontend container sees `/`. With Vite's default `base: \"/\"`, `dist/index.html` referenced `/assets/...`, which the browser then requested at `https://nol.cs.nycu.edu.tw/assets/...` — no router rule, fell through to the catch-all `respond \"preview-router OK\" 200`. Two follow-on bugs would have surfaced once assets loaded: `BrowserRouter` had no `basename` (would render `*` NotFound at `/meal-staging/`), and `apiFetch` used absolute paths (would bypass the prefix on API calls).

See #20 for the full root-cause writeup.

## Test plan

- [x] Local: `docker compose up --build` — `https://localhost` still works (BASE_PATH default `/`).
- [x] Local: confirm Vite dev (`npm run dev` in `frontend/`) still loads at `http://localhost:3000` with proxied API calls.
- [x] Staging: after merge, Jenkins staging pipeline rebuilds the frontend with `BASE_PATH=/meal-staging/`; `https://nol.cs.nycu.edu.tw/meal-staging/` should render the login page and assets should 200.
- [x] Staging: login as employee → menu list → vendor menu navigation works and API calls hit `/meal-staging/employee/*`.
- [x] Preview: open a draft PR to confirm `/meal-preview/<slug>/` still works with the per-PR `ROOT_PATH`.

## Related

- Closes #20
- Follow-up to #19 (React+Vite frontend), #9 (preview router), #6 (Jenkins pipelines / ROOT_PATH)