### PR TITLE
feat(frontend): add employee cart and order flow

### DIFF
--- a/Jenkinsfile.preview
+++ b/Jenkinsfile.preview
@@ -74,6 +74,7 @@ pipeline {
 
             BRANCH_RAW="$BRANCH_RAW" \
             ROOT_PATH="$ROOT_PATH" \
+            BASE_PATH="${ROOT_PATH}/" \
             SLUG="$SLUG" \
             GATEWAY_CONTAINER_NAME="mealorder-${SLUG}-gateway" \
               docker compose \

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -38,12 +38,14 @@ pipeline {
           docker network inspect preview-net >/dev/null 2>&1 \
             || docker network create preview-net
           ROOT_PATH="$ROOT_PATH" \
+          BASE_PATH="${ROOT_PATH}/" \
           GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
             docker compose -p "$COMPOSE_PROJECT_NAME" \
             -f docker-compose.yml \
             -f infra/deploy/docker-compose.prod.yml \
             build
           ROOT_PATH="$ROOT_PATH" \
+          BASE_PATH="${ROOT_PATH}/" \
           GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
             docker compose -p "$COMPOSE_PROJECT_NAME" \
             -f docker-compose.yml \

--- a/Jenkinsfile.staging
+++ b/Jenkinsfile.staging
@@ -32,6 +32,7 @@ pipeline {
             -f infra/deploy/docker-compose.staging.yml \
             down -v --remove-orphans || true
           ROOT_PATH="$ROOT_PATH" \
+          BASE_PATH="${ROOT_PATH}/" \
           GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
             docker compose -p "$COMPOSE_PROJECT_NAME" \
             -f docker-compose.yml \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
   frontend:
     build:
       context: ./frontend
+      args:
+        BASE_PATH: ${BASE_PATH:-/}
     ports:
       - "3000:80"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
+ARG BASE_PATH=/
+ENV BASE_PATH=$BASE_PATH
+
 COPY package.json ./
 RUN npm install
 

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,5 +1,11 @@
 import { readStoredSession } from "../auth/authStorage";
 
+function withBase(path) {
+  if (/^https?:\/\//.test(path)) return path;
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  return base + (path.startsWith("/") ? path : `/${path}`);
+}
+
 export async function apiFetch(path, options = {}) {
   const session = readStoredSession();
   const headers = { ...options.headers };
@@ -14,7 +20,7 @@ export async function apiFetch(path, options = {}) {
     }
   }
 
-  const res = await fetch(path, { ...options, headers });
+  const res = await fetch(withBase(path), { ...options, headers });
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));

--- a/frontend/src/api/employee.js
+++ b/frontend/src/api/employee.js
@@ -20,6 +20,18 @@ export function getVendor(vendorId) {
   );
 }
 
+export function submitSelection(vendorId, { itemId, quantity }) {
+  return apiFetch(`/employee/vendors/${vendorId}/selections`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ item_id: itemId, quantity }),
+  });
+}
+
+export function getMySelections() {
+  return withMockFallback(() => apiFetch("/employee/me/selections"), []);
+}
+
 export function getVendorMenu(vendorId, { available } = {}) {
   const params = new URLSearchParams();
   if (available != null) params.set("available", String(available));

--- a/frontend/src/auth/mockUsers.js
+++ b/frontend/src/auth/mockUsers.js
@@ -1,6 +1,7 @@
 export const mockUsers = [
   {
     id: "employee-demo",
+    numericId: 1,
     role: "employee",
     name: "Ting Lin",
     title: "Employee",

--- a/frontend/src/hooks/useMySelections.js
+++ b/frontend/src/hooks/useMySelections.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import { getMySelections } from "../api/employee";
+
+export function useMySelections() {
+  const [selections, setSelections] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getMySelections()
+      .then((data) => { if (!cancelled) setSelections(data); })
+      .catch((err) => { if (!cancelled) setError(err); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return { selections, loading, error };
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -9,7 +9,7 @@ import "./styles/global.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <AuthProvider>
         <CartProvider>
           <App />

--- a/frontend/src/pages/employee/CartPage.jsx
+++ b/frontend/src/pages/employee/CartPage.jsx
@@ -1,0 +1,215 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { submitSelection } from "../../api/employee";
+import { useCart } from "../../cart/CartContext";
+import { formatPrice } from "../../utils/format";
+
+function errorMessage(item, err) {
+  if (err.code === "item_unavailable") return `${item.item.name} 已停止供應`;
+  if (err.code === "quantity_exceeds_daily_quota") return `${item.item.name} 數量超過今日配額`;
+  return `${item.item.name} 送出失敗，請稍後再試`;
+}
+
+export default function CartPage() {
+  const { items, updateQuantity, removeItem, clearCart, totalCount } = useCart();
+  const navigate = useNavigate();
+
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState(null);
+
+  const totalCents = items.reduce(
+    (sum, i) => sum + i.item.price_cents * i.quantity,
+    0,
+  );
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    setResult(null);
+
+    const errors = [];
+    for (const cartItem of items) {
+      try {
+        await submitSelection(cartItem.vendorId, {
+          itemId: cartItem.item.id,
+          quantity: cartItem.quantity,
+        });
+      } catch (err) {
+        errors.push(errorMessage(cartItem, err));
+      }
+    }
+
+    setSubmitting(false);
+
+    if (errors.length === 0) {
+      clearCart();
+      setResult({ ok: true });
+    } else {
+      setResult({ ok: false, errors });
+    }
+  }
+
+  if (result?.ok) {
+    return (
+      <div>
+        <div className="page-header">
+          <p className="eyebrow">Employee · Order</p>
+          <h2>訂單已送出</h2>
+        </div>
+        <div className="panel" style={{ marginTop: 24 }}>
+          <p className="panel-copy">您的餐點已成功送出，請等待廠商確認。</p>
+          <div style={{ display: "flex", gap: 12, marginTop: 20 }}>
+            <button
+              className="primary-button"
+              type="button"
+              onClick={() => navigate("/employee/orders")}
+            >
+              查看訂單
+            </button>
+            <button
+              className="ghost-button"
+              type="button"
+              onClick={() => navigate("/employee/menu")}
+            >
+              繼續點餐
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (totalCount === 0) {
+    return (
+      <div>
+        <div className="page-header">
+          <p className="eyebrow">Employee · Cart</p>
+          <h2>購物車</h2>
+        </div>
+        <p className="empty-state" style={{ marginTop: 40 }}>購物車是空的</p>
+        <button
+          className="ghost-button"
+          type="button"
+          style={{ marginTop: 16 }}
+          onClick={() => navigate("/employee/menu")}
+        >
+          ← 去瀏覽菜單
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="page-header">
+        <p className="eyebrow">Employee · Cart</p>
+        <h2>購物車</h2>
+      </div>
+
+      {result?.errors && (
+        <div className="error-state" style={{ marginBottom: 20 }}>
+          <strong>部分品項送出失敗：</strong>
+          <ul style={{ margin: "8px 0 0 16px" }}>
+            {result.errors.map((msg, i) => <li key={i}>{msg}</li>)}
+          </ul>
+        </div>
+      )}
+
+      <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
+        {items.map((cartItem, idx) => (
+          <div
+            key={cartItem.item.id}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 16,
+              padding: "16px 20px",
+              borderBottom: idx < items.length - 1 ? "1px solid var(--line)" : "none",
+            }}
+          >
+            <div style={{ flex: 1 }}>
+              <p style={{ fontWeight: 600, margin: 0 }}>{cartItem.item.name}</p>
+              <p style={{ color: "var(--muted)", fontSize: 13, margin: "2px 0 0" }}>
+                {formatPrice(cartItem.item.price_cents)} / 份
+              </p>
+            </div>
+
+            <div className="quantity-stepper">
+              <button
+                className="stepper-btn"
+                type="button"
+                aria-label="減少數量"
+                onClick={() => updateQuantity(cartItem.item.id, cartItem.quantity - 1)}
+                disabled={cartItem.quantity <= 1}
+              >
+                −
+              </button>
+              <span className="stepper-value">{cartItem.quantity}</span>
+              <button
+                className="stepper-btn"
+                type="button"
+                aria-label="增加數量"
+                onClick={() => updateQuantity(cartItem.item.id, cartItem.quantity + 1)}
+              >
+                ＋
+              </button>
+            </div>
+
+            <p style={{ width: 80, textAlign: "right", fontWeight: 600, margin: 0 }}>
+              {formatPrice(cartItem.item.price_cents * cartItem.quantity)}
+            </p>
+
+            <button
+              type="button"
+              aria-label={`移除 ${cartItem.item.name}`}
+              onClick={() => removeItem(cartItem.item.id)}
+              style={{
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                color: "var(--muted)",
+                fontSize: 18,
+                padding: "4px 8px",
+              }}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginTop: 20,
+          flexWrap: "wrap",
+          gap: 12,
+        }}
+      >
+        <div>
+          <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>合計</p>
+          <p style={{ margin: 0, fontSize: 22, fontWeight: 700 }}>{formatPrice(totalCents)}</p>
+        </div>
+        <div style={{ display: "flex", gap: 12 }}>
+          <button
+            className="ghost-button"
+            type="button"
+            onClick={clearCart}
+            disabled={submitting}
+          >
+            清空購物車
+          </button>
+          <button
+            className="primary-button"
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting}
+          >
+            {submitting ? "送出中..." : "送出訂單"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/employee/OrdersPage.jsx
+++ b/frontend/src/pages/employee/OrdersPage.jsx
@@ -1,0 +1,65 @@
+import { useMySelections } from "../../hooks/useMySelections";
+import { formatPrice } from "../../utils/format";
+
+function formatDate(isoString) {
+  const d = new Date(isoString);
+  return d.toLocaleString("zh-TW", {
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function OrdersPage() {
+  const { selections, loading, error } = useMySelections();
+
+  return (
+    <div>
+      <div className="page-header">
+        <p className="eyebrow">Employee · Orders</p>
+        <h2>我的訂單</h2>
+      </div>
+
+      {loading && <p className="loading-state">載入訂單中...</p>}
+
+      {error && (
+        <p className="error-state">無法載入訂單，請稍後再試。</p>
+      )}
+
+      {!loading && !error && selections.length === 0 && (
+        <p className="empty-state">尚無訂單紀錄。</p>
+      )}
+
+      {!loading && !error && selections.length > 0 && (
+        <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
+          {selections.map((sel, idx) => (
+            <div
+              key={sel.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 16,
+                padding: "16px 20px",
+                borderBottom: idx < selections.length - 1 ? "1px solid var(--line)" : "none",
+              }}
+            >
+              <div style={{ flex: 1 }}>
+                <p style={{ fontWeight: 600, margin: 0 }}>{sel.item_name}</p>
+                <p style={{ color: "var(--muted)", fontSize: 13, margin: "2px 0 0" }}>
+                  {formatDate(sel.created_at)}
+                </p>
+              </div>
+              <p style={{ color: "var(--muted)", fontSize: 14, margin: 0 }}>
+                × {sel.quantity}
+              </p>
+              <p style={{ width: 90, textAlign: "right", fontWeight: 600, margin: 0 }}>
+                {formatPrice(sel.total_price_cents)}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -3,8 +3,10 @@ import { useAuth } from "../auth/AuthContext";
 import AppShell from "../layout/AppShell";
 import { roleHomePath } from "../layout/navigation";
 import AdminHomePage from "../pages/admin/AdminHomePage";
+import CartPage from "../pages/employee/CartPage";
 import EmployeeHomePage from "../pages/employee/EmployeeHomePage";
 import MenuListPage from "../pages/employee/MenuListPage";
+import OrdersPage from "../pages/employee/OrdersPage";
 import VendorMenuPage from "../pages/employee/VendorMenuPage";
 import ForbiddenPage from "../pages/ForbiddenPage";
 import LoginPage from "../pages/LoginPage";
@@ -46,15 +48,8 @@ export function AppRouter() {
             <Route element={<EmployeeHomePage />} path="/employee" />
             <Route element={<MenuListPage />} path="/employee/menu" />
             <Route element={<VendorMenuPage />} path="/employee/menu/:vendorId" />
-            <Route
-              element={
-                <PlaceholderPage
-                  description="Active order tracking belongs to the employee order flow branch."
-                  title="Employee Orders"
-                />
-              }
-              path="/employee/orders"
-            />
+            <Route element={<CartPage />} path="/employee/cart" />
+            <Route element={<OrdersPage />} path="/employee/orders" />
           </Route>
 
           <Route element={<RoleRoute allowedRoles={["vendor"]} />}>

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -12,5 +12,6 @@ export function quotaLabel(dailyQuota) {
 
 export function photoUrl(photoPath) {
   if (!photoPath) return null;
-  return `/uploads/${photoPath}`;
+  const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+  return `${base}/uploads/${photoPath}`;
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  base: process.env.BASE_PATH || "/",
   plugins: [react()],
   server: {
     host: "0.0.0.0",


### PR DESCRIPTION
## Summary

  - **CartPage** (`/employee/cart`): display cart items with quantity stepper,
    remove and clear actions; inline success/error result after submission
  - **OrdersPage** (`/employee/orders`): list submitted selections from
    `GET /employee/me/selections`, falls back to empty list when backend is down
  - Add `useMySelections` hook, `submitSelection` and `getMySelections` API functions
  - Fix employee mock user missing `numericId` so `x-user-id` header is correctly sent
  - Cherry-pick `fix(frontend): make build subpath-aware via BASE_PATH` from main

  ## Test plan

  - [x] Login as Employee → add items to cart → Topbar badge shows correct count
  - [x] Click cart icon → navigate to `/employee/cart`, items listed correctly
  - [x] Adjust quantity, remove single item, clear cart
  - [x] Submit order with backend down → error banner shown
  - [x] Submit order with backend running → success banner, cart cleared, redirect to `/employee/orders`
  - [x] `/employee/orders` displays submitted selections
  - [x] Login as Vendor or Admin → no cart icon in Topbar