### PR TITLE
feat(frontend): vendor menu management

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -30,5 +30,6 @@ export async function apiFetch(path, options = {}) {
     throw err;
   }
 
+  if (res.status === 204) return null;
   return res.json();
 }

--- a/frontend/src/api/vendor.js
+++ b/frontend/src/api/vendor.js
@@ -1,0 +1,17 @@
+import { apiFetch } from "./client";
+import { MOCK_MENU } from "./mockData";
+
+function withMockFallback(apiCall, mockResult) {
+  return apiCall().catch(() => mockResult);
+}
+
+export function getMyMenu() {
+  return withMockFallback(
+    () => apiFetch("/vendor/me/menu"),
+    (MOCK_MENU[1] ?? []).map((item) => ({
+      ...item,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })),
+  );
+}

--- a/frontend/src/auth/mockUsers.js
+++ b/frontend/src/auth/mockUsers.js
@@ -8,7 +8,7 @@ export const mockUsers = [
   },
   {
     id: "vendor-demo",
-    role: "vendor",
+    role: "vendor_manager",
     name: "Sunny Kitchen",
     title: "Vendor",
     email: "vendor@corpmeal.local",

--- a/frontend/src/layout/navigation.js
+++ b/frontend/src/layout/navigation.js
@@ -1,6 +1,6 @@
 export const roleHomePath = {
   employee: "/employee",
-  vendor: "/vendor",
+  vendor_manager: "/vendor",
   admin: "/admin",
 };
 
@@ -11,7 +11,7 @@ export const navigationByRole = {
     { label: "Current Orders", to: "/employee/orders" },
     { label: "Notifications", to: "/notifications" },
   ],
-  vendor: [
+  vendor_manager: [
     { label: "Dashboard", to: "/vendor" },
     { label: "Menu Management", to: "/vendor/menu" },
     { label: "Orders", to: "/vendor/orders" },

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { AuthProvider } from "./auth/AuthContext";
 import { CartProvider } from "./cart/CartContext";
+import { VendorMenuProvider } from "./vendor/VendorMenuContext";
 import "./styles/theme.css";
 import "./styles/global.css";
 
@@ -12,7 +13,9 @@ ReactDOM.createRoot(document.getElementById("root")).render(
     <BrowserRouter basename={import.meta.env.BASE_URL}>
       <AuthProvider>
         <CartProvider>
-          <App />
+          <VendorMenuProvider>
+            <App />
+          </VendorMenuProvider>
         </CartProvider>
       </AuthProvider>
     </BrowserRouter>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -10,7 +10,7 @@ const roleOptions = [
     detail: "Browse menus, place orders, track delivery status.",
   },
   {
-    role: "vendor",
+    role: "vendor_manager",
     label: "Vendor",
     detail: "Maintain menus and manage operational orders.",
   },

--- a/frontend/src/pages/vendor/VendorMenuFormPage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuFormPage.jsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useVendorMenu } from "../../vendor/VendorMenuContext";
+
+const EMPTY_FORM = {
+  name: "",
+  description: "",
+  price_cents: "",
+  available: true,
+  daily_quota: "",
+};
+
+function formToData(form) {
+  return {
+    name: form.name.trim(),
+    description: form.description.trim() || null,
+    price_cents: Math.round(parseFloat(form.price_cents) * 100),
+    available: form.available,
+    daily_quota: form.daily_quota === "" ? null : Number(form.daily_quota),
+  };
+}
+
+export default function VendorMenuFormPage() {
+  const { itemId } = useParams();
+  const navigate = useNavigate();
+  const { getItem, addItem, updateItem } = useVendorMenu();
+  const isEdit = Boolean(itemId);
+
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!isEdit) return;
+    const item = getItem(Number(itemId));
+    if (!item) { navigate("/vendor/menu"); return; }
+    setForm({
+      name: item.name,
+      description: item.description ?? "",
+      price_cents: (item.price_cents / 100).toString(),
+      available: item.available,
+      daily_quota: item.daily_quota === null || item.daily_quota === undefined ? "" : String(item.daily_quota),
+    });
+  }, [isEdit, itemId, navigate, getItem]);
+
+  function handleChange(e) {
+    const { name, value, type, checked } = e.target;
+    setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+
+    if (!form.name.trim()) { setError("請填寫餐點名稱。"); return; }
+    if (!form.price_cents || isNaN(parseFloat(form.price_cents))) { setError("請填寫有效價格。"); return; }
+
+    const data = formToData(form);
+    if (isEdit) {
+      updateItem(Number(itemId), data);
+    } else {
+      addItem(data);
+    }
+    navigate("/vendor/menu");
+  }
+
+  return (
+    <div>
+      <div className="page-header">
+        <p className="eyebrow">Vendor · Menu</p>
+        <h2>{isEdit ? "編輯餐點" : "新增餐點"}</h2>
+      </div>
+
+      {error && <p className="error-state" style={{ marginBottom: 16 }}>{error}</p>}
+
+      <form className="panel" onSubmit={handleSubmit} style={{ maxWidth: 560 }}>
+        <div style={{ display: "grid", gap: 20 }}>
+
+          <label style={{ display: "grid", gap: 6 }}>
+            <span style={{ fontWeight: 600 }}>餐點名稱 *</span>
+            <input
+              className="form-input"
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              required
+              placeholder="例：雞腿飯"
+            />
+          </label>
+
+          <label style={{ display: "grid", gap: 6 }}>
+            <span style={{ fontWeight: 600 }}>描述</span>
+            <textarea
+              className="form-input"
+              name="description"
+              value={form.description}
+              onChange={handleChange}
+              rows={3}
+              placeholder="食材、口味、配菜說明..."
+              style={{ resize: "vertical" }}
+            />
+          </label>
+
+          <label style={{ display: "grid", gap: 6 }}>
+            <span style={{ fontWeight: 600 }}>價格（元）*</span>
+            <input
+              className="form-input"
+              name="price_cents"
+              type="number"
+              min="0"
+              step="0.5"
+              value={form.price_cents}
+              onChange={handleChange}
+              required
+              placeholder="例：90"
+            />
+          </label>
+
+          <label style={{ display: "grid", gap: 6 }}>
+            <span style={{ fontWeight: 600 }}>今日配額</span>
+            <input
+              className="form-input"
+              name="daily_quota"
+              type="number"
+              min="0"
+              value={form.daily_quota}
+              onChange={handleChange}
+              placeholder="留空表示不限制"
+            />
+            <span style={{ color: "var(--muted)", fontSize: 13 }}>
+              填 0 表示今日售完；留空表示無限制
+            </span>
+          </label>
+
+          <label style={{ display: "flex", alignItems: "center", gap: 10, cursor: "pointer" }}>
+            <input
+              type="checkbox"
+              name="available"
+              checked={form.available}
+              onChange={handleChange}
+              style={{ width: 18, height: 18 }}
+            />
+            <span style={{ fontWeight: 600 }}>供應中</span>
+          </label>
+
+        </div>
+
+        <div style={{ display: "flex", gap: 12, marginTop: 28 }}>
+          <button className="primary-button" type="submit">
+            {isEdit ? "儲存變更" : "建立餐點"}
+          </button>
+          <button
+            className="ghost-button"
+            type="button"
+            onClick={() => navigate("/vendor/menu")}
+          >
+            取消
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/vendor/VendorMenuListPage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuListPage.jsx
@@ -1,0 +1,97 @@
+import { useNavigate } from "react-router-dom";
+import { useVendorMenu } from "../../vendor/VendorMenuContext";
+import { formatPrice } from "../../utils/format";
+
+export default function VendorMenuListPage() {
+  const navigate = useNavigate();
+  const { items, loading, error, removeItem } = useVendorMenu();
+
+  function handleDelete(item) {
+    if (!window.confirm(`確定要刪除「${item.name}」嗎？`)) return;
+    removeItem(item.id);
+  }
+
+  return (
+    <div>
+      <div className="page-header" style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between" }}>
+        <div>
+          <p className="eyebrow">Vendor · Menu</p>
+          <h2>菜單管理</h2>
+        </div>
+        <button
+          className="primary-button"
+          type="button"
+          onClick={() => navigate("/vendor/menu/new")}
+        >
+          + 新增餐點
+        </button>
+      </div>
+
+      {loading && <p className="loading-state">載入菜單中...</p>}
+
+      {error && <p className="error-state">無法載入菜單，請稍後再試。</p>}
+
+      {!loading && !error && items.length === 0 && (
+        <p className="empty-state">尚未建立任何餐點，點擊「新增餐點」開始。</p>
+      )}
+
+      {!loading && !error && items.length > 0 && (
+        <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
+          {items.map((item, idx) => (
+            <div
+              key={item.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 16,
+                padding: "16px 20px",
+                borderBottom: idx < items.length - 1 ? "1px solid var(--line)" : "none",
+              }}
+            >
+              <div style={{ flex: 1 }}>
+                <p style={{ fontWeight: 600, margin: 0 }}>{item.name}</p>
+                {item.description && (
+                  <p style={{ color: "var(--muted)", fontSize: 13, margin: "2px 0 0" }}>
+                    {item.description}
+                  </p>
+                )}
+              </div>
+
+              <p style={{ width: 80, textAlign: "right", margin: 0 }}>
+                {formatPrice(item.price_cents)}
+              </p>
+
+              <span className={`badge ${item.available ? "badge-available" : "badge-unavailable"}`}>
+                {item.available ? "供應中" : "暫停供應"}
+              </span>
+
+              {item.daily_quota !== null && item.daily_quota !== undefined && (
+                <span className="badge badge-quota">
+                  {item.daily_quota === 0 ? "今日售完" : `配額 ${item.daily_quota}`}
+                </span>
+              )}
+
+              <div style={{ display: "flex", gap: 8 }}>
+                <button
+                  className="ghost-button"
+                  type="button"
+                  onClick={() => navigate(`/vendor/menu/${item.id}/edit`)}
+                >
+                  編輯
+                </button>
+                <button
+                  className="ghost-button"
+                  type="button"
+                  onClick={() => handleDelete(item)}
+                  style={{ color: "var(--error, #e53e3e)", borderColor: "var(--error, #e53e3e)" }}
+                >
+                  刪除
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -10,6 +10,8 @@ import ForbiddenPage from "../pages/ForbiddenPage";
 import LoginPage from "../pages/LoginPage";
 import NotFoundPage from "../pages/NotFoundPage";
 import VendorHomePage from "../pages/vendor/VendorHomePage";
+import VendorMenuFormPage from "../pages/vendor/VendorMenuFormPage";
+import VendorMenuListPage from "../pages/vendor/VendorMenuListPage";
 import ProtectedRoute from "./ProtectedRoute";
 import RoleRoute from "./RoleRoute";
 
@@ -57,17 +59,11 @@ export function AppRouter() {
             />
           </Route>
 
-          <Route element={<RoleRoute allowedRoles={["vendor"]} />}>
+          <Route element={<RoleRoute allowedRoles={["vendor_manager"]} />}>
             <Route element={<VendorHomePage />} path="/vendor" />
-            <Route
-              element={
-                <PlaceholderPage
-                  description="Menu CRUD and supply setup will be implemented in vendor menu management."
-                  title="Vendor Menu"
-                />
-              }
-              path="/vendor/menu"
-            />
+            <Route element={<VendorMenuListPage />} path="/vendor/menu" />
+            <Route element={<VendorMenuFormPage />} path="/vendor/menu/new" />
+            <Route element={<VendorMenuFormPage />} path="/vendor/menu/:itemId/edit" />
             <Route
               element={
                 <PlaceholderPage

--- a/frontend/src/vendor/VendorMenuContext.jsx
+++ b/frontend/src/vendor/VendorMenuContext.jsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { getMyMenu } from "../api/vendor";
+
+const VendorMenuContext = createContext(null);
+
+export function VendorMenuProvider({ children }) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getMyMenu()
+      .then((data) => { if (!cancelled) setItems(data); })
+      .catch((err) => { if (!cancelled) setError(err); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  function addItem(data) {
+    const newItem = {
+      ...data,
+      id: Date.now(),
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+    setItems((prev) => [...prev, newItem]);
+    return newItem;
+  }
+
+  function updateItem(id, data) {
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === id ? { ...item, ...data, updated_at: new Date().toISOString() } : item,
+      ),
+    );
+  }
+
+  function removeItem(id) {
+    setItems((prev) => prev.filter((item) => item.id !== id));
+  }
+
+  function getItem(id) {
+    return items.find((item) => item.id === id) ?? null;
+  }
+
+  return (
+    <VendorMenuContext.Provider value={{ items, loading, error, addItem, updateItem, removeItem, getItem }}>
+      {children}
+    </VendorMenuContext.Provider>
+  );
+}
+
+export function useVendorMenu() {
+  return useContext(VendorMenuContext);
+}


### PR DESCRIPTION
## Summary

- Fix vendor role key from `"vendor"` to `"vendor_manager"` across mockUsers, LoginPage, navigation, router, and RoleRoute guards
- Add `VendorMenuContext` with in-memory CRUD (add / update / remove / getItem); initial list loads from API with full mock fallback until JWT auth is in place
- Add `VendorMenuListPage` and `VendorMenuFormPage` for create, edit, and delete flows wired to `/vendor/menu`
- Fix `apiFetch` to handle `204 No Content` without throwing a JSON parse error

## Test plan

- [ ] Login as Vendor → redirected to `/vendor`
- [ ] Navigate to Menu Management → list loads (mock data if backend unavailable)
- [ ] Click Add Item → fill form → submit → item appears in list
- [ ] Click Edit on an item → form pre-filled → save → list updated
- [ ] Click Delete → confirm dialog → item removed
- [ ] Login as Employee or Admin → `/vendor/menu` blocked by RoleRoute