### PR TITLE
feat(frontend): vendor orders and revenue pages

### DIFF
--- a/frontend/src/api/mockData.js
+++ b/frontend/src/api/mockData.js
@@ -28,6 +28,57 @@ export const MOCK_VENDORS = [
   },
 ];
 
+export const MOCK_VENDOR_SELECTIONS = [
+  {
+    id: 1,
+    employee_id: 1,
+    employee_name: "Ting Lin",
+    vendor_id: 1,
+    item_id: 101,
+    item_name: "雞腿飯",
+    quantity: 2,
+    unit_price_cents: 9000,
+    total_price_cents: 18000,
+    created_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+  },
+  {
+    id: 2,
+    employee_id: 2,
+    employee_name: "Alex Chen",
+    vendor_id: 1,
+    item_id: 102,
+    item_name: "排骨飯",
+    quantity: 1,
+    unit_price_cents: 8500,
+    total_price_cents: 8500,
+    created_at: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
+  },
+  {
+    id: 3,
+    employee_id: 3,
+    employee_name: "Wei Zhang",
+    vendor_id: 1,
+    item_id: 101,
+    item_name: "雞腿飯",
+    quantity: 1,
+    unit_price_cents: 9000,
+    total_price_cents: 9000,
+    created_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: 4,
+    employee_id: 4,
+    employee_name: "Mei Wang",
+    vendor_id: 1,
+    item_id: 103,
+    item_name: "素食套餐",
+    quantity: 1,
+    unit_price_cents: 7500,
+    total_price_cents: 7500,
+    created_at: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
+  },
+];
+
 export const MOCK_MENU = {
   1: [
     {

--- a/frontend/src/pages/vendor/VendorOrdersPage.jsx
+++ b/frontend/src/pages/vendor/VendorOrdersPage.jsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { MOCK_VENDOR_SELECTIONS } from "../../api/mockData";
+import { formatPrice } from "../../utils/format";
+
+function formatTime(isoString) {
+  const d = new Date(isoString);
+  return d.toLocaleTimeString("zh-TW", { hour: "2-digit", minute: "2-digit", hour12: false });
+}
+
+function useMockSelections() {
+  const [selections, setSelections] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setSelections(MOCK_VENDOR_SELECTIONS);
+      setLoading(false);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return { selections, loading };
+}
+
+export default function VendorOrdersPage() {
+  const { selections, loading } = useMockSelections();
+
+  const totalRevenue = selections.reduce((sum, s) => sum + s.total_price_cents, 0);
+  const totalItems = selections.reduce((sum, s) => sum + s.quantity, 0);
+
+  return (
+    <div>
+      <div className="page-header">
+        <p className="eyebrow">Vendor · Orders</p>
+        <h2>今日訂單</h2>
+      </div>
+
+      {loading && <p className="loading-state">載入訂單中...</p>}
+
+      {!loading && selections.length === 0 && (
+        <p className="empty-state">今日尚未收到任何訂單。</p>
+      )}
+
+      {!loading && selections.length > 0 && (
+        <>
+          <div style={{ display: "flex", gap: 16, marginBottom: 24 }}>
+            <div className="panel" style={{ flex: 1, padding: "16px 20px" }}>
+              <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>訂單數</p>
+              <p style={{ margin: "4px 0 0", fontWeight: 700, fontSize: 22 }}>{selections.length}</p>
+            </div>
+            <div className="panel" style={{ flex: 1, padding: "16px 20px" }}>
+              <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>總份數</p>
+              <p style={{ margin: "4px 0 0", fontWeight: 700, fontSize: 22 }}>{totalItems} 份</p>
+            </div>
+            <div className="panel" style={{ flex: 1, padding: "16px 20px" }}>
+              <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>預估收入</p>
+              <p style={{ margin: "4px 0 0", fontWeight: 700, fontSize: 22 }}>{formatPrice(totalRevenue)}</p>
+            </div>
+          </div>
+
+          <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "140px 1fr 80px 100px 100px 80px",
+                padding: "10px 20px",
+                borderBottom: "1px solid var(--line)",
+                color: "var(--muted)",
+                fontSize: 12,
+                fontWeight: 600,
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+              }}
+            >
+              <span>來源</span>
+              <span>品項</span>
+              <span style={{ textAlign: "right" }}>數量</span>
+              <span style={{ textAlign: "right" }}>單價</span>
+              <span style={{ textAlign: "right" }}>小計</span>
+              <span style={{ textAlign: "right" }}>時間</span>
+            </div>
+
+            {selections.map((s, idx) => (
+              <div
+                key={s.id}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "140px 1fr 80px 100px 100px 80px",
+                  alignItems: "center",
+                  padding: "14px 20px",
+                  borderBottom: idx < selections.length - 1 ? "1px solid var(--line)" : "none",
+                }}
+              >
+                <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>
+                  {s.employee_name ?? `員工 #${s.employee_id}`}
+                </p>
+                <p style={{ margin: 0, fontWeight: 500 }}>{s.item_name}</p>
+                <p style={{ margin: 0, textAlign: "right" }}>× {s.quantity}</p>
+                <p style={{ margin: 0, textAlign: "right", color: "var(--muted)" }}>
+                  {formatPrice(s.unit_price_cents)}
+                </p>
+                <p style={{ margin: 0, textAlign: "right", fontWeight: 600 }}>
+                  {formatPrice(s.total_price_cents)}
+                </p>
+                <p style={{ margin: 0, textAlign: "right", color: "var(--muted)", fontSize: 13 }}>
+                  {formatTime(s.created_at)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/vendor/VendorRevenuePage.jsx
+++ b/frontend/src/pages/vendor/VendorRevenuePage.jsx
@@ -1,0 +1,151 @@
+import { MOCK_VENDOR_SELECTIONS } from "../../api/mockData";
+import { formatPrice } from "../../utils/format";
+
+const MOCK_WEEKLY_REVENUE = 284500;
+const MOCK_MONTHLY_REVENUE = 1138000;
+
+const MOCK_DAILY_TREND = [
+  { label: "週一", revenue_cents: 52000 },
+  { label: "週二", revenue_cents: 67500 },
+  { label: "週三", revenue_cents: 43000 },
+  { label: "週四", revenue_cents: 78000 },
+  { label: "週五", revenue_cents: 61500 },
+  { label: "週六", revenue_cents: 0 },
+  { label: "今日", revenue_cents: null },
+];
+
+function buildItemStats(selections) {
+  const map = {};
+  for (const s of selections) {
+    if (!map[s.item_id]) {
+      map[s.item_id] = {
+        item_id: s.item_id,
+        item_name: s.item_name,
+        order_count: 0,
+        total_quantity: 0,
+        total_revenue_cents: 0,
+      };
+    }
+    map[s.item_id].order_count += 1;
+    map[s.item_id].total_quantity += s.quantity;
+    map[s.item_id].total_revenue_cents += s.total_price_cents;
+  }
+  return Object.values(map).sort((a, b) => b.total_revenue_cents - a.total_revenue_cents);
+}
+
+export default function VendorRevenuePage() {
+  const todayRevenue = MOCK_VENDOR_SELECTIONS.reduce((sum, s) => sum + s.total_price_cents, 0);
+  const todayOrders = MOCK_VENDOR_SELECTIONS.length;
+  const itemStats = buildItemStats(MOCK_VENDOR_SELECTIONS);
+
+  const trend = MOCK_DAILY_TREND.map((d) => ({
+    ...d,
+    revenue_cents: d.revenue_cents === null ? todayRevenue : d.revenue_cents,
+  }));
+  const maxRevenue = Math.max(...trend.map((d) => d.revenue_cents));
+
+  return (
+    <div>
+      <div className="page-header">
+        <p className="eyebrow">Vendor · Revenue</p>
+        <h2>收益總覽</h2>
+      </div>
+
+      {/* 收入摘要 */}
+      <div style={{ display: "flex", gap: 16, marginBottom: 32 }}>
+        <div className="panel" style={{ flex: 1, padding: "16px 20px" }}>
+          <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>今日收入</p>
+          <p style={{ margin: "4px 0 0", fontWeight: 700, fontSize: 22 }}>{formatPrice(todayRevenue)}</p>
+          <p style={{ margin: "4px 0 0", color: "var(--muted)", fontSize: 12 }}>{todayOrders} 筆訂單</p>
+        </div>
+        <div className="panel" style={{ flex: 1, padding: "16px 20px" }}>
+          <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>本週收入</p>
+          <p style={{ margin: "4px 0 0", fontWeight: 700, fontSize: 22 }}>{formatPrice(MOCK_WEEKLY_REVENUE)}</p>
+        </div>
+        <div className="panel" style={{ flex: 1, padding: "16px 20px" }}>
+          <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>本月收入</p>
+          <p style={{ margin: "4px 0 0", fontWeight: 700, fontSize: 22 }}>{formatPrice(MOCK_MONTHLY_REVENUE)}</p>
+        </div>
+      </div>
+
+      {/* 歷史收入趨勢 */}
+      <div style={{ marginBottom: 32 }}>
+        <p style={{ fontWeight: 600, marginBottom: 16 }}>本週收入趨勢</p>
+        <div className="panel" style={{ padding: "20px 24px" }}>
+          <div style={{ display: "flex", alignItems: "flex-end", gap: 12, height: 120 }}>
+            {trend.map((d) => {
+              const pct = maxRevenue > 0 ? d.revenue_cents / maxRevenue : 0;
+              const isToday = d.label === "今日";
+              return (
+                <div key={d.label} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+                  <p style={{ margin: 0, fontSize: 11, color: "var(--muted)", fontWeight: 600 }}>
+                    {formatPrice(d.revenue_cents)}
+                  </p>
+                  <div
+                    style={{
+                      width: "100%",
+                      height: `${Math.max(pct * 72, d.revenue_cents > 0 ? 4 : 0)}px`,
+                      background: isToday ? "var(--accent, #3b82f6)" : "var(--line, #e5e7eb)",
+                      borderRadius: 4,
+                      transition: "height 0.3s",
+                    }}
+                  />
+                  <p style={{ margin: 0, fontSize: 12, color: isToday ? "var(--accent, #3b82f6)" : "var(--muted)", fontWeight: isToday ? 700 : 400 }}>
+                    {d.label}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* 今日品項銷售明細 */}
+      <p style={{ fontWeight: 600, marginBottom: 16 }}>今日品項銷售</p>
+      {itemStats.length === 0 ? (
+        <p className="empty-state">今日尚無銷售資料。</p>
+      ) : (
+        <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 80px 80px 120px",
+              padding: "10px 20px",
+              borderBottom: "1px solid var(--line)",
+              color: "var(--muted)",
+              fontSize: 12,
+              fontWeight: 600,
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+            }}
+          >
+            <span>品項</span>
+            <span style={{ textAlign: "right" }}>訂單數</span>
+            <span style={{ textAlign: "right" }}>總份數</span>
+            <span style={{ textAlign: "right" }}>銷售額</span>
+          </div>
+
+          {itemStats.map((stat, idx) => (
+            <div
+              key={stat.item_id}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr 80px 80px 120px",
+                alignItems: "center",
+                padding: "14px 20px",
+                borderBottom: idx < itemStats.length - 1 ? "1px solid var(--line)" : "none",
+              }}
+            >
+              <p style={{ margin: 0, fontWeight: 500 }}>{stat.item_name}</p>
+              <p style={{ margin: 0, textAlign: "right", color: "var(--muted)" }}>{stat.order_count}</p>
+              <p style={{ margin: 0, textAlign: "right", color: "var(--muted)" }}>{stat.total_quantity} 份</p>
+              <p style={{ margin: 0, textAlign: "right", fontWeight: 600 }}>
+                {formatPrice(stat.total_revenue_cents)}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -13,6 +13,7 @@ import LoginPage from "../pages/LoginPage";
 import NotFoundPage from "../pages/NotFoundPage";
 import VendorHomePage from "../pages/vendor/VendorHomePage";
 import VendorOrdersPage from "../pages/vendor/VendorOrdersPage";
+import VendorRevenuePage from "../pages/vendor/VendorRevenuePage";
 import VendorMenuFormPage from "../pages/vendor/VendorMenuFormPage";
 import VendorMenuListPage from "../pages/vendor/VendorMenuListPage";
 import ProtectedRoute from "./ProtectedRoute";
@@ -65,12 +66,7 @@ export function AppRouter() {
               path="/vendor/orders"
             />
             <Route
-              element={
-                <PlaceholderPage
-                  description="Revenue and invoice pages are planned as a separate branch."
-                  title="Vendor Revenue"
-                />
-              }
+              element={<VendorRevenuePage />}
               path="/vendor/revenue"
             />
           </Route>

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -12,6 +12,7 @@ import ForbiddenPage from "../pages/ForbiddenPage";
 import LoginPage from "../pages/LoginPage";
 import NotFoundPage from "../pages/NotFoundPage";
 import VendorHomePage from "../pages/vendor/VendorHomePage";
+import VendorOrdersPage from "../pages/vendor/VendorOrdersPage";
 import VendorMenuFormPage from "../pages/vendor/VendorMenuFormPage";
 import VendorMenuListPage from "../pages/vendor/VendorMenuListPage";
 import ProtectedRoute from "./ProtectedRoute";
@@ -60,12 +61,7 @@ export function AppRouter() {
             <Route element={<VendorMenuFormPage />} path="/vendor/menu/new" />
             <Route element={<VendorMenuFormPage />} path="/vendor/menu/:itemId/edit" />
             <Route
-              element={
-                <PlaceholderPage
-                  description="Incoming orders and status transitions will land in vendor order management."
-                  title="Vendor Orders"
-                />
-              }
+              element={<VendorOrdersPage />}
               path="/vendor/orders"
             />
             <Route


### PR DESCRIPTION
## Summary

- Add `VendorOrdersPage` at `/vendor/orders` — displays today's incoming selections with employee name, item, quantity, unit price, subtotal, and time; summary cards show total order count, portions, and estimated revenue
- Add `VendorRevenuePage` at `/vendor/revenue` — shows revenue summary (today / week / month), weekly bar chart trend, and per-item sales breakdown
- Add `MOCK_VENDOR_SELECTIONS` to mock data with realistic employee order entries

## Test plan

- [x] Login as Vendor → navigate to Orders → today's order list displays with employee names and summary cards
- [x] Navigate to Revenue → summary cards, weekly bar chart, and per-item breakdown all render correctly
- [x] Login as Employee or Admin → `/vendor/orders` and `/vendor/revenue` blocked by RoleRoute