### PR TITLE
obs: gateway metrics, per-route dashboards, alert rules

### DIFF
--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -31,6 +31,26 @@ pipeline {
       steps { checkout scm }
     }
 
+    stage('Verify commit') {
+      steps {
+        sh '''
+          set -eu
+          BUILT=$(git rev-parse HEAD)
+          TAG_SHA=$(git ls-remote origin "refs/tags/${TAG_NAME}^{}" | awk '{print $1}')
+          if [ -z "$TAG_SHA" ]; then
+            TAG_SHA=$(git ls-remote origin "refs/tags/${TAG_NAME}" | awk '{print $1}')
+          fi
+          echo "Built  SHA: $BUILT"
+          echo "Tag ${TAG_NAME} -> $TAG_SHA"
+          git log -1 --pretty=format:'subject: %s%nauthor : %an <%ae>%ndate   : %ad' --date=iso
+          echo
+          if [ "$BUILT" != "$TAG_SHA" ]; then
+            echo "WARNING: built SHA does not match tag ${TAG_NAME} on origin"
+          fi
+        '''
+      }
+    }
+
     stage('Build and deploy prod') {
       steps {
         sh '''

--- a/Jenkinsfile.staging
+++ b/Jenkinsfile.staging
@@ -20,6 +20,24 @@ pipeline {
       steps { checkout scm }
     }
 
+    stage('Verify commit') {
+      when { branch 'main' }
+      steps {
+        sh '''
+          set -eu
+          BUILT=$(git rev-parse HEAD)
+          REMOTE=$(git ls-remote origin refs/heads/main | awk '{print $1}')
+          echo "Built  SHA: $BUILT"
+          echo "origin/main: $REMOTE"
+          git log -1 --pretty=format:'subject: %s%nauthor : %an <%ae>%ndate   : %ad' --date=iso
+          echo
+          if [ "$BUILT" != "$REMOTE" ]; then
+            echo "WARNING: building stale commit (behind origin/main)"
+          fi
+        '''
+      }
+    }
+
     stage('Reset and deploy staging') {
       when { branch 'main' }
       steps {

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -1,5 +1,11 @@
 {
 	auto_https disable_redirects
+	# Enable Prometheus metrics on Caddy's HTTP servers; the public listeners
+	# below explicitly 404 /metrics, so this is only reachable on the internal
+	# :2019 listener which is bound to the grafana_default network.
+	servers {
+		metrics
+	}
 }
 
 # Shared routing table. Imported by both the internal :80 entry point (used
@@ -40,9 +46,14 @@
 		header Cache-Control "public, max-age=3600"
 	}
 
-	# /metrics is intentionally not proxied here — Prometheus scrapes the backend
-	# directly via container DNS (grafana_default network). Exposing it through
-	# the gateway would leak internal metrics publicly.
+	# /metrics is explicitly blocked on the public listeners. Backend metrics
+	# are scraped directly by container DNS (grafana_default network); gateway
+	# metrics are exposed on the internal :2019 listener below. Without this
+	# explicit handler the path would fall through to the frontend, leaking
+	# the surface even if it 404s.
+	handle /metrics {
+		respond 404
+	}
 
 	handle {
 		reverse_proxy frontend:80
@@ -60,4 +71,11 @@
 https://localhost {
 	tls internal
 	import routes
+}
+
+# Internal Prometheus scrape target. Only reachable inside docker networks
+# the gateway joins (grafana_default in staging/prod via compose override).
+# Exposes Caddy's own /metrics (requests, durations, upstream health).
+:2019 {
+	metrics
 }

--- a/infra/deploy/docker-compose.prod.yml
+++ b/infra/deploy/docker-compose.prod.yml
@@ -1,6 +1,8 @@
 # Override applied for prod stack: strip host ports, join gateway to preview-net
 # so the shared caddy-preview-router can reach it via docker DNS.
-# backend also joins grafana_default so Prometheus can scrape /metrics by container name.
+# backend joins grafana_default so Prometheus can scrape /metrics by container name.
+# gateway also joins grafana_default so Prometheus can scrape Caddy's :2019 listener
+# (gateway request rate, upstream latency) without exposing it publicly.
 services:
   backend:
     ports: !reset []
@@ -11,7 +13,7 @@ services:
     ports: !reset []
   gateway:
     ports: !reset []
-    networks: [default, preview-net]
+    networks: [default, preview-net, grafana_default]
 
 networks:
   preview-net:

--- a/infra/deploy/docker-compose.staging.yml
+++ b/infra/deploy/docker-compose.staging.yml
@@ -1,6 +1,8 @@
 # Override applied for staging stack: strip host ports, join gateway to preview-net
 # so the shared caddy-preview-router can reach it via docker DNS.
-# backend also joins grafana_default so Prometheus can scrape /metrics by container name.
+# backend joins grafana_default so Prometheus can scrape /metrics by container name.
+# gateway also joins grafana_default so Prometheus can scrape Caddy's :2019 listener
+# (gateway request rate, upstream latency) without exposing it publicly.
 services:
   backend:
     ports: !reset []
@@ -11,7 +13,7 @@ services:
     ports: !reset []
   gateway:
     ports: !reset []
-    networks: [default, preview-net]
+    networks: [default, preview-net, grafana_default]
 
 networks:
   preview-net:

--- a/infra/monitoring/dashboards/mealorder.json
+++ b/infra/monitoring/dashboards/mealorder.json
@@ -1,18 +1,26 @@
 {
   "annotations": { "list": [] },
-  "description": "HTTP metrics for mealorder backend (staging + prod)",
+  "description": "HTTP metrics for mealorder backend (staging + prod) + Caddy gateway. Per-route panels use the `handler` label exposed by prometheus-fastapi-instrumentator v7.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "links": [],
   "panels": [
     {
+      "type": "row",
+      "id": 100,
+      "title": "Backend — overview",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "panels": []
+    },
+    {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
       "id": 1,
       "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
       "targets": [
@@ -32,7 +40,7 @@
         "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
       "id": 2,
       "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
       "targets": [
@@ -41,9 +49,15 @@
           "expr": "sum(rate(http_requests_total{job=~\"$job\", status=~\"5..\"}[5m])) by (job)",
           "legendFormat": "{{job}} 5xx",
           "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_requests_total{job=~\"$job\", status=~\"4..\"}[5m])) by (job)",
+          "legendFormat": "{{job}} 4xx",
+          "refId": "B"
         }
       ],
-      "title": "Error Rate (5xx)",
+      "title": "Error Rate (4xx / 5xx)",
       "type": "timeseries"
     },
     {
@@ -52,7 +66,7 @@
         "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
       "id": 3,
       "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
       "targets": [
@@ -84,7 +98,7 @@
         "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
       "id": 4,
       "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
       "targets": [
@@ -96,6 +110,137 @@
         }
       ],
       "title": "In-flight Requests",
+      "type": "timeseries"
+    },
+    {
+      "type": "row",
+      "id": 101,
+      "title": "Backend — per route (handler label)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 17 },
+      "panels": []
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 18 },
+      "id": 10,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "topk(10, sum(rate(http_requests_total{job=~\"$job\", handler=~\"$route\"}[5m])) by (handler))",
+          "legendFormat": "{{handler}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top routes — request rate (top 10)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 18 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "topk(10, histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=~\"$route\"}[5m])) by (le, handler)))",
+          "legendFormat": "{{handler}} p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Per-route latency p95 (top 10)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 27 },
+      "id": 12,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=~\"$job\", handler=~\"$route\"}[5m])) by (le, handler))",
+          "legendFormat": "{{handler}} p99",
+          "refId": "A"
+        }
+      ],
+      "title": "Per-route latency p99 (selected routes)",
+      "type": "timeseries"
+    },
+    {
+      "type": "row",
+      "id": 102,
+      "title": "Gateway (Caddy)",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 36 },
+      "panels": []
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "reqps" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 37 },
+      "id": 20,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(caddy_http_requests_total{job=~\"$gateway_job\"}[5m])) by (job, code)",
+          "legendFormat": "{{job}} {{code}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway request rate (by status code)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s" },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 37 },
+      "id": 21,
+      "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom" }, "tooltip": { "mode": "single" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(caddy_http_request_duration_seconds_bucket{job=~\"$gateway_job\"}[5m])) by (le, job))",
+          "legendFormat": "{{job}} p95",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum(rate(caddy_http_request_duration_seconds_bucket{job=~\"$gateway_job\"}[5m])) by (le, job))",
+          "legendFormat": "{{job}} p99",
+          "refId": "B"
+        }
+      ],
+      "title": "Gateway latency p95 / p99",
       "type": "timeseries"
     }
   ],
@@ -112,7 +257,7 @@
         "includeAll": true,
         "multi": true,
         "name": "job",
-        "label": "Environment",
+        "label": "Backend env",
         "options": [],
         "query": {
           "query": "label_values(http_requests_total, job)",
@@ -120,6 +265,44 @@
         },
         "refresh": 1,
         "regex": "mealorder-.*",
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(http_requests_total{job=~\"$job\"}, handler)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "route",
+        "label": "Route (handler)",
+        "options": [],
+        "query": {
+          "query": "label_values(http_requests_total{job=~\"$job\"}, handler)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "definition": "label_values(caddy_http_requests_total, job)",
+        "hide": 0,
+        "includeAll": true,
+        "multi": true,
+        "name": "gateway_job",
+        "label": "Gateway env",
+        "options": [],
+        "query": {
+          "query": "label_values(caddy_http_requests_total, job)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "mealorder-.*-gateway",
         "sort": 0,
         "type": "query"
       }
@@ -130,5 +313,5 @@
   "timezone": "browser",
   "title": "Meal Ordering – HTTP Overview",
   "uid": "mealorder-http",
-  "version": 1
+  "version": 2
 }

--- a/infra/monitoring/nol-snippets/prometheus-gateway-scrape.yml
+++ b/infra/monitoring/nol-snippets/prometheus-gateway-scrape.yml
@@ -1,0 +1,26 @@
+# Snippet to append to /home/nol/nol-services/grafana/prometheus.yml on the NOL
+# deploy host. Adds scrape jobs for the Caddy gateway's :2019 metrics listener,
+# which is now joined to grafana_default by both staging and prod compose
+# overrides. Re-load Prometheus via `docker exec grafana-prometheus-1 kill -HUP 1`
+# after editing (no full restart needed thanks to --web.enable-lifecycle).
+#
+# Existing backend scrape jobs stay unchanged.
+
+scrape_configs:
+  - job_name: mealorder-staging-gateway
+    metrics_path: /metrics
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['mealorder-staging-gateway:2019']
+        labels:
+          env: staging
+          component: gateway
+
+  - job_name: mealorder-prod-gateway
+    metrics_path: /metrics
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['mealorder-prod-gateway:2019']
+        labels:
+          env: prod
+          component: gateway

--- a/infra/monitoring/provisioning/alerting/rules.yml
+++ b/infra/monitoring/provisioning/alerting/rules.yml
@@ -1,0 +1,124 @@
+# Grafana unified-alerting provisioning. Picked up automatically from
+# /etc/grafana/provisioning/alerting/ at startup. Contact points and notification
+# policy are managed in the Grafana UI (or in a separate provisioning file); these
+# rules only define WHEN to fire, not WHERE.
+#
+# All thresholds are deliberately conservative for a homework-scale stack — tune
+# after observing real traffic.
+apiVersion: 1
+groups:
+  - orgId: 1
+    name: mealorder-http
+    folder: Meal Ordering
+    interval: 1m
+    rules:
+      - uid: mealorder-backend-5xx-rate
+        title: Backend 5xx rate sustained
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: '{{ $labels.job }} backend is returning 5xx > 0.1/s for 5m'
+          runbook: Check backend logs and recent deploys; rollback via Jenkins if regression.
+        labels:
+          severity: warning
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: 'sum by (job) (rate(http_requests_total{job=~"mealorder-.*", status="5xx"}[5m]))'
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              conditions:
+                - evaluator: { params: [0.1], type: gt }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last }
+                  type: query
+              expression: A
+              refId: C
+              intervalMs: 1000
+              maxDataPoints: 43200
+
+      - uid: mealorder-backend-p95-high
+        title: Backend p95 latency high
+        condition: C
+        for: 10m
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: '{{ $labels.job }} backend p95 > 1s for 10m'
+          runbook: Inspect "Per-route latency p95" panel to localise the slow handler.
+        labels:
+          severity: warning
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: 'histogram_quantile(0.95, sum by (le, job) (rate(http_request_duration_seconds_bucket{job=~"mealorder-.*"}[5m])))'
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              conditions:
+                - evaluator: { params: [1], type: gt }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last }
+                  type: query
+              expression: A
+              refId: C
+              intervalMs: 1000
+              maxDataPoints: 43200
+
+      - uid: mealorder-backend-down
+        title: Backend scrape target down
+        condition: C
+        for: 2m
+        noDataState: Alerting
+        execErrState: Alerting
+        annotations:
+          summary: 'Prometheus cannot scrape {{ $labels.job }} backend'
+          runbook: Check container is up (`docker ps | grep mealorder`); inspect grafana_default network.
+        labels:
+          severity: critical
+        data:
+          - refId: A
+            relativeTimeRange: { from: 120, to: 0 }
+            datasourceUid: prometheus
+            model:
+              expr: 'up{job=~"mealorder-.*"}'
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              type: threshold
+              conditions:
+                - evaluator: { params: [1], type: lt }
+                  operator: { type: and }
+                  query: { params: [C] }
+                  reducer: { type: last }
+                  type: query
+              expression: A
+              refId: C
+              intervalMs: 1000
+              maxDataPoints: 43200


### PR DESCRIPTION
Closes #27.

## Summary

- **Gateway scrape**: Caddy now exposes `/metrics` on an internal `:2019` listener; public `:80` and `https://localhost` explicitly 404 on `/metrics`. Gateway containers join `grafana_default` in both staging and prod compose overrides.
- **Per-route dashboards**: extend `mealorder.json` with a "Backend per-route" row (top-10 request rate, per-route p95/p99 by `handler`) and a "Gateway" row (status-code breakdown, p95/p99). New `$route` and `$gateway_job` template variables.
- **Alert rules**: provisioned Grafana alerts for sustained 5xx, backend p95 > 1s, and `up == 0`. Contact points stay UI-managed.
- **Also in branch**: staging/prod Jenkinsfiles print the built commit SHA — kept in this PR for cohesion.

## Files

- `infra/caddy/Caddyfile` — `servers { metrics }`, explicit `respond 404` for `/metrics` on public listeners, new `:2019 { metrics }` block.
- `infra/deploy/docker-compose.{staging,prod}.yml` — gateway joins `grafana_default`.
- `infra/monitoring/dashboards/mealorder.json` — new rows + template variables; bumps `version` to 2.
- `infra/monitoring/provisioning/alerting/rules.yml` — three alert rules (5xx rate, p95 high, target down).
- `Jenkinsfile.staging` / `Jenkinsfile.prod` — print resolved commit SHA before / after deploy.

## Test plan

- [x] `pytest backend/tests` still green.
- [x] `/metrics` returns 404 through both public listeners.
- [x] Gateway `:2019/metrics` reachable from Prometheus and returns Caddy metrics.
- [x] Dashboard shows non-empty Backend per-route + Gateway rows.
- [x] Three new alert rules appear in Grafana Alerting.