### PR TITLE
feat: add employee order management core

### DIFF
--- a/backend/db/migrations/003_order_management_core.sql
+++ b/backend/db/migrations/003_order_management_core.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS orders (
+  id BIGSERIAL PRIMARY KEY,
+  employee_id BIGINT NOT NULL REFERENCES users(id),
+  vendor_id BIGINT NOT NULL REFERENCES vendors(id),
+  status VARCHAR(30) NOT NULL DEFAULT 'pending',
+  total_price_cents INT NOT NULL DEFAULT 0 CHECK (total_price_cents >= 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  cancelled_at TIMESTAMPTZ,
+  CHECK (status IN ('pending', 'confirmed', 'preparing', 'ready', 'delivered', 'cancelled'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_orders_employee_created
+  ON orders (employee_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_orders_vendor_status_created
+  ON orders (vendor_id, status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS order_items (
+  id BIGSERIAL PRIMARY KEY,
+  order_id BIGINT NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+  item_id BIGINT REFERENCES menu_items(id) ON DELETE SET NULL,
+  item_name TEXT NOT NULL,
+  quantity INT NOT NULL CHECK (quantity > 0),
+  unit_price_cents INT NOT NULL CHECK (unit_price_cents >= 0),
+  total_price_cents INT NOT NULL CHECK (total_price_cents >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_order_items_order
+  ON order_items (order_id);

--- a/backend/repositories/employee_selection_repository.py
+++ b/backend/repositories/employee_selection_repository.py
@@ -1,43 +1,137 @@
-"""In-memory employee meal selection repository."""
+"""In-memory employee orders with legacy meal selection compatibility."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from itertools import count
 
-from backend.schemas.employee import MealSelection
+from backend.schemas.employee import EmployeeOrder, EmployeeOrderItem, MealSelection, OrderStatus
 
 
 @dataclass
-class _SelectionRecord:
-    id: int
-    employee_id: int
-    vendor_id: int
+class OrderItemSnapshot:
     item_id: int
     item_name: str
     quantity: int
     unit_price_cents: int
+
+
+@dataclass
+class _OrderRecord:
+    id: int
+    employee_id: int
+    vendor_id: int
+    status: OrderStatus
     created_at: datetime
+    updated_at: datetime
+    cancelled_at: datetime | None
 
 
-def _to_schema(rec: _SelectionRecord) -> MealSelection:
-    return MealSelection(
+@dataclass
+class _OrderItemRecord:
+    id: int
+    order_id: int
+    item_id: int
+    item_name: str
+    quantity: int
+    unit_price_cents: int
+
+
+def _item_to_schema(rec: _OrderItemRecord) -> EmployeeOrderItem:
+    return EmployeeOrderItem(
         id=rec.id,
-        employee_id=rec.employee_id,
-        vendor_id=rec.vendor_id,
+        order_id=rec.order_id,
         item_id=rec.item_id,
         item_name=rec.item_name,
         quantity=rec.quantity,
         unit_price_cents=rec.unit_price_cents,
         total_price_cents=rec.quantity * rec.unit_price_cents,
-        created_at=rec.created_at,
+    )
+
+
+def _selection_to_schema(order: _OrderRecord, item: _OrderItemRecord) -> MealSelection:
+    return MealSelection(
+        id=item.id,
+        order_id=order.id,
+        employee_id=order.employee_id,
+        vendor_id=order.vendor_id,
+        item_id=item.item_id,
+        item_name=item.item_name,
+        quantity=item.quantity,
+        unit_price_cents=item.unit_price_cents,
+        total_price_cents=item.quantity * item.unit_price_cents,
+        created_at=order.created_at,
     )
 
 
 class EmployeeSelectionRepository:
     def __init__(self) -> None:
-        self._rows: dict[int, _SelectionRecord] = {}
-        self._id_seq = count(1)
+        self._orders: dict[int, _OrderRecord] = {}
+        self._items: dict[int, _OrderItemRecord] = {}
+        self._order_id_seq = count(1)
+        self._item_id_seq = count(1)
+
+    def create_order(
+        self,
+        *,
+        employee_id: int,
+        vendor_id: int,
+        items: list[OrderItemSnapshot],
+    ) -> EmployeeOrder:
+        now = datetime.now(timezone.utc)
+        order = _OrderRecord(
+            id=next(self._order_id_seq),
+            employee_id=employee_id,
+            vendor_id=vendor_id,
+            status="pending",
+            created_at=now,
+            updated_at=now,
+            cancelled_at=None,
+        )
+        self._orders[order.id] = order
+
+        for item in items:
+            rec = _OrderItemRecord(
+                id=next(self._item_id_seq),
+                order_id=order.id,
+                item_id=item.item_id,
+                item_name=item.item_name,
+                quantity=item.quantity,
+                unit_price_cents=item.unit_price_cents,
+            )
+            self._items[rec.id] = rec
+
+        return self._order_to_schema(order)
+
+    def list_orders(self, *, employee_id: int) -> list[EmployeeOrder]:
+        rows = [r for r in self._orders.values() if r.employee_id == employee_id]
+        rows.sort(key=lambda r: r.id)
+        return [self._order_to_schema(r) for r in rows]
+
+    def get_order(self, *, employee_id: int, order_id: int) -> EmployeeOrder | None:
+        order = self._orders.get(order_id)
+        if order is None or order.employee_id != employee_id:
+            return None
+        return self._order_to_schema(order)
+
+    def cancel_order(self, *, employee_id: int, order_id: int) -> EmployeeOrder | None:
+        order = self._orders.get(order_id)
+        if order is None or order.employee_id != employee_id:
+            return None
+        if order.status != "pending":
+            return self._order_to_schema(order)
+
+        now = datetime.now(timezone.utc)
+        self._orders[order.id] = _OrderRecord(
+            id=order.id,
+            employee_id=order.employee_id,
+            vendor_id=order.vendor_id,
+            status="cancelled",
+            created_at=order.created_at,
+            updated_at=now,
+            cancelled_at=now,
+        )
+        return self._order_to_schema(self._orders[order.id])
 
     def create(
         self,
@@ -49,20 +143,46 @@ class EmployeeSelectionRepository:
         quantity: int,
         unit_price_cents: int,
     ) -> MealSelection:
-        rec = _SelectionRecord(
-            id=next(self._id_seq),
+        order = self.create_order(
             employee_id=employee_id,
             vendor_id=vendor_id,
-            item_id=item_id,
-            item_name=item_name,
-            quantity=quantity,
-            unit_price_cents=unit_price_cents,
-            created_at=datetime.now(timezone.utc),
+            items=[
+                OrderItemSnapshot(
+                    item_id=item_id,
+                    item_name=item_name,
+                    quantity=quantity,
+                    unit_price_cents=unit_price_cents,
+                )
+            ],
         )
-        self._rows[rec.id] = rec
-        return _to_schema(rec)
+        return self._order_to_selection_schemas(order.id)[0]
 
     def list(self, *, employee_id: int) -> list[MealSelection]:
-        rows = [r for r in self._rows.values() if r.employee_id == employee_id]
-        rows.sort(key=lambda r: r.id)
-        return [_to_schema(r) for r in rows]
+        selections: list[MealSelection] = []
+        for order in sorted(self._orders.values(), key=lambda r: r.id):
+            if order.employee_id != employee_id:
+                continue
+            selections.extend(self._order_to_selection_schemas(order.id))
+        return selections
+
+    def _order_to_schema(self, order: _OrderRecord) -> EmployeeOrder:
+        items = [r for r in self._items.values() if r.order_id == order.id]
+        items.sort(key=lambda r: r.id)
+        schema_items = [_item_to_schema(item) for item in items]
+        return EmployeeOrder(
+            id=order.id,
+            employee_id=order.employee_id,
+            vendor_id=order.vendor_id,
+            status=order.status,
+            items=schema_items,
+            total_price_cents=sum(item.total_price_cents for item in schema_items),
+            created_at=order.created_at,
+            updated_at=order.updated_at,
+            cancelled_at=order.cancelled_at,
+        )
+
+    def _order_to_selection_schemas(self, order_id: int) -> list[MealSelection]:
+        order = self._orders[order_id]
+        items = [r for r in self._items.values() if r.order_id == order_id]
+        items.sort(key=lambda r: r.id)
+        return [_selection_to_schema(order, item) for item in items]

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -11,7 +11,14 @@ from backend.repositories.employee_selection_repository import EmployeeSelection
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
 from backend.routes.vendor_menu import get_menu_item_repository
-from backend.schemas.employee import EmployeeMenuItem, EmployeeVendor, MealSelection, MealSelectionCreate
+from backend.schemas.employee import (
+    EmployeeMenuItem,
+    EmployeeOrder,
+    EmployeeOrderCreate,
+    EmployeeVendor,
+    MealSelection,
+    MealSelectionCreate,
+)
 from backend.services.employee_ordering_service import EmployeeOrderingService
 
 router = APIRouter(prefix="/employee", tags=["employee"])
@@ -69,9 +76,45 @@ def select_meal(
     return service.select_meal(employee_id, vendor_id, payload)
 
 
+@router.post("/vendors/{vendor_id}/orders", response_model=EmployeeOrder, status_code=status.HTTP_201_CREATED)
+def create_order(
+    vendor_id: int,
+    payload: EmployeeOrderCreate,
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> EmployeeOrder:
+    return service.create_order(employee_id, vendor_id, payload)
+
+
 @router.get("/me/selections", response_model=list[MealSelection])
 def list_my_selections(
     employee_id: Annotated[int, Depends(require_employee)],
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
 ) -> list[MealSelection]:
     return service.list_my_selections(employee_id)
+
+
+@router.get("/me/orders", response_model=list[EmployeeOrder])
+def list_my_orders(
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> list[EmployeeOrder]:
+    return service.list_my_orders(employee_id)
+
+
+@router.get("/me/orders/{order_id}", response_model=EmployeeOrder)
+def get_my_order(
+    order_id: int,
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> EmployeeOrder:
+    return service.get_my_order(employee_id, order_id)
+
+
+@router.post("/me/orders/{order_id}/cancel", response_model=EmployeeOrder)
+def cancel_my_order(
+    order_id: int,
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> EmployeeOrder:
+    return service.cancel_my_order(employee_id, order_id)

--- a/backend/schemas/employee.py
+++ b/backend/schemas/employee.py
@@ -1,7 +1,8 @@
-"""Employee-facing vendor, menu, and meal selection schemas."""
+"""Employee-facing vendor, menu, order, and meal selection schemas."""
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -37,6 +38,7 @@ class MealSelectionCreate(BaseModel):
 
 class MealSelection(BaseModel):
     id: int
+    order_id: int | None = None
     employee_id: int
     vendor_id: int
     item_id: int
@@ -45,3 +47,37 @@ class MealSelection(BaseModel):
     unit_price_cents: int
     total_price_cents: int
     created_at: datetime
+
+
+OrderStatus = Literal["pending", "confirmed", "preparing", "ready", "delivered", "cancelled"]
+
+
+class EmployeeOrderItemCreate(BaseModel):
+    item_id: int
+    quantity: int = Field(ge=1)
+
+
+class EmployeeOrderCreate(BaseModel):
+    items: list[EmployeeOrderItemCreate] = Field(min_length=1)
+
+
+class EmployeeOrderItem(BaseModel):
+    id: int
+    order_id: int
+    item_id: int
+    item_name: str
+    quantity: int
+    unit_price_cents: int
+    total_price_cents: int
+
+
+class EmployeeOrder(BaseModel):
+    id: int
+    employee_id: int
+    vendor_id: int
+    status: OrderStatus
+    items: list[EmployeeOrderItem]
+    total_price_cents: int
+    created_at: datetime
+    updated_at: datetime
+    cancelled_at: datetime | None = None

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -2,10 +2,18 @@
 from __future__ import annotations
 
 from backend.core.errors import CodedHTTPException
-from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository, OrderItemSnapshot
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
-from backend.schemas.employee import EmployeeMenuItem, EmployeeVendor, MealSelection, MealSelectionCreate
+from backend.schemas.employee import (
+    EmployeeMenuItem,
+    EmployeeOrder,
+    EmployeeOrderCreate,
+    EmployeeOrderItemCreate,
+    EmployeeVendor,
+    MealSelection,
+    MealSelectionCreate,
+)
 from backend.schemas.vendor_self import MenuItem as VendorMenuItem
 
 
@@ -40,30 +48,67 @@ class EmployeeOrderingService:
     def select_meal(
         self, employee_id: int, vendor_id: int, payload: MealSelectionCreate
     ) -> MealSelection:
-        self._get_approved_vendor(vendor_id)
-        item = self.menu_item_repository.get(vendor_id=vendor_id, item_id=payload.item_id)
-        if item is None:
-            raise CodedHTTPException(status_code=404, code="not_found", detail="menu item not found")
-        if not item.available:
-            raise CodedHTTPException(status_code=409, code="item_unavailable", detail="menu item unavailable")
-        if item.daily_quota is not None and payload.quantity > item.daily_quota:
-            raise CodedHTTPException(
-                status_code=409,
-                code="quantity_exceeds_daily_quota",
-                detail="quantity exceeds daily quota",
-            )
-
-        return self.selection_repository.create(
-            employee_id=employee_id,
-            vendor_id=vendor_id,
-            item_id=item.id,
-            item_name=item.name,
-            quantity=payload.quantity,
-            unit_price_cents=item.price_cents,
+        order = self.create_order(
+            employee_id,
+            vendor_id,
+            EmployeeOrderCreate(
+                items=[
+                    EmployeeOrderItemCreate(
+                        item_id=payload.item_id,
+                        quantity=payload.quantity,
+                    )
+                ]
+            ),
+        )
+        item = order.items[0]
+        return MealSelection(
+            id=item.id,
+            order_id=order.id,
+            employee_id=order.employee_id,
+            vendor_id=order.vendor_id,
+            item_id=item.item_id,
+            item_name=item.item_name,
+            quantity=item.quantity,
+            unit_price_cents=item.unit_price_cents,
+            total_price_cents=item.total_price_cents,
+            created_at=order.created_at,
         )
 
     def list_my_selections(self, employee_id: int) -> list[MealSelection]:
         return self.selection_repository.list(employee_id=employee_id)
+
+    def create_order(
+        self, employee_id: int, vendor_id: int, payload: EmployeeOrderCreate
+    ) -> EmployeeOrder:
+        self._get_approved_vendor(vendor_id)
+        snapshots = self._build_order_items(vendor_id, payload)
+        return self.selection_repository.create_order(
+            employee_id=employee_id,
+            vendor_id=vendor_id,
+            items=snapshots,
+        )
+
+    def list_my_orders(self, employee_id: int) -> list[EmployeeOrder]:
+        return self.selection_repository.list_orders(employee_id=employee_id)
+
+    def get_my_order(self, employee_id: int, order_id: int) -> EmployeeOrder:
+        order = self.selection_repository.get_order(employee_id=employee_id, order_id=order_id)
+        if order is None:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
+        return order
+
+    def cancel_my_order(self, employee_id: int, order_id: int) -> EmployeeOrder:
+        order = self.get_my_order(employee_id, order_id)
+        if order.status != "pending":
+            raise CodedHTTPException(
+                status_code=409,
+                code="order_not_cancellable",
+                detail="only pending orders can be cancelled",
+            )
+        cancelled = self.selection_repository.cancel_order(employee_id=employee_id, order_id=order_id)
+        if cancelled is None:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
+        return cancelled
 
     def _get_approved_vendor(self, vendor_id: int) -> VendorRecord:
         vendor = self.vendor_repository.get(vendor_id)
@@ -95,3 +140,36 @@ class EmployeeOrderingService:
             daily_quota=item.daily_quota,
             photo_path=item.photo_path,
         )
+
+    def _build_order_items(
+        self, vendor_id: int, payload: EmployeeOrderCreate
+    ) -> list[OrderItemSnapshot]:
+        requested_by_item: dict[int, int] = {}
+        for requested in payload.items:
+            requested_by_item[requested.item_id] = (
+                requested_by_item.get(requested.item_id, 0) + requested.quantity
+            )
+
+        snapshots: list[OrderItemSnapshot] = []
+        for requested in payload.items:
+            item = self.menu_item_repository.get(vendor_id=vendor_id, item_id=requested.item_id)
+            if item is None:
+                raise CodedHTTPException(status_code=404, code="not_found", detail="menu item not found")
+            if not item.available:
+                raise CodedHTTPException(status_code=409, code="item_unavailable", detail="menu item unavailable")
+            if item.daily_quota is not None and requested_by_item[item.id] > item.daily_quota:
+                raise CodedHTTPException(
+                    status_code=409,
+                    code="quantity_exceeds_daily_quota",
+                    detail="quantity exceeds daily quota",
+                )
+
+            snapshots.append(
+                OrderItemSnapshot(
+                    item_id=item.id,
+                    item_name=item.name,
+                    quantity=requested.quantity,
+                    unit_price_cents=item.price_cents,
+                )
+            )
+        return snapshots

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -104,6 +104,7 @@ def test_select_meal_records_quantity_and_total_price() -> None:
 
     assert resp.status_code == 201
     body = resp.json()
+    assert body["order_id"] is not None
     assert body["employee_id"] == 100
     assert body["vendor_id"] == 1
     assert body["item_id"] == item.id
@@ -114,6 +115,85 @@ def test_select_meal_records_quantity_and_total_price() -> None:
 
     selections = client.get("/employee/me/selections", headers=_h(100)).json()
     assert [selection["id"] for selection in selections] == [body["id"]]
+
+
+def test_create_order_records_multiple_items_and_total_price() -> None:
+    client, item_repo, _ = _setup()
+    rice = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=5)
+    tea = item_repo.create(vendor_id=1, name="Tea", price_cents=40, daily_quota=10)
+
+    resp = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={
+            "items": [
+                {"item_id": rice.id, "quantity": 2},
+                {"item_id": tea.id, "quantity": 1},
+            ]
+        },
+    )
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["employee_id"] == 100
+    assert body["vendor_id"] == 1
+    assert body["status"] == "pending"
+    assert body["total_price_cents"] == 280
+    assert [(item["item_name"], item["quantity"]) for item in body["items"]] == [
+        ("Rice Bowl", 2),
+        ("Tea", 1),
+    ]
+
+
+def test_my_orders_are_scoped_by_employee() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+    client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"items": [{"item_id": item.id, "quantity": 1}]},
+    )
+
+    resp = client.get("/employee/me/orders", headers=_h(200))
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_cancel_pending_order_marks_order_cancelled() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+    order = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"items": [{"item_id": item.id, "quantity": 1}]},
+    ).json()
+
+    resp = client.post(f"/employee/me/orders/{order['id']}/cancel", headers=_h(100))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "cancelled"
+    assert body["cancelled_at"] is not None
+
+
+def test_create_order_sums_duplicate_item_quantities_for_quota() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=2)
+
+    resp = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={
+            "items": [
+                {"item_id": item.id, "quantity": 1},
+                {"item_id": item.id, "quantity": 2},
+            ]
+        },
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "quantity_exceeds_daily_quota"
 
 
 def test_my_selections_are_scoped_by_employee() -> None:


### PR DESCRIPTION
## Summary
- add employee order/order item schemas and in-memory order storage while keeping legacy meal selection responses compatible
- expose employee order create/list/detail/cancel endpoints
- add order management migration for `orders` and `order_items`
- cover multi-item orders, employee scoping, cancellation, and duplicate item quota validation

## Tests
- `./.venv/Scripts/python.exe -m pytest backend/tests -q --basetemp=.pytest_tmp`
- Result: `90 passed, 4 skipped`

## Notes
- Local documentation was kept in `.local-notes/order-management-core.md` and excluded via `.git/info/exclude`, so it is not part of this PR.