### PR TITLE
test(staging): seed dedicated k6 smoke vendor

### DIFF
--- a/Jenkinsfile.staging
+++ b/Jenkinsfile.staging
@@ -97,7 +97,7 @@ pipeline {
             -e BASE_URL="$BASE_URL" \
             -e VUS=3 \
             -e DURATION=20s \
-            -e VENDOR_ID=1 \
+            -e VENDOR_ID=99 \
             grafana/k6:latest run --insecure-skip-tls-verify - \
             < load/vendor-flow.js
         '''

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+import logging
 import os
 
 from fastapi import FastAPI
@@ -7,7 +8,9 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from backend.core.config import settings
 from backend.core.errors import install_error_handler
+from backend.core.vendor_identity import _REPO_SINGLETON as _VENDOR_REPO_SINGLETON
 from backend.db.migrate import run_migrations
+from backend.repositories.vendor_profile_repository import VendorRecord
 from backend.routes import (
     admin_vendors,
     committee_reviews,
@@ -19,9 +22,42 @@ from backend.routes import (
 )
 
 
+_logger = logging.getLogger(__name__)
+
+# Dedicated bot vendor used by the k6 post-deploy smoke in Jenkinsfile.staging.
+# Kept far away from auto-incremented human application IDs so it cannot collide
+# with — or be mistaken for — a real vendor created via the normal application
+# + admin-approval flow.
+_K6_SMOKE_VENDOR_ID = 99
+_K6_SMOKE_VENDOR_NAME = "K6 Smoke Vendor"
+
+
+def _seed_k6_smoke_vendor() -> None:
+    """Seed the dedicated bot vendor used by the Jenkins staging k6 smoke.
+
+    Guarded by env var so prod (whose compose override does NOT set it) is
+    untouched. The warning log is intentional: if this line ever shows up in
+    prod logs, someone copy-pasted the staging compose by mistake.
+    """
+    if os.getenv("SEED_K6_SMOKE_VENDOR") != "1":
+        return
+    _logger.warning(
+        "seeding K6 smoke vendor (id=%d) — must not run in prod",
+        _K6_SMOKE_VENDOR_ID,
+    )
+    _VENDOR_REPO_SINGLETON.seed(
+        VendorRecord(
+            id=_K6_SMOKE_VENDOR_ID,
+            name=_K6_SMOKE_VENDOR_NAME,
+            status="approved",
+        )
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     run_migrations()
+    _seed_k6_smoke_vendor()
     yield
 
 

--- a/backend/tests/test_seed_k6_smoke_vendor.py
+++ b/backend/tests/test_seed_k6_smoke_vendor.py
@@ -1,0 +1,81 @@
+"""Lifespan-time seed for the K6 smoke vendor.
+
+Guards:
+1. Env var off  → no seed (default, prod behaviour).
+2. Env var "1"  → vendor 99 exists, approved, named "K6 Smoke Vendor".
+3. Env var "0" / unset / anything-not-"1" → no seed (strict comparison).
+
+If a future change ever drops the env-var guard or expands the seed beyond
+the single bot vendor, these tests will catch it before staging picks up
+the regression.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import backend.main as backend_main
+from backend.core.vendor_identity import _REPO_SINGLETON as _VENDOR_REPO_SINGLETON
+
+
+@pytest.fixture(autouse=True)
+def _clear_repo_state() -> None:
+    """Each test starts from an empty repo regardless of execution order."""
+    _VENDOR_REPO_SINGLETON._vendors.clear()
+    _VENDOR_REPO_SINGLETON._facilities.clear()
+    yield
+    _VENDOR_REPO_SINGLETON._vendors.clear()
+    _VENDOR_REPO_SINGLETON._facilities.clear()
+
+
+def test_seed_skipped_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SEED_K6_SMOKE_VENDOR", raising=False)
+    backend_main._seed_k6_smoke_vendor()
+    assert _VENDOR_REPO_SINGLETON.get(99) is None
+
+
+def test_seed_skipped_when_env_not_exactly_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Anything other than the exact string "1" must not trigger seeding —
+    # avoids accidental enables from "true" / "yes" / "TRUE" / "0".
+    for value in ("0", "true", "yes", "TRUE", "", " 1 "):
+        monkeypatch.setenv("SEED_K6_SMOKE_VENDOR", value)
+        backend_main._seed_k6_smoke_vendor()
+        assert _VENDOR_REPO_SINGLETON.get(99) is None, (
+            f"unexpected seed for env value {value!r}"
+        )
+
+
+def test_seed_creates_approved_vendor_when_env_is_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SEED_K6_SMOKE_VENDOR", "1")
+    backend_main._seed_k6_smoke_vendor()
+
+    record = _VENDOR_REPO_SINGLETON.get(99)
+    assert record is not None
+    assert record.id == 99
+    assert record.status == "approved"
+    assert record.name == "K6 Smoke Vendor"
+
+
+def test_seed_emits_warning_log(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A warning level entry is the canary for accidental prod activation."""
+    monkeypatch.setenv("SEED_K6_SMOKE_VENDOR", "1")
+    with caplog.at_level("WARNING", logger="backend.main"):
+        backend_main._seed_k6_smoke_vendor()
+    assert any(
+        "K6 smoke vendor" in r.message and r.levelname == "WARNING"
+        for r in caplog.records
+    )
+
+
+def test_seed_only_affects_target_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Seeding must not touch unrelated vendor ids that the test may rely on."""
+    monkeypatch.setenv("SEED_K6_SMOKE_VENDOR", "1")
+    backend_main._seed_k6_smoke_vendor()
+    assert _VENDOR_REPO_SINGLETON.get(1) is None
+    assert _VENDOR_REPO_SINGLETON.get(2) is None

--- a/infra/deploy/docker-compose.staging.yml
+++ b/infra/deploy/docker-compose.staging.yml
@@ -7,6 +7,12 @@ services:
   backend:
     ports: !reset []
     networks: [default, grafana_default]
+    # SEED_K6_SMOKE_VENDOR enables a single bot vendor (id=99, approved) at
+    # lifespan startup so the post-deploy k6 stage in Jenkinsfile.staging has
+    # something to act on. Do NOT copy this env var into docker-compose.prod.yml
+    # — prod must go through the real apply + admin-approval pipeline.
+    environment:
+      SEED_K6_SMOKE_VENDOR: "1"
   frontend:
     ports: !reset []
   db:


### PR DESCRIPTION
Refs #30 (follow-up; reopened that issue to track this).

## Why

The post-deploy k6 stage shipped in PR #31 ran successfully end-to-end against staging but every check returned `404 vendor not found`. The in-memory `VendorProfileRepository` starts empty on every Jenkins `docker compose down -v` + `up`, and the k6 script assumes vendor id `1` exists (matching how the unit smoke test seeds it via dependency overrides). Real staging has no such seeding.

## Fix

Single dedicated bot vendor, guarded by env var, only set in the staging compose.

| File | Change |
|---|---|
| `backend/main.py` | Add `_seed_k6_smoke_vendor()` called from lifespan after `run_migrations()`. Seeds vendor `id=99`, name `K6 Smoke Vendor`, status `approved` — but only when `SEED_K6_SMOKE_VENDOR == "1"`. Strict string compare. WARNING log on fire. |
| `backend/tests/test_seed_k6_smoke_vendor.py` | 5 tests: env-unset, env-not-`"1"` (`"0"`, `"true"`, `"TRUE"`, `" 1 "`, etc.), env-`"1"`, warning log, no-collision-with-other-ids. |
| `infra/deploy/docker-compose.staging.yml` | `SEED_K6_SMOKE_VENDOR: "1"` on backend, with inline "do not copy to prod" comment. |
| `Jenkinsfile.staging` | k6 stage `-e VENDOR_ID=99`. |

## Prod isolation

- `docker-compose.prod.yml` is **not modified**.
- Without the env var, `_seed_k6_smoke_vendor()` returns immediately — same behaviour as today.
- `Jenkinsfile.prod` has no k6 stage and is **not modified**.
- Even an external k6 run against prod would 404 since vendor 99 wouldn't exist.

## Why vendor 99, not 1/2/3

Frontend / admin / committee auth flows are other teammates' scope; pre-seeding "ready-made approved" vendors at low IDs invites shortcuts that bypass the real apply + admin-approval pipeline. Vendor 99 is far enough from the auto-increment range to read clearly as "bot only".

## Test plan

- [x] `pytest backend/tests/test_seed_k6_smoke_vendor.py -v` — 5/5 passed locally.
- [x] `pytest backend/tests --ignore=backend/tests/integration -q` — 95/95 passed (0.73s).
- [x] CI `unit` + `integration` + Jenkins preview green.
- [x] First staging build from main after merge: k6 stage runs against vendor 99, thresholds report > 99% checks succeeded.