### PR TITLE
obs: structured JSON logs, request_id middleware, Loki forwarding, py-spy

### DIFF
--- a/backend/core/observability.py
+++ b/backend/core/observability.py
@@ -1,0 +1,215 @@
+"""Structured logging + per-request correlation + optional Loki forwarding.
+
+Three colocated concerns, kept in one module so the wiring is easy to follow:
+
+1. `RequestIDMiddleware` — generates a UUID per request, exposes it as the
+   `X-Request-ID` response header, and propagates it via a `ContextVar` so any
+   log emitted during the request (sync or async, route or service layer)
+   picks it up automatically through `RequestIDFilter`.
+
+2. `JsonFormatter` — std-lib only, emits one JSON object per log record with a
+   stable field set (`ts`, `level`, `logger`, `msg`, `request_id`, `service`,
+   `env`). Any `logger.x(..., extra={...})` extras are merged in. Exceptions
+   serialise via `formatException` into a single `exc_info` string field —
+   easier to query in Loki than multi-line tracebacks.
+
+3. `configure_logging()` — installs the formatter on root, optionally attaches
+   a queue-backed `LokiHandler` when `LOKI_URL` is set. Queue handler keeps the
+   request hot path off the network; Loki being unreachable degrades to
+   stdout-only without raising. Idempotent so test runs that import `backend.main`
+   repeatedly do not stack handlers.
+
+On-demand flame graphs: the backend image bundles `py-spy`. From the deploy host:
+    docker exec -it mealorder-staging-backend-1 py-spy record -o /tmp/flame.svg \\
+        -d 30 --pid 1
+Attach needs `--cap-add SYS_PTRACE` on the container (staging compose adds it).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import logging.handlers
+import os
+import uuid
+from contextvars import ContextVar
+from queue import Queue
+from typing import Any, Awaitable, Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+# Default `-` (not empty) makes log lines visibly explicit about "no request
+# context" instead of looking like a missing field.
+_request_id_ctx: ContextVar[str] = ContextVar("request_id", default="-")
+
+_LOGGING_CONFIGURED = False
+
+# Fields the JsonFormatter copies from LogRecord. Anything passed via
+# `logger.x("...", extra={"key": "value"})` lands as record attributes and is
+# captured by the extras pass below.
+_RESERVED_LOGRECORD_ATTRS = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "asctime",
+        "message",
+        "taskName",
+        "request_id",
+    }
+)
+
+
+class RequestIDFilter(logging.Filter):
+    """Inject the current ContextVar request id into every record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = _request_id_ctx.get()
+        return True
+
+
+class JsonFormatter(logging.Formatter):
+    """One JSON object per line. Stable shape, Loki-friendly."""
+
+    def __init__(self, service: str, env: str) -> None:
+        super().__init__()
+        self._service = service
+        self._env = env
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S%z"),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+            "request_id": getattr(record, "request_id", "-"),
+            "service": self._service,
+            "env": self._env,
+        }
+        # Merge extras (anything not in the LogRecord standard attribute set).
+        for key, value in record.__dict__.items():
+            if key in _RESERVED_LOGRECORD_ATTRS or key.startswith("_"):
+                continue
+            payload[key] = value
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str, ensure_ascii=False)
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Generate a UUID per request, propagate via ContextVar, expose as header.
+
+    Honours an inbound `X-Request-ID` if a client (or upstream proxy like a
+    load balancer) already set one — useful for end-to-end correlation across
+    services. Falls back to a fresh UUID otherwise.
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        incoming = request.headers.get("x-request-id")
+        request_id = incoming if incoming else uuid.uuid4().hex
+        token = _request_id_ctx.set(request_id)
+        try:
+            response = await call_next(request)
+        finally:
+            _request_id_ctx.reset(token)
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+
+def _build_loki_handler(
+    loki_url: str, service: str, env: str
+) -> logging.Handler | None:
+    """Return a queue-backed Loki handler, or None if the optional lib is absent.
+
+    Wrapping `LokiHandler` in `QueueHandler` + `QueueListener` keeps the request
+    hot path off the network — log calls return as soon as the record is on the
+    in-memory queue. The listener thread drains in the background.
+
+    Loki labels stay narrow (service/env/level) to avoid cardinality blowup.
+    Per-record context (request_id, vendor_id, handler) lives inside the JSON
+    body, queryable via LogQL `|= "vendor_id=42"` etc.
+    """
+    try:
+        import logging_loki  # type: ignore[import-not-found]
+    except ImportError:
+        logging.getLogger(__name__).warning(
+            "LOKI_URL=%s set but python-logging-loki not installed; "
+            "logs stay on stdout",
+            loki_url,
+        )
+        return None
+
+    loki_target = logging_loki.LokiHandler(
+        url=f"{loki_url.rstrip('/')}/loki/api/v1/push",
+        tags={"service": service, "env": env},
+        version="1",
+    )
+    loki_target.setFormatter(JsonFormatter(service=service, env=env))
+
+    queue: Queue[logging.LogRecord] = Queue(maxsize=10_000)
+    queue_handler = logging.handlers.QueueHandler(queue)
+    listener = logging.handlers.QueueListener(
+        queue, loki_target, respect_handler_level=True
+    )
+    listener.daemon = True  # type: ignore[attr-defined]
+    listener.start()
+    return queue_handler
+
+
+def configure_logging() -> None:
+    """Install JSON formatter on root + optional Loki handler. Idempotent."""
+    global _LOGGING_CONFIGURED
+    if _LOGGING_CONFIGURED:
+        return
+
+    service = os.getenv("SERVICE_NAME", "mealorder-backend")
+    env = os.getenv("APP_ENV", "development")
+    loki_url = os.getenv("LOKI_URL", "").strip()
+
+    formatter = JsonFormatter(service=service, env=env)
+    request_id_filter = RequestIDFilter()
+
+    stdout_handler = logging.StreamHandler()
+    stdout_handler.setFormatter(formatter)
+    stdout_handler.addFilter(request_id_filter)
+
+    root = logging.getLogger()
+    # Drop any handler installed by basicConfig() / earlier configure pass so
+    # we do not double-emit when imports re-run (uvicorn reload, test reload).
+    for existing in list(root.handlers):
+        root.removeHandler(existing)
+    root.addHandler(stdout_handler)
+    root.setLevel(logging.INFO)
+
+    if loki_url:
+        loki_handler = _build_loki_handler(loki_url, service, env)
+        if loki_handler is not None:
+            loki_handler.addFilter(request_id_filter)
+            root.addHandler(loki_handler)
+            logging.getLogger(__name__).info(
+                "loki_logging_enabled", extra={"loki_url": loki_url}
+            )
+
+    _LOGGING_CONFIGURED = True

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,7 @@ from prometheus_fastapi_instrumentator import Instrumentator
 
 from backend.core.config import settings
 from backend.core.errors import install_error_handler
+from backend.core.observability import RequestIDMiddleware, configure_logging
 from backend.core.vendor_identity import get_vendor_profile_repository
 from backend.db.migrate import run_migrations
 from backend.repositories.vendor_profile_repository import VendorRecord
@@ -68,11 +69,17 @@ async def lifespan(app: FastAPI):
 
 
 def create_app() -> FastAPI:
+    configure_logging()
+
     app = FastAPI(
         title=settings.app_name,
         root_path=os.getenv("ROOT_PATH", ""),
         lifespan=lifespan,
     )
+
+    # RequestIDMiddleware before CORS so the response header survives CORS
+    # rewrites and is the outermost wrapper that touches every response.
+    app.add_middleware(RequestIDMiddleware)
 
     app.add_middleware(
         CORSMiddleware,

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -1,0 +1,201 @@
+"""Structured logging + request-id middleware behaviour."""
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.core import observability
+from backend.core.observability import (
+    JsonFormatter,
+    RequestIDFilter,
+    _request_id_ctx,
+    configure_logging,
+)
+from backend.main import app
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging() -> None:
+    """Each test starts from a fresh logging state."""
+    observability._LOGGING_CONFIGURED = False
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    yield
+    observability._LOGGING_CONFIGURED = False
+    for h in list(root.handlers):
+        root.removeHandler(h)
+
+
+# ---------------------------------------------------------------------------
+# RequestIDMiddleware
+# ---------------------------------------------------------------------------
+def test_middleware_generates_request_id_when_absent() -> None:
+    client = TestClient(app)
+    r = client.get("/health")
+    rid = r.headers.get("X-Request-ID")
+    assert rid, "X-Request-ID header missing on response"
+    assert len(rid) == 32  # uuid4().hex length
+
+
+def test_middleware_honours_inbound_request_id() -> None:
+    client = TestClient(app)
+    r = client.get("/health", headers={"X-Request-ID": "trace-abc-123"})
+    assert r.headers["X-Request-ID"] == "trace-abc-123"
+
+
+def test_middleware_unique_per_request() -> None:
+    client = TestClient(app)
+    a = client.get("/health").headers["X-Request-ID"]
+    b = client.get("/health").headers["X-Request-ID"]
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# JsonFormatter
+# ---------------------------------------------------------------------------
+def test_json_formatter_stable_field_shape() -> None:
+    formatter = JsonFormatter(service="mealorder-backend", env="test")
+    record = logging.LogRecord(
+        name="backend.routes.vendor_menu",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="created menu item id=%d",
+        args=(42,),
+        exc_info=None,
+    )
+    record.request_id = "abc"
+    payload = json.loads(formatter.format(record))
+
+    assert payload["level"] == "INFO"
+    assert payload["logger"] == "backend.routes.vendor_menu"
+    assert payload["msg"] == "created menu item id=42"
+    assert payload["request_id"] == "abc"
+    assert payload["service"] == "mealorder-backend"
+    assert payload["env"] == "test"
+    assert "ts" in payload
+
+
+def test_json_formatter_merges_extras() -> None:
+    formatter = JsonFormatter(service="s", env="e")
+    record = logging.LogRecord(
+        name="x", level=logging.INFO, pathname="/", lineno=1,
+        msg="hi", args=None, exc_info=None,
+    )
+    record.request_id = "-"
+    record.vendor_id = 99
+    record.handler = "/vendor/me/menu"
+    payload = json.loads(formatter.format(record))
+    assert payload["vendor_id"] == 99
+    assert payload["handler"] == "/vendor/me/menu"
+
+
+def test_json_formatter_serialises_exception() -> None:
+    formatter = JsonFormatter(service="s", env="e")
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+        record = logging.LogRecord(
+            name="x", level=logging.ERROR, pathname="/", lineno=1,
+            msg="failed", args=None, exc_info=sys.exc_info(),
+        )
+    record.request_id = "-"
+    payload = json.loads(formatter.format(record))
+    assert "exc_info" in payload
+    assert "ValueError" in payload["exc_info"]
+    assert "boom" in payload["exc_info"]
+
+
+# ---------------------------------------------------------------------------
+# RequestIDFilter + ContextVar propagation
+# ---------------------------------------------------------------------------
+def test_filter_pulls_request_id_from_context() -> None:
+    f = RequestIDFilter()
+    token = _request_id_ctx.set("ctx-rid-xyz")
+    try:
+        record = logging.LogRecord(
+            name="x", level=logging.INFO, pathname="/", lineno=1,
+            msg="hi", args=None, exc_info=None,
+        )
+        f.filter(record)
+        assert record.request_id == "ctx-rid-xyz"
+    finally:
+        _request_id_ctx.reset(token)
+
+
+def test_log_during_request_carries_id(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """End-to-end: log emitted during a request reflects that request's id."""
+    configure_logging()
+    logger = logging.getLogger("test.request_log")
+    logger.addFilter(RequestIDFilter())
+
+    from fastapi import APIRouter
+
+    captured: list[str] = []
+    router = APIRouter()
+
+    @router.get("/_obs_test/log")
+    def _emit() -> dict[str, str]:
+        # Re-fetch the request id via the contextvar so the test does not
+        # depend on a logging handler being installed in caplog's path.
+        captured.append(_request_id_ctx.get())
+        logger.info("hello from handler")
+        return {"ok": "1"}
+
+    app.include_router(router)
+    try:
+        client = TestClient(app)
+        resp = client.get("/_obs_test/log", headers={"X-Request-ID": "trace-xyz"})
+        assert resp.status_code == 200
+        assert captured == ["trace-xyz"]
+        assert resp.headers["X-Request-ID"] == "trace-xyz"
+    finally:
+        app.router.routes = [r for r in app.router.routes if getattr(r, "path", "") != "/_obs_test/log"]
+
+
+# ---------------------------------------------------------------------------
+# configure_logging() behaviour
+# ---------------------------------------------------------------------------
+def test_configure_logging_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LOKI_URL", raising=False)
+    configure_logging()
+    handlers_after_first = list(logging.getLogger().handlers)
+    configure_logging()
+    handlers_after_second = list(logging.getLogger().handlers)
+    assert handlers_after_first == handlers_after_second
+
+
+def test_configure_logging_skips_loki_when_url_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LOKI_URL", raising=False)
+    configure_logging()
+    root = logging.getLogger()
+    # Only one stdout StreamHandler, no QueueHandler from the Loki path.
+    assert len(root.handlers) == 1
+    assert isinstance(root.handlers[0], logging.StreamHandler)
+
+
+def test_stdout_handler_emits_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LOKI_URL", raising=False)
+    configure_logging()
+    root = logging.getLogger()
+    buf = io.StringIO()
+    root.handlers[0].stream = buf
+    logging.getLogger("backend.test").info("hello", extra={"vendor_id": 7})
+    line = buf.getvalue().strip().splitlines()[-1]
+    payload = json.loads(line)
+    assert payload["msg"] == "hello"
+    assert payload["vendor_id"] == 7
+    assert "request_id" in payload

--- a/infra/deploy/docker-compose.prod.yml
+++ b/infra/deploy/docker-compose.prod.yml
@@ -7,6 +7,10 @@ services:
   backend:
     ports: !reset []
     networks: [default, grafana_default]
+    environment:
+      APP_ENV: prod
+      SERVICE_NAME: mealorder-backend
+      LOKI_URL: http://loki:3100
   frontend:
     ports: !reset []
   db:

--- a/infra/deploy/docker-compose.staging.yml
+++ b/infra/deploy/docker-compose.staging.yml
@@ -13,6 +13,16 @@ services:
     # — prod must go through the real apply + admin-approval pipeline.
     environment:
       SEED_K6_SMOKE_VENDOR: "1"
+      APP_ENV: staging
+      SERVICE_NAME: mealorder-backend
+      # Loki is on grafana_default network as service "loki" (container
+      # grafana-loki-1). Push handler is queue-backed, so unreachable Loki
+      # degrades gracefully to stdout.
+      LOKI_URL: http://loki:3100
+    cap_add:
+      # Needed for `py-spy record --pid 1` to attach inside the container.
+      # Scoped to staging so prod stays minimal-privilege.
+      - SYS_PTRACE
   frontend:
     ports: !reset []
   db:

--- a/infra/monitoring/provisioning/datasources/loki.yml
+++ b/infra/monitoring/provisioning/datasources/loki.yml
@@ -1,8 +1,17 @@
 apiVersion: 1
-datasources:
+
+# Drop the previously provisioned "Loki" (uid=loki) before re-inserting under
+# the meal-prefixed name. Grafana provisioning treats a name change as a new
+# datasource and leaves the old one orphaned otherwise. UI-created entries
+# (lowercase "loki", editable=true) are untouched — different name.
+deleteDatasources:
   - name: Loki
+    orgId: 1
+
+datasources:
+  - name: meal-Loki
     type: loki
-    uid: loki
+    uid: meal-loki
     url: http://loki:3100
     access: proxy
     isDefault: false

--- a/infra/monitoring/provisioning/datasources/loki.yml
+++ b/infra/monitoring/provisioning/datasources/loki.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+  - name: Loki
+    type: loki
+    uid: loki
+    url: http://loki:3100
+    access: proxy
+    isDefault: false
+    editable: false
+    jsonData:
+      maxLines: 1000

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ Pillow==11.0.0
 python-multipart==0.0.27
 psycopg[binary]==3.2.9
 prometheus-fastapi-instrumentator==7.1.0
+python-logging-loki==0.3.1
+py-spy==0.3.14


### PR DESCRIPTION
Closes #35.

## Summary

- **Structured JSON logs** — std-lib `JsonFormatter`, stable field shape (`ts`, `level`, `logger`, `msg`, `request_id`, `service`, `env`). Extras from `logger.x(..., extra={...})` are merged in. Exceptions become a single `exc_info` string field.
- **Request-id middleware** — UUID per request, honours an inbound `X-Request-ID` (so an upstream proxy / k6 / curl trace stays end-to-end correlated), exposes it as the response header, propagates via `ContextVar` for any log emitted during the request.
- **Optional Loki forwarding** — `configure_logging()` attaches a queue-backed `LokiHandler` only when `LOKI_URL` is set. Loki being unreachable degrades gracefully to stdout; the request hot path never blocks on the network.
- **`py-spy` in the image** — `docker exec -it mealorder-staging-backend-1 py-spy record -o /tmp/flame.svg -d 30 --pid 1` produces a flame graph against the live process. Staging container has `cap_add: SYS_PTRACE` for the attach; prod stays minimal-privilege.
- **Grafana Loki datasource** — `infra/monitoring/provisioning/datasources/loki.yml` so explore + future dashboards pick it up at provisioning time.

## Design notes

- Single backend file (`backend/core/observability.py`, ~170 LoC) keeps formatter + middleware + handler wiring colocated and easy to read end-to-end. No over-modularisation into three files.
- Loki labels intentionally narrow (`service`, `env`, `level`) to avoid cardinality blowup. Per-record context (`request_id`, `vendor_id`, `handler`) lives in the JSON body, queryable via LogQL `|= "vendor_id"` etc.
- `prometheus-fastapi-instrumentator` metrics untouched — `request_id` never becomes a Prometheus label.
- Skipped patterns versus an earlier overspec: no `python-json-logger` dep, no custom queue/thread loki handler (use the library's), no `contextvar` plumbing across multiple modules.

## Files

| File | Change |
|---|---|
| `backend/core/observability.py` | New: JsonFormatter, RequestIDMiddleware, RequestIDFilter, configure_logging(). |
| `backend/main.py` | Wire `configure_logging()` + `add_middleware(RequestIDMiddleware)` outside CORS. |
| `requirements.txt` | `python-logging-loki==0.3.1`, `py-spy==0.3.14`. |
| `infra/deploy/docker-compose.staging.yml` | `APP_ENV=staging`, `SERVICE_NAME=mealorder-backend`, `LOKI_URL=http://loki:3100`, `cap_add: SYS_PTRACE`. |
| `infra/deploy/docker-compose.prod.yml` | Same env (no `SYS_PTRACE` — prod stays minimal). |
| `infra/monitoring/provisioning/datasources/loki.yml` | New: Grafana datasource provisioning. |
| `backend/tests/test_observability.py` | 11 tests covering middleware, formatter, filter, idempotency, Loki-skip path, stdout-emits-JSON. |

## Test plan

- [x] `pytest backend/tests/test_observability.py -v` — 11/11 pass (0.34s).
- [x] `pytest backend/tests --ignore=backend/tests/integration -q` — 106/106 pass (0.69s).
- [x] CI `unit` + `integration` + Jenkins preview green.
- [x] After deploy + the new Grafana datasource is in place, `{service="mealorder-backend"}` returns log lines in Grafana Explore.
- [x] `curl -i https://.../meal-staging/health` returns an `X-Request-ID` header on the response.
- [x] `docker exec mealorder-staging-backend-1 py-spy --version` resolves (image carries the tool).