### PR TITLE
fix(network): pin Caddy upstream resolution to a single network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,14 @@ services:
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000
     ports:
       - "8000:8000"
+    networks:
+      default:
+        # Caddyfile references the backend as `api:8000`. Declaring the alias
+        # in the base compose keeps local-dev (no override) working; staging
+        # and prod overrides keep the alias on default while joining
+        # grafana_default for the Prometheus scrape path.
+        aliases:
+          - api
     depends_on:
       db:
         condition: service_healthy

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -13,31 +13,31 @@
 # and the local-dev https://localhost entry point.
 (routes) {
 	handle /health {
-		reverse_proxy backend:8000
+		reverse_proxy api:8000
 	}
 
 	handle /docs* {
-		reverse_proxy backend:8000
+		reverse_proxy api:8000
 	}
 
 	handle /openapi.json {
-		reverse_proxy backend:8000
+		reverse_proxy api:8000
 	}
 
 	handle /admin/* {
-		reverse_proxy backend:8000
+		reverse_proxy api:8000
 	}
 
 	handle /vendor/* {
-		reverse_proxy backend:8000
+		reverse_proxy api:8000
 	}
 
 	handle /employee/* {
-		reverse_proxy backend:8000
+		reverse_proxy api:8000
 	}
 
 	handle /committee/* {
-		reverse_proxy backend:8000
+		reverse_proxy api:8000
 	}
 
 	handle_path /uploads/* {

--- a/infra/deploy/docker-compose.prod.yml
+++ b/infra/deploy/docker-compose.prod.yml
@@ -6,7 +6,14 @@
 services:
   backend:
     ports: !reset []
-    networks: [default, grafana_default]
+    # See staging override for the rationale: pin Caddy gateway → backend
+    # resolution to a single network alias so Docker DNS does not round-robin
+    # across the two networks the gateway shares with backend.
+    networks:
+      default:
+        aliases:
+          - api
+      grafana_default: {}
     environment:
       APP_ENV: prod
       SERVICE_NAME: mealorder-backend

--- a/infra/deploy/docker-compose.staging.yml
+++ b/infra/deploy/docker-compose.staging.yml
@@ -6,7 +6,18 @@
 services:
   backend:
     ports: !reset []
-    networks: [default, grafana_default]
+    # Per-network aliases pin the Caddy gateway's upstream resolution. `backend`
+    # remains reachable as `backend` on grafana_default (Prometheus scrape) and
+    # `api` on default (gateway reverse_proxy). The gateway sits on default +
+    # preview-net + grafana_default; without this pin Docker DNS returned the
+    # backend's IP on both shared networks, and Caddy round-robined into a path
+    # that intermittently returned stale 404s. Single alias on a single network
+    # eliminates that race.
+    networks:
+      default:
+        aliases:
+          - api
+      grafana_default: {}
     # SEED_K6_SMOKE_VENDOR enables a single bot vendor (id=99, approved) at
     # lifespan startup so the post-deploy k6 stage in Jenkinsfile.staging has
     # something to act on. Do NOT copy this env var into docker-compose.prod.yml


### PR DESCRIPTION
Refs #30.

## Root cause

After PR #36 merged, the staging k6 stage settled at 30-50% success — across multiple back-to-back builds, never the deterministic >99% the script's thresholds expect. Direct probes confirmed:

- `docker exec mealorder-staging-backend-1 curl http://127.0.0.1:8000/vendor/me/profile` → 100% green
- `docker exec mealorder-staging-gateway wget http://backend:8000/vendor/me/profile` → intermittent 404
- `curl https://nol.cs.nycu.edu.tw/meal-staging/vendor/me/profile` → 30-50% green
- The failing responses carry the backend's exact "vendor not found" body but **never appear in uvicorn's access log** — request never reaches the live process.

The Caddy gateway and the backend both live on `default` (compose project) **and** `grafana_default` (so Prometheus can scrape `/metrics`). Docker DNS returned both backend IPs to Caddy; `reverse_proxy backend:8000` round-robined, and one path intermittently dead-ended with a stale 404.

## Fix

Per-network alias. `backend` keeps its `backend` service name on `grafana_default` (Prometheus path unchanged), and gains an `api` alias **only on the default network**. The Caddy gateway's reverse_proxy is rewritten to target `api:8000`, which resolves to exactly one IP — eliminating the round-robin.

| File | Change |
|---|---|
| `infra/caddy/Caddyfile` | `backend:8000` → `api:8000` (7 sites). |
| `docker-compose.yml` | backend joins default with `aliases: [api]` so local dev (no override) keeps working. |
| `infra/deploy/docker-compose.staging.yml` | Long-form `networks:` block — alias on default, plain join on grafana_default. |
| `infra/deploy/docker-compose.prod.yml` | Same as staging. |

## What this does NOT change

- Grafana dashboard's Gateway row keeps showing data (gateway → grafana_default is untouched).
- Prometheus scrape of `mealorder-{env}-backend-1:8000/metrics` is untouched.
- Per-env routing topology unchanged — only DNS resolution behaviour.
- No NOL platform changes required.

## Test plan

- [x] `pytest backend/tests --ignore=backend/tests/integration -q` — 106/106 pass.
- [x] `docker compose -f docker-compose.yml -f infra/deploy/docker-compose.staging.yml config` validates with the expected `aliases: [api]` on default and plain join on grafana_default.
- [x] CI `unit` + `integration` + Jenkins preview green.
- [x] First staging Jenkins build after merge: k6 `checks_succeeded` close to 100%, build green.