### PR TITLE
chore(staging): drop k6 smoke vendor from DB after k6 stage

### DIFF
--- a/Jenkinsfile.staging
+++ b/Jenkinsfile.staging
@@ -102,6 +102,23 @@ pipeline {
             < load/vendor-flow.js
         '''
       }
+      post {
+        always {
+          // Remove the bot vendor so /employee/vendors does not surface
+          // "K6 Smoke Vendor" after the build. menu_items / menu_categories /
+          // vendor_facilities are wiped by ON DELETE CASCADE — one row goes
+          // and the whole subtree follows. Next deploy reseeds the row via
+          // lifespan, so this is cleanup for the current container's lifetime
+          // only. Runs whether k6 passed or failed (always{}) so partial
+          // failures still get cleaned up.
+          sh '''
+            set -euo pipefail
+            docker exec mealorder-staging-db-1 psql -U meal_user -d meal_ordering \
+              -v ON_ERROR_STOP=1 -c "DELETE FROM vendors WHERE id = 99;"
+            echo "cleaned k6 smoke vendor (cascade drops menu items, categories, facilities)"
+          '''
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Refs #30.

## Why

The seeded bot vendor (id=99, "K6 Smoke Vendor") used by the post-deploy k6 stage was surfacing in `/employee/vendors`, polluting the demo UI with a synthetic row real users never created.

## Approach

Cleanup at the right layer — when the k6 stage finishes, drop the row. `ON DELETE CASCADE` on `menu_items`, `menu_categories`, and `vendor_facilities` means one DELETE on `vendors` drops the whole subtree. Next deploy reseeds via lifespan.

Considered introducing a synthetic `status="approved_internal"` instead. Rejected because it spreads vendor lifecycle semantics across `main.py` (seed), `vendor_identity.py` (RBAC widened), and the employee listing (filter side effect); future DB enum / check constraint on `status` would silently bypass it.

## Change

`Jenkinsfile.staging` — the existing `stage('k6 vendor smoke')` gets a `post { always { ... } }` block that execs a single `DELETE FROM vendors WHERE id = 99;` against `mealorder-staging-db-1`. Runs whether k6 thresholds passed or failed.

## Exposure window

Bot vendor is visible to `/employee/vendors` only between lifespan seed and k6 stage cleanup — roughly 60-90 seconds per deploy. After cleanup, gone until the next deploy.

## Files

| File | Change |
|---|---|
| `Jenkinsfile.staging` | k6 stage gains a `post { always { sh '... DELETE FROM vendors ...' } }` block. |

## Test plan

- [x] `pytest backend/tests --ignore=backend/tests/integration -q` — 106/106 pass (no backend change).
- [x] CI `unit` + `integration` + Jenkins preview green.
- [x] After merge, first staging build: k6 stage completes (pass or fail), post-block runs, `docker exec mealorder-staging-db-1 psql ... -c 'SELECT count(*) FROM vendors;'` returns 0.
- [x] `curl https://nol.cs.nycu.edu.tw/meal-staging/employee/vendors -H 'x-user-role: employee' -H 'x-user-id: 1'` returns an empty list.