### PR TITLE
fix(deploy): self-contained router image + hourly CD self-heal

### DIFF
--- a/Jenkinsfile.cleanup
+++ b/Jenkinsfile.cleanup
@@ -12,6 +12,20 @@ pipeline {
   stages {
     stage('Checkout') { steps { checkout scm } }
 
+    stage('Ensure router') {
+      // Self-heal the shared deploy router. The container is self-contained
+      // (Caddyfile baked into the image — no bind mount), so this is a no-op
+      // when it is already running on the current Caddyfile, and recreates it
+      // if it died (e.g. host reboot) or the Caddyfile changed. Without this,
+      // a dead router silently 502s every /meal* path until someone notices.
+      steps {
+        sh '''
+          set -euo pipefail
+          bash infra/deploy/router/run-router.sh
+        '''
+      }
+    }
+
     stage('Hourly sweep') {
       steps {
         withCredentials([usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {

--- a/infra/deploy/SETUP.md
+++ b/infra/deploy/SETUP.md
@@ -26,16 +26,37 @@ docker network inspect preview-net >/dev/null 2>&1 \
 
 ## 2. Shared internal router
 
-Clone the repo somewhere ONLY for running the router script (the router itself only mounts the Caddyfile; once the container is up the clone isn't needed):
+The router image is **self-contained**: `run-router.sh` builds an image with the
+Caddyfile baked in (`infra/deploy/router/Dockerfile`) — there is **no bind
+mount**, so the container has no host-path dependency and survives host reboots,
+docker daemon restarts, and `/tmp` / Jenkins-workspace cleanup.
+
+> ⚠️ Do **NOT** clone into `/tmp` or any path that gets wiped. An earlier setup
+> bind-mounted the Caddyfile from `/tmp/cmos`; when `/tmp` was cleared, Docker
+> recreated the missing mount source as an empty *directory*, the mount onto
+> `/etc/caddy/Caddyfile` failed, and the container died with **exit 127** —
+> 502ing every `/meal*` path. The baked-in image removes that failure mode.
+
+Bootstrap once from any checkout (the build copies the Caddyfile into the image,
+so the checkout is genuinely not needed afterwards):
 
 ```bash
-git clone https://github.com/mizu5555/Corporate-Meal-Ordering-System.git /tmp/cmos
-bash /tmp/cmos/infra/deploy/router/run-router.sh
+git clone https://github.com/mizu5555/Corporate-Meal-Ordering-System.git ~/cmos
+bash ~/cmos/infra/deploy/router/run-router.sh
 curl -s http://127.0.0.1:18080/ ; echo
 # expect: preview-router OK
 ```
 
-If the Caddyfile changes upstream, re-run the script (it recreates the container).
+`run-router.sh` is idempotent: it rebuilds the image and only recreates the
+container when the Caddyfile changed or the container is missing/stopped.
+`Jenkinsfile.cleanup` runs it **hourly**, so a dead router self-heals within an
+hour without manual intervention. If the Caddyfile changes upstream and you want
+it live immediately, just re-run the script.
+
+**Troubleshooting `502 Bad Gateway` on `/meal*`:** the router is the single
+host-facing entry on `127.0.0.1:18080`; if it is down, every stack 502s even
+though the gateways are healthy. Check `docker ps -a | grep router` and re-run
+`run-router.sh`.
 
 ## 3. NPM — add /meal-staging/ and /meal/ proxy locations
 

--- a/infra/deploy/router/Dockerfile
+++ b/infra/deploy/router/Dockerfile
@@ -1,0 +1,8 @@
+# Shared internal deploy router. The Caddyfile is baked into the image rather
+# than bind-mounted, so the container has NO host-path dependency: it survives
+# host reboots, docker daemon restarts, and /tmp or Jenkins-workspace cleanup.
+# (A bind mount from an ephemeral path is what previously killed this container
+# with exit 127 — Docker auto-created the missing source as a directory and the
+# mount onto /etc/caddy/Caddyfile failed.)
+FROM caddy:2-alpine
+COPY Caddyfile /etc/caddy/Caddyfile

--- a/infra/deploy/router/run-router.sh
+++ b/infra/deploy/router/run-router.sh
@@ -1,24 +1,44 @@
 #!/usr/bin/env bash
-# Idempotent bootstrap for the shared deploy router container on the NOL host.
-# Safe to re-run; recreates the container if Caddyfile changes.
+# Idempotent ensure for the shared deploy router container on the NOL host.
+#
+# Builds a self-contained image (Caddyfile baked in — no bind mount) and brings
+# the container up. Re-running is cheap and safe:
+#   - Caddyfile unchanged + container already running  -> no-op (no blip)
+#   - Caddyfile changed, or container missing/stopped   -> recreate
+#
+# Designed to be called both as a one-time manual bootstrap AND on a schedule
+# (Jenkinsfile.cleanup runs it hourly) so a dead router self-heals within an
+# hour. Because the image is self-contained, the container also recovers on its
+# own across reboots via `--restart unless-stopped`.
 set -euo pipefail
 
-CADDYFILE="${CADDYFILE:-$(cd "$(dirname "$0")" && pwd)/Caddyfile}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
 NETWORK="${NETWORK:-preview-net}"
 NAME="${NAME:-caddy-preview-router}"
+IMAGE="${IMAGE:-caddy-preview-router:latest}"
 HOST_PORT="${HOST_PORT:-127.0.0.1:18080}"
 
 docker network inspect "$NETWORK" >/dev/null 2>&1 \
   || docker network create "$NETWORK"
 
-docker rm -f "$NAME" >/dev/null 2>&1 || true
+# Build (layer-cached; only the COPY layer changes when Caddyfile changes).
+docker build -q -t "$IMAGE" "$DIR" >/dev/null
 
+want_img="$(docker image inspect "$IMAGE" --format '{{.Id}}')"
+have_img="$(docker inspect "$NAME" --format '{{.Image}}' 2>/dev/null || echo "")"
+running="$(docker inspect "$NAME" --format '{{.State.Running}}' 2>/dev/null || echo "false")"
+
+if [ "$running" = "true" ] && [ "$have_img" = "$want_img" ]; then
+  echo "router already up-to-date on ${HOST_PORT} (image ${want_img:0:19})"
+  exit 0
+fi
+
+docker rm -f "$NAME" >/dev/null 2>&1 || true
 docker run -d \
   --name "$NAME" \
   --restart unless-stopped \
   -p "${HOST_PORT}:80" \
   --network "$NETWORK" \
-  -v "${CADDYFILE}:/etc/caddy/Caddyfile:ro" \
-  caddy:2-alpine
+  "$IMAGE"
 
-echo "router up on ${HOST_PORT} using ${CADDYFILE}"
+echo "router (re)created on ${HOST_PORT} using image ${IMAGE}"


### PR DESCRIPTION
Closes #39

## Root cause

`caddy-preview-router` is the single host-facing entry for all deploy stacks (`NPM → 127.0.0.1:18080 → per-stack gateway` over `preview-net`). It died and every `/meal*` path 502'd; Jenkins smoke checks failed with `+ exit 1`.

`run-router.sh` bind-mounted the Caddyfile from `/tmp/cmos`. After `/tmp` was cleared, Docker recreated the missing mount source as an empty **directory**, so mounting it onto `/etc/caddy/Caddyfile` (a file) failed and the container exited **127**. The router was also absent from every Jenkinsfile, so nothing brought it back.

## Fix

| File | Change |
|---|---|
| `infra/deploy/router/Dockerfile` (new) | Bake the Caddyfile into the image (`COPY`) — no bind mount, so the container has no host-path dependency. |
| `infra/deploy/router/run-router.sh` | Build the image + idempotent ensure: no-op when unchanged, recreate only when the Caddyfile changed or the container is missing/stopped. |
| `Jenkinsfile.cleanup` | New `Ensure router` stage (runs hourly) so a dead router self-heals within an hour. |
| `infra/deploy/SETUP.md` | Correct the wrong "clone not needed" note; document the image is self-contained; add a `502 on /meal*` troubleshooting step. |

## What this does NOT change

- Routing topology, path prefixes, and the `preview-net` docker-DNS dispatch are unchanged.
- No NPM / NOL platform changes required.
- Per-stack gateways still publish no host ports — the router stays the only `:18080` listener.

## Test plan (run on the NOL host)

- [x] Router rebuilt from the image: `mounts=0`, `restart=unless-stopped`.
- [x] `https://nol.cs.nycu.edu.tw/meal-staging/health` and `/meal/health` return `200`.
- [x] Re-running `run-router.sh` with no Caddyfile change is a no-op (`already up-to-date`), no container churn.
- [x] `bash -n run-router.sh` passes.
