### PR TITLE
Add employee random meal picker

### DIFF
--- a/backend/db/migrations/004_order_meal_date.sql
+++ b/backend/db/migrations/004_order_meal_date.sql
@@ -1,0 +1,5 @@
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS meal_date DATE;
+
+CREATE INDEX IF NOT EXISTS idx_orders_meal_date_vendor_status
+  ON orders (meal_date, vendor_id, status);

--- a/backend/repositories/employee_selection_repository.py
+++ b/backend/repositories/employee_selection_repository.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from itertools import count
 
 from backend.schemas.employee import EmployeeOrder, EmployeeOrderItem, MealSelection, OrderStatus
@@ -21,6 +21,7 @@ class _OrderRecord:
     id: int
     employee_id: int
     vendor_id: int
+    meal_date: date | None
     status: OrderStatus
     created_at: datetime
     updated_at: datetime
@@ -55,6 +56,7 @@ def _selection_to_schema(order: _OrderRecord, item: _OrderItemRecord) -> MealSel
         order_id=order.id,
         employee_id=order.employee_id,
         vendor_id=order.vendor_id,
+        meal_date=order.meal_date,
         item_id=item.item_id,
         item_name=item.item_name,
         quantity=item.quantity,
@@ -77,12 +79,14 @@ class EmployeeSelectionRepository:
         employee_id: int,
         vendor_id: int,
         items: list[OrderItemSnapshot],
+        meal_date: date | None = None,
     ) -> EmployeeOrder:
         now = datetime.now(timezone.utc)
         order = _OrderRecord(
             id=next(self._order_id_seq),
             employee_id=employee_id,
             vendor_id=vendor_id,
+            meal_date=meal_date,
             status="pending",
             created_at=now,
             updated_at=now,
@@ -126,6 +130,7 @@ class EmployeeSelectionRepository:
             id=order.id,
             employee_id=order.employee_id,
             vendor_id=order.vendor_id,
+            meal_date=order.meal_date,
             status="cancelled",
             created_at=order.created_at,
             updated_at=now,
@@ -142,10 +147,12 @@ class EmployeeSelectionRepository:
         item_name: str,
         quantity: int,
         unit_price_cents: int,
+        meal_date: date | None = None,
     ) -> MealSelection:
         order = self.create_order(
             employee_id=employee_id,
             vendor_id=vendor_id,
+            meal_date=meal_date,
             items=[
                 OrderItemSnapshot(
                     item_id=item_id,
@@ -173,6 +180,21 @@ class EmployeeSelectionRepository:
             selections.extend(self._order_to_selection_schemas(order.id))
         return selections
 
+    def item_quantities_for_date(
+        self, *, meal_date: date, vendor_ids: list[int] | None = None
+    ) -> dict[int, int]:
+        vendor_filter = set(vendor_ids) if vendor_ids is not None else None
+        quantities: dict[int, int] = {}
+        for order in self._orders.values():
+            if order.meal_date != meal_date or order.status == "cancelled":
+                continue
+            if vendor_filter is not None and order.vendor_id not in vendor_filter:
+                continue
+            for item in self._items.values():
+                if item.order_id == order.id:
+                    quantities[item.item_id] = quantities.get(item.item_id, 0) + item.quantity
+        return quantities
+
     def _order_to_schema(self, order: _OrderRecord) -> EmployeeOrder:
         items = [r for r in self._items.values() if r.order_id == order.id]
         items.sort(key=lambda r: r.id)
@@ -181,6 +203,7 @@ class EmployeeSelectionRepository:
             id=order.id,
             employee_id=order.employee_id,
             vendor_id=order.vendor_id,
+            meal_date=order.meal_date,
             status=order.status,
             items=schema_items,
             total_price_cents=sum(item.total_price_cents for item in schema_items),

--- a/backend/repositories/postgres_employee_selection_repository.py
+++ b/backend/repositories/postgres_employee_selection_repository.py
@@ -1,13 +1,27 @@
 from __future__ import annotations
 
+from datetime import date
+
 from backend.db.connection import get_connection
-from backend.schemas.employee import MealSelection
+from backend.repositories.employee_selection_repository import OrderItemSnapshot
+from backend.schemas.employee import EmployeeOrder, EmployeeOrderItem, MealSelection
 
 
-def _to_schema(row) -> MealSelection:
+def _selection_to_schema(row) -> MealSelection:
     d = dict(row)
     d["total_price_cents"] = d["quantity"] * d["unit_price_cents"]
     return MealSelection(**d)
+
+
+def _order_item_to_schema(row) -> EmployeeOrderItem:
+    return EmployeeOrderItem(**dict(row))
+
+
+def _order_to_schema(order_row, item_rows) -> EmployeeOrder:
+    order = dict(order_row)
+    items = [_order_item_to_schema(row) for row in item_rows]
+    order["items"] = items
+    return EmployeeOrder(**order)
 
 
 class PostgresEmployeeSelectionRepository:
@@ -20,44 +34,204 @@ class PostgresEmployeeSelectionRepository:
         item_name: str,
         quantity: int,
         unit_price_cents: int,
+        meal_date: date | None = None,
     ) -> MealSelection:
+        order = self.create_order(
+            employee_id=employee_id,
+            vendor_id=vendor_id,
+            meal_date=meal_date,
+            items=[
+                OrderItemSnapshot(
+                    item_id=item_id,
+                    item_name=item_name,
+                    quantity=quantity,
+                    unit_price_cents=unit_price_cents,
+                )
+            ],
+        )
+        item = order.items[0]
+        return MealSelection(
+            id=item.id,
+            order_id=order.id,
+            employee_id=order.employee_id,
+            vendor_id=order.vendor_id,
+            meal_date=order.meal_date,
+            item_id=item.item_id,
+            item_name=item.item_name,
+            quantity=item.quantity,
+            unit_price_cents=item.unit_price_cents,
+            total_price_cents=item.total_price_cents,
+            created_at=order.created_at,
+        )
+
+    def create_order(
+        self,
+        *,
+        employee_id: int,
+        vendor_id: int,
+        items: list[OrderItemSnapshot],
+        meal_date: date | None = None,
+    ) -> EmployeeOrder:
+        total_price_cents = sum(item.quantity * item.unit_price_cents for item in items)
         with get_connection() as conn:
-            row = conn.execute(
+            order_row = conn.execute(
                 """
-                INSERT INTO meal_selections
-                    (employee_id, vendor_id, item_id, item_name, quantity, unit_price_cents)
-                VALUES (%s, %s, %s, %s, %s, %s)
-                RETURNING id, employee_id, vendor_id, item_id, item_name,
-                          quantity, unit_price_cents, created_at
+                INSERT INTO orders (employee_id, vendor_id, meal_date, total_price_cents)
+                VALUES (%s, %s, %s, %s)
+                RETURNING id, employee_id, vendor_id, meal_date, status,
+                          total_price_cents, created_at, updated_at, cancelled_at
                 """,
-                (employee_id, vendor_id, item_id, item_name, quantity, unit_price_cents),
+                (employee_id, vendor_id, meal_date, total_price_cents),
             ).fetchone()
-        return _to_schema(row)
+            order_id = order_row["id"]
+            item_rows = []
+            for item in items:
+                item_rows.append(
+                    conn.execute(
+                        """
+                        INSERT INTO order_items (
+                            order_id, item_id, item_name, quantity,
+                            unit_price_cents, total_price_cents
+                        )
+                        VALUES (%s, %s, %s, %s, %s, %s)
+                        RETURNING id, order_id, item_id, item_name, quantity,
+                                  unit_price_cents, total_price_cents
+                        """,
+                        (
+                            order_id,
+                            item.item_id,
+                            item.item_name,
+                            item.quantity,
+                            item.unit_price_cents,
+                            item.quantity * item.unit_price_cents,
+                        ),
+                    ).fetchone()
+                )
+        return _order_to_schema(order_row, item_rows)
 
     def list(self, *, employee_id: int) -> list[MealSelection]:
-        with get_connection() as conn:
-            rows = conn.execute(
-                """
-                SELECT id, employee_id, vendor_id, item_id, item_name,
-                       quantity, unit_price_cents, created_at
-                FROM meal_selections
-                WHERE employee_id = %s
-                ORDER BY id
-                """,
-                (employee_id,),
-            ).fetchall()
-        return [_to_schema(r) for r in rows]
+        selections: list[MealSelection] = []
+        for order in self.list_orders(employee_id=employee_id):
+            for item in order.items:
+                selections.append(
+                    MealSelection(
+                        id=item.id,
+                        order_id=order.id,
+                        employee_id=order.employee_id,
+                        vendor_id=order.vendor_id,
+                        meal_date=order.meal_date,
+                        item_id=item.item_id,
+                        item_name=item.item_name,
+                        quantity=item.quantity,
+                        unit_price_cents=item.unit_price_cents,
+                        total_price_cents=item.total_price_cents,
+                        created_at=order.created_at,
+                    )
+                )
+        return selections
 
     def list_by_vendor(self, *, vendor_id: int) -> list[MealSelection]:
         with get_connection() as conn:
             rows = conn.execute(
                 """
-                SELECT id, employee_id, vendor_id, item_id, item_name,
-                       quantity, unit_price_cents, created_at
-                FROM meal_selections
-                WHERE vendor_id = %s
-                ORDER BY id
+                SELECT oi.id, o.id AS order_id, o.employee_id, o.vendor_id,
+                       o.meal_date, oi.item_id, oi.item_name, oi.quantity,
+                       oi.unit_price_cents, o.created_at
+                FROM orders o
+                JOIN order_items oi ON oi.order_id = o.id
+                WHERE o.vendor_id = %s
+                ORDER BY oi.id
                 """,
                 (vendor_id,),
             ).fetchall()
-        return [_to_schema(r) for r in rows]
+        return [_selection_to_schema(r) for r in rows]
+
+    def list_orders(self, *, employee_id: int) -> list[EmployeeOrder]:
+        with get_connection() as conn:
+            order_rows = conn.execute(
+                """
+                SELECT id, employee_id, vendor_id, meal_date, status,
+                       total_price_cents, created_at, updated_at, cancelled_at
+                FROM orders
+                WHERE employee_id = %s
+                ORDER BY id
+                """,
+                (employee_id,),
+            ).fetchall()
+            return [self._hydrate_order(conn, row) for row in order_rows]
+
+    def get_order(self, *, employee_id: int, order_id: int) -> EmployeeOrder | None:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT id, employee_id, vendor_id, meal_date, status,
+                       total_price_cents, created_at, updated_at, cancelled_at
+                FROM orders
+                WHERE employee_id = %s AND id = %s
+                """,
+                (employee_id, order_id),
+            ).fetchone()
+            if row is None:
+                return None
+            return self._hydrate_order(conn, row)
+
+    def cancel_order(self, *, employee_id: int, order_id: int) -> EmployeeOrder | None:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                UPDATE orders
+                SET status = 'cancelled', updated_at = NOW(), cancelled_at = NOW()
+                WHERE employee_id = %s AND id = %s AND status = 'pending'
+                RETURNING id, employee_id, vendor_id, meal_date, status,
+                          total_price_cents, created_at, updated_at, cancelled_at
+                """,
+                (employee_id, order_id),
+            ).fetchone()
+            if row is None:
+                row = conn.execute(
+                    """
+                    SELECT id, employee_id, vendor_id, meal_date, status,
+                           total_price_cents, created_at, updated_at, cancelled_at
+                    FROM orders
+                    WHERE employee_id = %s AND id = %s
+                    """,
+                    (employee_id, order_id),
+                ).fetchone()
+                if row is None:
+                    return None
+            return self._hydrate_order(conn, row)
+
+    def item_quantities_for_date(
+        self, *, meal_date: date, vendor_ids: list[int] | None = None
+    ) -> dict[int, int]:
+        where = ["o.meal_date = %s", "o.status <> 'cancelled'"]
+        values: list[object] = [meal_date]
+        if vendor_ids is not None:
+            where.append("o.vendor_id = ANY(%s)")
+            values.append(vendor_ids)
+
+        with get_connection() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT oi.item_id, COALESCE(SUM(oi.quantity), 0) AS quantity
+                FROM orders o
+                JOIN order_items oi ON oi.order_id = o.id
+                WHERE {" AND ".join(where)}
+                GROUP BY oi.item_id
+                """,
+                values,
+            ).fetchall()
+        return {int(row["item_id"]): int(row["quantity"]) for row in rows}
+
+    def _hydrate_order(self, conn, order_row) -> EmployeeOrder:
+        item_rows = conn.execute(
+            """
+            SELECT id, order_id, item_id, item_name, quantity,
+                   unit_price_cents, total_price_cents
+            FROM order_items
+            WHERE order_id = %s
+            ORDER BY id
+            """,
+            (order_row["id"],),
+        ).fetchall()
+        return _order_to_schema(order_row, item_rows)

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -20,6 +20,8 @@ from backend.schemas.employee import (
     EmployeeVendor,
     MealSelection,
     MealSelectionCreate,
+    RandomMealDraw,
+    RandomMealDrawRequest,
 )
 from backend.services.employee_ordering_service import EmployeeOrderingService
 
@@ -69,6 +71,15 @@ def list_menu(
     available: Annotated[bool | None, Query()] = True,
 ) -> list[EmployeeMenuItem]:
     return service.list_menu(vendor_id, category_id=category_id, available=available)
+
+
+@router.post("/random-meals/draw", response_model=RandomMealDraw)
+def draw_random_meal(
+    payload: RandomMealDrawRequest,
+    _employee_role: Annotated[None, Depends(require_employee_role)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> RandomMealDraw:
+    return service.draw_random_meal(payload)
 
 
 @router.post("/vendors/{vendor_id}/selections", response_model=MealSelection, status_code=status.HTTP_201_CREATED)

--- a/backend/schemas/employee.py
+++ b/backend/schemas/employee.py
@@ -1,7 +1,7 @@
 """Employee-facing vendor, menu, order, and meal selection schemas."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -34,6 +34,7 @@ class EmployeeMenuItem(BaseModel):
 class MealSelectionCreate(BaseModel):
     item_id: int
     quantity: int = Field(ge=1)
+    meal_date: date | None = None
 
 
 class MealSelection(BaseModel):
@@ -41,6 +42,7 @@ class MealSelection(BaseModel):
     order_id: int | None = None
     employee_id: int
     vendor_id: int
+    meal_date: date | None = None
     item_id: int
     item_name: str
     quantity: int
@@ -59,6 +61,7 @@ class EmployeeOrderItemCreate(BaseModel):
 
 class EmployeeOrderCreate(BaseModel):
     items: list[EmployeeOrderItemCreate] = Field(min_length=1)
+    meal_date: date | None = None
 
 
 class EmployeeOrderItem(BaseModel):
@@ -75,9 +78,22 @@ class EmployeeOrder(BaseModel):
     id: int
     employee_id: int
     vendor_id: int
+    meal_date: date | None = None
     status: OrderStatus
     items: list[EmployeeOrderItem]
     total_price_cents: int
     created_at: datetime
     updated_at: datetime
     cancelled_at: datetime | None = None
+
+
+class RandomMealDrawRequest(BaseModel):
+    meal_date: date
+    vendor_ids: list[int] | None = None
+
+
+class RandomMealDraw(BaseModel):
+    meal_date: date
+    vendor: EmployeeVendor
+    item: EmployeeMenuItem
+    remaining_quantity: int | None = None

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -1,6 +1,9 @@
 """Employee-facing read and meal selection workflow."""
 from __future__ import annotations
 
+import random
+from datetime import date
+
 from backend.core.errors import CodedHTTPException
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository, OrderItemSnapshot
 from backend.repositories.menu_item_repository import MenuItemRepository
@@ -13,6 +16,8 @@ from backend.schemas.employee import (
     EmployeeVendor,
     MealSelection,
     MealSelectionCreate,
+    RandomMealDraw,
+    RandomMealDrawRequest,
 )
 from backend.schemas.vendor_self import MenuItem as VendorMenuItem
 
@@ -52,6 +57,7 @@ class EmployeeOrderingService:
             employee_id,
             vendor_id,
             EmployeeOrderCreate(
+                meal_date=payload.meal_date,
                 items=[
                     EmployeeOrderItemCreate(
                         item_id=payload.item_id,
@@ -66,6 +72,7 @@ class EmployeeOrderingService:
             order_id=order.id,
             employee_id=order.employee_id,
             vendor_id=order.vendor_id,
+            meal_date=order.meal_date,
             item_id=item.item_id,
             item_name=item.item_name,
             quantity=item.quantity,
@@ -81,11 +88,58 @@ class EmployeeOrderingService:
         self, employee_id: int, vendor_id: int, payload: EmployeeOrderCreate
     ) -> EmployeeOrder:
         self._get_approved_vendor(vendor_id)
-        snapshots = self._build_order_items(vendor_id, payload)
+        meal_date = payload.meal_date or date.today()
+        snapshots = self._build_order_items(vendor_id, payload, meal_date=meal_date)
         return self.selection_repository.create_order(
             employee_id=employee_id,
             vendor_id=vendor_id,
             items=snapshots,
+            meal_date=meal_date,
+        )
+
+    def draw_random_meal(self, payload: RandomMealDrawRequest) -> RandomMealDraw:
+        approved_vendors = {vendor.id: vendor for vendor in self.vendor_repository.list(status="approved")}
+        if payload.vendor_ids is None:
+            vendor_ids = list(approved_vendors)
+        else:
+            vendor_ids = list(dict.fromkeys(payload.vendor_ids))
+
+        if not vendor_ids:
+            raise CodedHTTPException(
+                status_code=400,
+                code="validation_error",
+                detail="at least one vendor must be selected",
+            )
+
+        missing_vendor_ids = [vendor_id for vendor_id in vendor_ids if vendor_id not in approved_vendors]
+        if missing_vendor_ids:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="vendor not found")
+
+        used_by_item = self.selection_repository.item_quantities_for_date(
+            meal_date=payload.meal_date,
+            vendor_ids=vendor_ids,
+        )
+        candidates: list[tuple[VendorRecord, VendorMenuItem, int | None]] = []
+        for vendor_id in vendor_ids:
+            vendor = approved_vendors[vendor_id]
+            for item in self.menu_item_repository.list(vendor_id=vendor_id, available=True):
+                remaining = self._remaining_quantity(item, used_by_item.get(item.id, 0))
+                if remaining is None or remaining > 0:
+                    candidates.append((vendor, item, remaining))
+
+        if not candidates:
+            raise CodedHTTPException(
+                status_code=409,
+                code="no_random_meal_available",
+                detail="no available meals remain for the selected date and vendors",
+            )
+
+        vendor, item, remaining = random.choice(candidates)
+        return RandomMealDraw(
+            meal_date=payload.meal_date,
+            vendor=self._vendor_to_schema(vendor),
+            item=self._menu_item_to_schema(item),
+            remaining_quantity=remaining,
         )
 
     def list_my_orders(self, employee_id: int) -> list[EmployeeOrder]:
@@ -142,7 +196,7 @@ class EmployeeOrderingService:
         )
 
     def _build_order_items(
-        self, vendor_id: int, payload: EmployeeOrderCreate
+        self, vendor_id: int, payload: EmployeeOrderCreate, *, meal_date: date
     ) -> list[OrderItemSnapshot]:
         requested_by_item: dict[int, int] = {}
         for requested in payload.items:
@@ -150,6 +204,10 @@ class EmployeeOrderingService:
                 requested_by_item.get(requested.item_id, 0) + requested.quantity
             )
 
+        used_by_item = self.selection_repository.item_quantities_for_date(
+            meal_date=meal_date,
+            vendor_ids=[vendor_id],
+        )
         snapshots: list[OrderItemSnapshot] = []
         for requested in payload.items:
             item = self.menu_item_repository.get(vendor_id=vendor_id, item_id=requested.item_id)
@@ -157,11 +215,12 @@ class EmployeeOrderingService:
                 raise CodedHTTPException(status_code=404, code="not_found", detail="menu item not found")
             if not item.available:
                 raise CodedHTTPException(status_code=409, code="item_unavailable", detail="menu item unavailable")
-            if item.daily_quota is not None and requested_by_item[item.id] > item.daily_quota:
+            used_quantity = used_by_item.get(item.id, 0)
+            if item.daily_quota is not None and used_quantity + requested_by_item[item.id] > item.daily_quota:
                 raise CodedHTTPException(
                     status_code=409,
                     code="quantity_exceeds_daily_quota",
-                    detail="quantity exceeds daily quota",
+                    detail="quantity exceeds remaining daily quota",
                 )
 
             snapshots.append(
@@ -173,3 +232,9 @@ class EmployeeOrderingService:
                 )
             )
         return snapshots
+
+    @staticmethod
+    def _remaining_quantity(item: VendorMenuItem, used_quantity: int) -> int | None:
+        if item.daily_quota is None:
+            return None
+        return max(item.daily_quota - used_quantity, 0)

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import random
-from datetime import date
+from datetime import date, timedelta
 
 from backend.core.errors import CodedHTTPException
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository, OrderItemSnapshot
@@ -20,6 +20,8 @@ from backend.schemas.employee import (
     RandomMealDrawRequest,
 )
 from backend.schemas.vendor_self import MenuItem as VendorMenuItem
+
+MEAL_DATE_WINDOW_DAYS = 7
 
 
 class EmployeeOrderingService:
@@ -89,6 +91,7 @@ class EmployeeOrderingService:
     ) -> EmployeeOrder:
         self._get_approved_vendor(vendor_id)
         meal_date = payload.meal_date or date.today()
+        self._ensure_meal_date_in_window(meal_date)
         snapshots = self._build_order_items(vendor_id, payload, meal_date=meal_date)
         return self.selection_repository.create_order(
             employee_id=employee_id,
@@ -98,6 +101,7 @@ class EmployeeOrderingService:
         )
 
     def draw_random_meal(self, payload: RandomMealDrawRequest) -> RandomMealDraw:
+        self._ensure_meal_date_in_window(payload.meal_date)
         approved_vendors = {vendor.id: vendor for vendor in self.vendor_repository.list(status="approved")}
         if payload.vendor_ids is None:
             vendor_ids = list(approved_vendors)
@@ -238,3 +242,14 @@ class EmployeeOrderingService:
         if item.daily_quota is None:
             return None
         return max(item.daily_quota - used_quantity, 0)
+
+    @staticmethod
+    def _ensure_meal_date_in_window(meal_date: date) -> None:
+        today = date.today()
+        max_date = today + timedelta(days=MEAL_DATE_WINDOW_DAYS - 1)
+        if meal_date < today or meal_date > max_date:
+            raise CodedHTTPException(
+                status_code=400,
+                code="validation_error",
+                detail="meal date must be within today and the next 6 days",
+            )

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -196,6 +196,90 @@ def test_create_order_sums_duplicate_item_quantities_for_quota() -> None:
     assert resp.json()["code"] == "quantity_exceeds_daily_quota"
 
 
+def test_create_order_tracks_quota_by_meal_date() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=2)
+    client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"meal_date": "2026-06-01", "items": [{"item_id": item.id, "quantity": 2}]},
+    )
+
+    same_date = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(200),
+        json={"meal_date": "2026-06-01", "items": [{"item_id": item.id, "quantity": 1}]},
+    )
+    other_date = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(200),
+        json={"meal_date": "2026-06-02", "items": [{"item_id": item.id, "quantity": 1}]},
+    )
+
+    assert same_date.status_code == 409
+    assert same_date.json()["code"] == "quantity_exceeds_daily_quota"
+    assert other_date.status_code == 201
+    assert other_date.json()["meal_date"] == "2026-06-02"
+
+
+def test_draw_random_meal_uses_selected_vendors_and_remaining_quota() -> None:
+    client, item_repo, _ = _setup()
+    sold_out = item_repo.create(vendor_id=1, name="Sold Out", price_cents=80, daily_quota=1)
+    available = item_repo.create(vendor_id=1, name="Noodles", price_cents=130, daily_quota=3)
+    item_repo.create(vendor_id=1, name="Hidden Soup", price_cents=90, available=False)
+    client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"meal_date": "2026-06-01", "items": [{"item_id": sold_out.id, "quantity": 1}]},
+    )
+
+    resp = client.post(
+        "/employee/random-meals/draw",
+        headers=_browse_h(),
+        json={"meal_date": "2026-06-01", "vendor_ids": [1]},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["meal_date"] == "2026-06-01"
+    assert body["vendor"]["id"] == 1
+    assert body["item"]["id"] == available.id
+    assert body["remaining_quantity"] == 3
+
+
+def test_draw_random_meal_returns_409_when_no_meals_remain() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=1)
+    client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"meal_date": "2026-06-01", "items": [{"item_id": item.id, "quantity": 1}]},
+    )
+
+    resp = client.post(
+        "/employee/random-meals/draw",
+        headers=_browse_h(),
+        json={"meal_date": "2026-06-01", "vendor_ids": [1]},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "no_random_meal_available"
+
+
+def test_confirm_random_meal_selection_records_meal_date() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+
+    resp = client.post(
+        "/employee/vendors/1/selections",
+        headers=_h(100),
+        json={"item_id": item.id, "quantity": 1, "meal_date": "2026-06-01"},
+    )
+
+    assert resp.status_code == 201
+    assert resp.json()["meal_date"] == "2026-06-01"
+
+
 def test_my_selections_are_scoped_by_employee() -> None:
     client, item_repo, _ = _setup()
     item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -1,4 +1,6 @@
 """Employee-facing vendor browsing, menu browsing, and meal selection APIs."""
+from datetime import date, timedelta
+
 from fastapi.testclient import TestClient
 
 from backend.core.vendor_identity import get_vendor_profile_repository
@@ -41,6 +43,10 @@ def _h(user_id: int = 100) -> dict[str, str]:
 
 def _browse_h() -> dict[str, str]:
     return {"x-user-role": "employee"}
+
+
+def _meal_date(days_from_today: int = 0) -> str:
+    return (date.today() + timedelta(days=days_from_today)).isoformat()
 
 
 def teardown_function() -> None:
@@ -199,27 +205,56 @@ def test_create_order_sums_duplicate_item_quantities_for_quota() -> None:
 def test_create_order_tracks_quota_by_meal_date() -> None:
     client, item_repo, _ = _setup()
     item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=2)
+    meal_date = _meal_date()
+    other_meal_date = _meal_date(1)
     client.post(
         "/employee/vendors/1/orders",
         headers=_h(100),
-        json={"meal_date": "2026-06-01", "items": [{"item_id": item.id, "quantity": 2}]},
+        json={"meal_date": meal_date, "items": [{"item_id": item.id, "quantity": 2}]},
     )
 
     same_date = client.post(
         "/employee/vendors/1/orders",
         headers=_h(200),
-        json={"meal_date": "2026-06-01", "items": [{"item_id": item.id, "quantity": 1}]},
+        json={"meal_date": meal_date, "items": [{"item_id": item.id, "quantity": 1}]},
     )
     other_date = client.post(
         "/employee/vendors/1/orders",
         headers=_h(200),
-        json={"meal_date": "2026-06-02", "items": [{"item_id": item.id, "quantity": 1}]},
+        json={"meal_date": other_meal_date, "items": [{"item_id": item.id, "quantity": 1}]},
     )
 
     assert same_date.status_code == 409
     assert same_date.json()["code"] == "quantity_exceeds_daily_quota"
     assert other_date.status_code == 201
-    assert other_date.json()["meal_date"] == "2026-06-02"
+    assert other_date.json()["meal_date"] == other_meal_date
+
+
+def test_create_order_rejects_meal_date_outside_next_seven_days() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+
+    past = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"meal_date": _meal_date(-1), "items": [{"item_id": item.id, "quantity": 1}]},
+    )
+    too_far = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"meal_date": _meal_date(7), "items": [{"item_id": item.id, "quantity": 1}]},
+    )
+    last_allowed = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"meal_date": _meal_date(6), "items": [{"item_id": item.id, "quantity": 1}]},
+    )
+
+    assert past.status_code == 400
+    assert past.json()["code"] == "validation_error"
+    assert too_far.status_code == 400
+    assert too_far.json()["code"] == "validation_error"
+    assert last_allowed.status_code == 201
 
 
 def test_draw_random_meal_uses_selected_vendors_and_remaining_quota() -> None:
@@ -227,21 +262,22 @@ def test_draw_random_meal_uses_selected_vendors_and_remaining_quota() -> None:
     sold_out = item_repo.create(vendor_id=1, name="Sold Out", price_cents=80, daily_quota=1)
     available = item_repo.create(vendor_id=1, name="Noodles", price_cents=130, daily_quota=3)
     item_repo.create(vendor_id=1, name="Hidden Soup", price_cents=90, available=False)
+    meal_date = _meal_date()
     client.post(
         "/employee/vendors/1/orders",
         headers=_h(100),
-        json={"meal_date": "2026-06-01", "items": [{"item_id": sold_out.id, "quantity": 1}]},
+        json={"meal_date": meal_date, "items": [{"item_id": sold_out.id, "quantity": 1}]},
     )
 
     resp = client.post(
         "/employee/random-meals/draw",
         headers=_browse_h(),
-        json={"meal_date": "2026-06-01", "vendor_ids": [1]},
+        json={"meal_date": meal_date, "vendor_ids": [1]},
     )
 
     assert resp.status_code == 200
     body = resp.json()
-    assert body["meal_date"] == "2026-06-01"
+    assert body["meal_date"] == meal_date
     assert body["vendor"]["id"] == 1
     assert body["item"]["id"] == available.id
     assert body["remaining_quantity"] == 3
@@ -250,34 +286,50 @@ def test_draw_random_meal_uses_selected_vendors_and_remaining_quota() -> None:
 def test_draw_random_meal_returns_409_when_no_meals_remain() -> None:
     client, item_repo, _ = _setup()
     item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=1)
+    meal_date = _meal_date()
     client.post(
         "/employee/vendors/1/orders",
         headers=_h(100),
-        json={"meal_date": "2026-06-01", "items": [{"item_id": item.id, "quantity": 1}]},
+        json={"meal_date": meal_date, "items": [{"item_id": item.id, "quantity": 1}]},
     )
 
     resp = client.post(
         "/employee/random-meals/draw",
         headers=_browse_h(),
-        json={"meal_date": "2026-06-01", "vendor_ids": [1]},
+        json={"meal_date": meal_date, "vendor_ids": [1]},
     )
 
     assert resp.status_code == 409
     assert resp.json()["code"] == "no_random_meal_available"
 
 
+def test_draw_random_meal_rejects_meal_date_outside_next_seven_days() -> None:
+    client, item_repo, _ = _setup()
+    item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+
+    resp = client.post(
+        "/employee/random-meals/draw",
+        headers=_browse_h(),
+        json={"meal_date": _meal_date(7), "vendor_ids": [1]},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"
+
+
 def test_confirm_random_meal_selection_records_meal_date() -> None:
     client, item_repo, _ = _setup()
     item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+    meal_date = _meal_date()
 
     resp = client.post(
         "/employee/vendors/1/selections",
         headers=_h(100),
-        json={"item_id": item.id, "quantity": 1, "meal_date": "2026-06-01"},
+        json={"item_id": item.id, "quantity": 1, "meal_date": meal_date},
     )
 
     assert resp.status_code == 201
-    assert resp.json()["meal_date"] == "2026-06-01"
+    assert resp.json()["meal_date"] == meal_date
 
 
 def test_my_selections_are_scoped_by_employee() -> None:

--- a/frontend/src/api/employee.js
+++ b/frontend/src/api/employee.js
@@ -4,7 +4,9 @@ import { MOCK_VENDORS, MOCK_MENU } from "./mockData";
 function withMockFallback(apiCall, mockResult) {
   return apiCall().catch((err) => {
     // TypeError = fetch failed (no proxy); 502/503/504 = Vite proxy can't reach backend
-    if (err instanceof TypeError || (err.status != null && err.status >= 500)) return mockResult;
+    if (err instanceof TypeError || (err.status != null && err.status >= 500)) {
+      return typeof mockResult === "function" ? mockResult() : mockResult;
+    }
     throw err;
   });
 }
@@ -20,11 +22,11 @@ export function getVendor(vendorId) {
   );
 }
 
-export function submitSelection(vendorId, { itemId, quantity }) {
+export function submitSelection(vendorId, { itemId, quantity, mealDate }) {
   return apiFetch(`/employee/vendors/${vendorId}/selections`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ item_id: itemId, quantity }),
+    body: JSON.stringify({ item_id: itemId, quantity, meal_date: mealDate }),
   });
 }
 
@@ -41,5 +43,41 @@ export function getVendorMenu(vendorId, { available } = {}) {
     (MOCK_MENU[Number(vendorId)] ?? []).filter(
       (item) => available == null || item.available === available,
     ),
+  );
+}
+
+function mockRandomMeal({ mealDate, vendorIds }) {
+  const selectedIds = vendorIds?.length ? vendorIds.map(Number) : MOCK_VENDORS.map((v) => v.id);
+  const candidates = selectedIds.flatMap((vendorId) =>
+    (MOCK_MENU[vendorId] ?? [])
+      .filter((item) => item.available && item.daily_quota !== 0)
+      .map((item) => ({
+        meal_date: mealDate,
+        vendor: MOCK_VENDORS.find((v) => v.id === vendorId),
+        item,
+        remaining_quantity: item.daily_quota,
+      })),
+  ).filter((entry) => entry.vendor);
+
+  if (candidates.length === 0) {
+    const err = new Error("No meals remain for the selected restaurants.");
+    err.status = 409;
+    err.code = "no_random_meal_available";
+    throw err;
+  }
+
+  return candidates[Math.floor(Math.random() * candidates.length)];
+}
+
+export function drawRandomMeal({ mealDate, vendorIds }) {
+  const payload = { meal_date: mealDate };
+  if (vendorIds != null) payload.vendor_ids = vendorIds;
+  return withMockFallback(
+    () => apiFetch("/employee/random-meals/draw", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    }),
+    () => mockRandomMeal({ mealDate, vendorIds }),
   );
 }

--- a/frontend/src/layout/navigation.js
+++ b/frontend/src/layout/navigation.js
@@ -8,6 +8,7 @@ export const navigationByRole = {
   employee: [
     { label: "Dashboard", to: "/employee" },
     { label: "Browse Meals", to: "/employee/menu" },
+    { label: "Random Meal", to: "/employee/random-meal" },
     { label: "Current Orders", to: "/employee/orders" },
     { label: "Notifications", to: "/notifications" },
   ],

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -4,22 +4,31 @@ import { drawRandomMeal, submitSelection } from "../../api/employee";
 import { useVendors } from "../../hooks/useVendors";
 import { formatPrice, quotaLabel } from "../../utils/format";
 
-function todayIso() {
-  return new Date().toISOString().slice(0, 10);
+function toLocalIso(date) {
+  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+  return localDate.toISOString().slice(0, 10);
+}
+
+function addDaysIso(days) {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return toLocalIso(date);
 }
 
 function drawErrorMessage(err) {
   if (err.code === "no_random_meal_available") {
     return "No available meals remain for the selected date and restaurants.";
   }
-  if (err.code === "validation_error") return "Choose at least one restaurant.";
+  if (err.code === "validation_error") return err.message ?? "Choose a valid date and restaurant range.";
   return "Could not draw a meal. Please try again.";
 }
 
 export default function RandomMealPage() {
   const navigate = useNavigate();
   const { vendors, loading, error } = useVendors();
-  const [mealDate, setMealDate] = useState(todayIso());
+  const minMealDate = addDaysIso(0);
+  const maxMealDate = addDaysIso(6);
+  const [mealDate, setMealDate] = useState(minMealDate);
   const [allVendors, setAllVendors] = useState(true);
   const [selectedVendorIds, setSelectedVendorIds] = useState([]);
   const [draw, setDraw] = useState(null);
@@ -29,7 +38,8 @@ export default function RandomMealPage() {
   const [submitted, setSubmitted] = useState(false);
 
   const selectedCount = allVendors ? vendors.length : selectedVendorIds.length;
-  const canDraw = mealDate && selectedCount > 0 && !drawing && !loading;
+  const mealDateInRange = mealDate >= minMealDate && mealDate <= maxMealDate;
+  const canDraw = mealDateInRange && selectedCount > 0 && !drawing && !loading;
   const remainingLabel = useMemo(() => {
     if (!draw) return null;
     if (draw.remaining_quantity == null) return "Unlimited";
@@ -97,6 +107,8 @@ export default function RandomMealPage() {
           <input
             className="date-input"
             id="random-meal-date"
+            max={maxMealDate}
+            min={minMealDate}
             type="date"
             value={mealDate}
             onChange={(event) => {

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -1,0 +1,219 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { drawRandomMeal, submitSelection } from "../../api/employee";
+import { useVendors } from "../../hooks/useVendors";
+import { formatPrice, quotaLabel } from "../../utils/format";
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function drawErrorMessage(err) {
+  if (err.code === "no_random_meal_available") {
+    return "No available meals remain for the selected date and restaurants.";
+  }
+  if (err.code === "validation_error") return "Choose at least one restaurant.";
+  return "Could not draw a meal. Please try again.";
+}
+
+export default function RandomMealPage() {
+  const navigate = useNavigate();
+  const { vendors, loading, error } = useVendors();
+  const [mealDate, setMealDate] = useState(todayIso());
+  const [allVendors, setAllVendors] = useState(true);
+  const [selectedVendorIds, setSelectedVendorIds] = useState([]);
+  const [draw, setDraw] = useState(null);
+  const [drawError, setDrawError] = useState(null);
+  const [drawing, setDrawing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const selectedCount = allVendors ? vendors.length : selectedVendorIds.length;
+  const canDraw = mealDate && selectedCount > 0 && !drawing && !loading;
+  const remainingLabel = useMemo(() => {
+    if (!draw) return null;
+    if (draw.remaining_quantity == null) return "Unlimited";
+    return `${draw.remaining_quantity} left`;
+  }, [draw]);
+
+  function toggleVendor(vendorId) {
+    setSelectedVendorIds((current) =>
+      current.includes(vendorId)
+        ? current.filter((id) => id !== vendorId)
+        : [...current, vendorId],
+    );
+    setDraw(null);
+    setSubmitted(false);
+  }
+
+  async function handleDraw() {
+    setDrawing(true);
+    setDrawError(null);
+    setSubmitted(false);
+    try {
+      const result = await drawRandomMeal({
+        mealDate,
+        vendorIds: allVendors ? null : selectedVendorIds,
+      });
+      setDraw(result);
+    } catch (err) {
+      setDraw(null);
+      setDrawError(drawErrorMessage(err));
+    } finally {
+      setDrawing(false);
+    }
+  }
+
+  async function handleConfirm() {
+    if (!draw) return;
+    setSubmitting(true);
+    setDrawError(null);
+    try {
+      await submitSelection(draw.vendor.id, {
+        itemId: draw.item.id,
+        quantity: 1,
+        mealDate,
+      });
+      setSubmitted(true);
+    } catch (err) {
+      setDrawError(drawErrorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div>
+      <div className="page-header">
+        <p className="eyebrow">Employee / Random Meal</p>
+        <h2>Let the menu decide</h2>
+      </div>
+
+      <section className="random-meal-layout">
+        <div className="panel random-meal-controls">
+          <label className="field-label" htmlFor="random-meal-date">
+            Meal date
+          </label>
+          <input
+            className="date-input"
+            id="random-meal-date"
+            type="date"
+            value={mealDate}
+            onChange={(event) => {
+              setMealDate(event.target.value);
+              setDraw(null);
+              setSubmitted(false);
+            }}
+          />
+
+          <div className="random-vendor-header">
+            <div>
+              <p className="field-label">Restaurants</p>
+              <p className="panel-copy">{selectedCount} selected</p>
+            </div>
+            <label className="toggle-row">
+              <input
+                type="checkbox"
+                checked={allVendors}
+                onChange={(event) => {
+                  setAllVendors(event.target.checked);
+                  setDraw(null);
+                  setSubmitted(false);
+                }}
+              />
+              <span>All restaurants</span>
+            </label>
+          </div>
+
+          {loading && <p className="loading-state compact-state">Loading restaurants...</p>}
+          {error && <p className="error-state">Could not load restaurants.</p>}
+
+          {!loading && !error && !allVendors && (
+            <div className="vendor-check-list">
+              {vendors.map((vendor) => (
+                <label className="vendor-check-row" key={vendor.id}>
+                  <input
+                    type="checkbox"
+                    checked={selectedVendorIds.includes(vendor.id)}
+                    onChange={() => toggleVendor(vendor.id)}
+                  />
+                  <span>{vendor.name}</span>
+                </label>
+              ))}
+            </div>
+          )}
+
+          <button
+            className="primary-button random-draw-button"
+            type="button"
+            onClick={handleDraw}
+            disabled={!canDraw}
+          >
+            {drawing ? "Drawing..." : draw ? "Draw again" : "Draw a meal"}
+          </button>
+        </div>
+
+        <div className="panel random-meal-result">
+          {!draw && !drawError && (
+            <div className="random-placeholder">
+              <p className="eyebrow">Ready</p>
+              <h3>Pick a date and restaurant range.</h3>
+              <p className="panel-copy">The result will be selected completely at random from meals that still have quota left.</p>
+            </div>
+          )}
+
+          {drawError && <p className="error-state">{drawError}</p>}
+
+          {draw && (
+            <div className="random-result-card">
+              <p className="eyebrow">{draw.vendor.name}</p>
+              <h3>{draw.item.name}</h3>
+              <p className="random-price">{formatPrice(draw.item.price_cents)}</p>
+              {draw.item.description && (
+                <p className="panel-copy">{draw.item.description}</p>
+              )}
+              <div className="item-badges">
+                <span className="badge badge-available">Available</span>
+                <span className="badge badge-quota">
+                  {remainingLabel ?? quotaLabel(draw.item.daily_quota)}
+                </span>
+              </div>
+
+              {submitted ? (
+                <div className="success-state">
+                  <p>Order sent for {mealDate}.</p>
+                  <button
+                    className="ghost-button"
+                    type="button"
+                    onClick={() => navigate("/employee/orders")}
+                  >
+                    View orders
+                  </button>
+                </div>
+              ) : (
+                <div className="random-result-actions">
+                  <button
+                    className="ghost-button"
+                    type="button"
+                    onClick={handleDraw}
+                    disabled={drawing || submitting}
+                  >
+                    Draw again
+                  </button>
+                  <button
+                    className="primary-button"
+                    type="button"
+                    onClick={handleConfirm}
+                    disabled={submitting}
+                  >
+                    {submitting ? "Sending..." : "Choose this meal"}
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -7,6 +7,7 @@ import CartPage from "../pages/employee/CartPage";
 import EmployeeHomePage from "../pages/employee/EmployeeHomePage";
 import MenuListPage from "../pages/employee/MenuListPage";
 import OrdersPage from "../pages/employee/OrdersPage";
+import RandomMealPage from "../pages/employee/RandomMealPage";
 import VendorMenuPage from "../pages/employee/VendorMenuPage";
 import ForbiddenPage from "../pages/ForbiddenPage";
 import LoginPage from "../pages/LoginPage";
@@ -55,6 +56,7 @@ export function AppRouter() {
             <Route element={<EmployeeHomePage />} path="/employee" />
             <Route element={<MenuListPage />} path="/employee/menu" />
             <Route element={<VendorMenuPage />} path="/employee/menu/:vendorId" />
+            <Route element={<RandomMealPage />} path="/employee/random-meal" />
             <Route element={<CartPage />} path="/employee/cart" />
             <Route element={<OrdersPage />} path="/employee/orders" />
           </Route>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -783,9 +783,138 @@ p {
   text-align: center;
 }
 
+.compact-state {
+  padding: 18px 0;
+}
+
+.random-meal-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.random-meal-controls {
+  display: grid;
+  gap: 18px;
+}
+
+.field-label {
+  color: var(--text);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.date-input {
+  width: 100%;
+  min-height: 48px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+  color: var(--text);
+  font: inherit;
+}
+
+.date-input:focus {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(200, 92, 44, 0.12);
+  outline: none;
+}
+
+.random-vendor-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+}
+
+.toggle-row,
+.vendor-check-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.toggle-row {
+  font-size: 0.9rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.vendor-check-list {
+  display: grid;
+  gap: 10px;
+  max-height: 320px;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.vendor-check-row {
+  min-height: 44px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.48);
+}
+
+.random-draw-button {
+  width: 100%;
+}
+
+.random-meal-result {
+  min-height: 360px;
+  display: grid;
+  align-items: center;
+}
+
+.random-placeholder {
+  display: grid;
+  gap: 12px;
+  max-width: 520px;
+}
+
+.random-placeholder h3,
+.random-result-card h3 {
+  font-size: 1.65rem;
+  line-height: 1.15;
+}
+
+.random-result-card {
+  display: grid;
+  gap: 14px;
+}
+
+.random-price {
+  color: var(--brand);
+  font-size: 2rem;
+  font-weight: 800;
+}
+
+.random-result-actions,
+.success-state {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.success-state {
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  background: rgba(47, 125, 74, 0.1);
+  color: var(--success);
+  font-weight: 700;
+}
+
 @media (max-width: 1080px) {
   .login-shell,
   .dashboard-grid,
+  .random-meal-layout,
   .app-shell {
     grid-template-columns: 1fr;
   }


### PR DESCRIPTION
## Summary
- Add an employee random meal picker endpoint that draws from date-scoped remaining meal availability.
- Add `meal_date` to employee order/selection flows and persist it through in-memory and PostgreSQL repositories.
- Add a new employee Random Meal page with date selection, restaurant scope selection, redraw, and confirm-to-order behavior.

## Tests
- `./.venv/Scripts/python.exe -m pytest backend/tests --basetemp=.pytest-tmp` -> 122 passed, 4 skipped

## Notes
- Frontend build was not run locally because this environment does not have `node`/`npm` on PATH.