### PR TITLE
fix(vendor): wire menu CRUD to backend API

### DIFF
--- a/frontend/src/api/vendor.js
+++ b/frontend/src/api/vendor.js
@@ -19,3 +19,23 @@ export function getMyMenu() {
 export function getMyOrders() {
   return apiFetch("/vendor/me/orders");
 }
+
+export function createMenuItem(data) {
+  return apiFetch("/vendor/me/menu", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function updateMenuItem(itemId, data) {
+  return apiFetch(`/vendor/me/menu/${itemId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteMenuItem(itemId) {
+  return apiFetch(`/vendor/me/menu/${itemId}`, { method: "DELETE" });
+}

--- a/frontend/src/pages/vendor/VendorMenuFormPage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuFormPage.jsx
@@ -47,20 +47,24 @@ export default function VendorMenuFormPage() {
     setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
   }
 
-  function handleSubmit(e) {
+  async function handleSubmit(e) {
     e.preventDefault();
     setError(null);
 
     if (!form.name.trim()) { setError("請填寫餐點名稱。"); return; }
     if (!form.price_cents || isNaN(parseFloat(form.price_cents))) { setError("請填寫有效價格。"); return; }
 
-    const data = formToData(form);
-    if (isEdit) {
-      updateItem(Number(itemId), data);
-    } else {
-      addItem(data);
+    try {
+      const data = formToData(form);
+      if (isEdit) {
+        await updateItem(Number(itemId), data);
+      } else {
+        await addItem(data);
+      }
+      navigate("/vendor/menu");
+    } catch (err) {
+      setError(err.message ?? "儲存失敗，請稍後再試。");
     }
-    navigate("/vendor/menu");
   }
 
   return (

--- a/frontend/src/pages/vendor/VendorMenuListPage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuListPage.jsx
@@ -6,9 +6,13 @@ export default function VendorMenuListPage() {
   const navigate = useNavigate();
   const { items, loading, error, removeItem } = useVendorMenu();
 
-  function handleDelete(item) {
+  async function handleDelete(item) {
     if (!window.confirm(`確定要刪除「${item.name}」嗎？`)) return;
-    removeItem(item.id);
+    try {
+      await removeItem(item.id);
+    } catch (err) {
+      alert(err.message ?? "刪除失敗，請稍後再試。");
+    }
   }
 
   return (

--- a/frontend/src/vendor/VendorMenuContext.jsx
+++ b/frontend/src/vendor/VendorMenuContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import { getMyMenu } from "../api/vendor";
+import { createMenuItem, deleteMenuItem, getMyMenu, updateMenuItem } from "../api/vendor";
 
 const VendorMenuContext = createContext(null);
 
@@ -19,26 +19,20 @@ export function VendorMenuProvider({ children }) {
     return () => { cancelled = true; };
   }, []);
 
-  function addItem(data) {
-    const newItem = {
-      ...data,
-      id: Date.now(),
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-    };
+  async function addItem(data) {
+    const newItem = await createMenuItem(data);
     setItems((prev) => [...prev, newItem]);
     return newItem;
   }
 
-  function updateItem(id, data) {
-    setItems((prev) =>
-      prev.map((item) =>
-        item.id === id ? { ...item, ...data, updated_at: new Date().toISOString() } : item,
-      ),
-    );
+  async function updateItem(id, data) {
+    const updated = await updateMenuItem(id, data);
+    setItems((prev) => prev.map((item) => (item.id === id ? updated : item)));
+    return updated;
   }
 
-  function removeItem(id) {
+  async function removeItem(id) {
+    await deleteMenuItem(id);
     setItems((prev) => prev.filter((item) => item.id !== id));
   }
 


### PR DESCRIPTION
## Summary

  - `VendorMenuContext` was only updating local state — `addItem`, `updateItem`, and `removeItem`
  never called the backend API, so vendor changes disappeared on refresh and employees saw empty
  menus 
  - Add `createMenuItem` / `updateMenuItem` / `deleteMenuItem` to `api/vendor.js`
  - Make all three operations async and call the real API; local state only updates after the API
  call succeeds
  - Form shows an inline error message on save failure; delete shows an alert on failure

  ## Test plan
  
  - [ ] Vendor creates a menu item → item persists after page refresh
  - [ ] Vendor edits a menu item → changes persist after page refresh
  - [ ] Vendor deletes a menu item → item is gone after page refresh
  - [ ] Employee can see menu items added by an approved vendor