### PR TITLE
fix(gateway): pin /auth/* upstream to api alias

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -18,7 +18,7 @@
 	request_header -x-vendor-id
 
 	handle /auth/* {
-		reverse_proxy backend:8000
+		reverse_proxy api:8000
 	}
 
 	handle /health {


### PR DESCRIPTION
## Problem

Registration (and all `/auth/*` calls) returned **404** on `https://nol.cs.nycu.edu.tw/meal-staging/` — body `{"detail":"Not Found"}` from FastAPI, i.e. the request reached an upstream but matched no route. Intermittent, matching the stale-404 DNS signature from the earlier network-pinning fix.

## Cause

`infra/caddy/Caddyfile` routed `/auth/*` to `backend:8000` while every other handle uses the `api:8000` alias. `api` is pinned to a single network (`default`); the bare `backend` service name is multi-homed (`default` + `grafana_default`) and the gateway spans `default + preview-net + grafana_default`, so resolving `backend` round-robins across interfaces and intermittently lands on a path that 404s.

### How it slipped in
- **#37** (pin Caddy upstream to a single network, merged 2026-05-20) moved all handles to the pinned `api:8000` alias.
- **#32** (JWT auth: login + registration, merged 2026-05-25) introduced the `/auth/*` handle with `backend:8000` and, landing after #37, never adopted the `api` pin — reintroducing the bug.

## Change

One line: `/auth/*` upstream `backend:8000` → `api:8000`, matching every other route.

Closes #47
