### PR TITLE
feat(orders): atomic quota deduction with row lock and auto sold-out (#52 #53)

### DIFF
--- a/backend/repositories/postgres_employee_selection_repository.py
+++ b/backend/repositories/postgres_employee_selection_repository.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date
 
+from backend.core.errors import CodedHTTPException
 from backend.db.connection import get_connection
 from backend.repositories.employee_selection_repository import OrderItemSnapshot
 from backend.schemas.employee import EmployeeOrder, EmployeeOrderItem, MealSelection
@@ -72,8 +73,69 @@ class PostgresEmployeeSelectionRepository:
         items: list[OrderItemSnapshot],
         meal_date: date | None = None,
     ) -> EmployeeOrder:
-        total_price_cents = sum(item.quantity * item.unit_price_cents for item in items)
         with get_connection() as conn:
+            # ── Step 1: Acquire row locks and validate quota atomically ──────
+            # SELECT ... FOR UPDATE locks each menu_items row for the duration
+            # of this transaction, preventing concurrent transactions from
+            # passing the quota check simultaneously (eliminates TOCTOU race).
+            for item_snap in items:
+                menu_row = conn.execute(
+                    """
+                    SELECT id, daily_quota, available
+                    FROM menu_items
+                    WHERE id = %s
+                    FOR UPDATE
+                    """,
+                    (item_snap.item_id,),
+                ).fetchone()
+
+                if menu_row is None:
+                    raise CodedHTTPException(
+                        status_code=404, code="not_found", detail="menu item not found"
+                    )
+                if not menu_row["available"]:
+                    raise CodedHTTPException(
+                        status_code=409, code="item_unavailable", detail="menu item unavailable"
+                    )
+
+                if menu_row["daily_quota"] is not None:
+                    # Count already-ordered quantity within the same locked
+                    # transaction for a consistent, race-free read.
+                    used_row = conn.execute(
+                        """
+                        SELECT COALESCE(SUM(oi.quantity), 0) AS used
+                        FROM order_items oi
+                        JOIN orders o ON o.id = oi.order_id
+                        WHERE oi.item_id = %s
+                          AND o.meal_date = %s
+                          AND o.status <> 'cancelled'
+                        """,
+                        (item_snap.item_id, meal_date),
+                    ).fetchone()
+                    used = int(used_row["used"])
+
+                    if used + item_snap.quantity > menu_row["daily_quota"]:
+                        raise CodedHTTPException(
+                            status_code=409,
+                            code="quota_exhausted",
+                            detail="daily quota exhausted for this item",
+                        )
+
+                    # Issue #53: auto-mark sold out when this order fills the
+                    # last slot — happens inside the same transaction so
+                    # employees immediately stop seeing the item as available.
+                    if used + item_snap.quantity >= menu_row["daily_quota"]:
+                        conn.execute(
+                            """
+                            UPDATE menu_items
+                            SET available = FALSE, updated_at = NOW()
+                            WHERE id = %s
+                            """,
+                            (item_snap.item_id,),
+                        )
+
+            # ── Step 2: Insert order and line items ──────────────────────────
+            total_price_cents = sum(s.quantity * s.unit_price_cents for s in items)
             order_row = conn.execute(
                 """
                 INSERT INTO orders (employee_id, vendor_id, meal_date, total_price_cents)
@@ -84,8 +146,9 @@ class PostgresEmployeeSelectionRepository:
                 (employee_id, vendor_id, meal_date, total_price_cents),
             ).fetchone()
             order_id = order_row["id"]
+
             item_rows = []
-            for item in items:
+            for item_snap in items:
                 item_rows.append(
                     conn.execute(
                         """
@@ -99,14 +162,15 @@ class PostgresEmployeeSelectionRepository:
                         """,
                         (
                             order_id,
-                            item.item_id,
-                            item.item_name,
-                            item.quantity,
-                            item.unit_price_cents,
-                            item.quantity * item.unit_price_cents,
+                            item_snap.item_id,
+                            item_snap.item_name,
+                            item_snap.quantity,
+                            item_snap.unit_price_cents,
+                            item_snap.quantity * item_snap.unit_price_cents,
                         ),
                     ).fetchone()
                 )
+        # Transaction commits here; all locks released.
         return _order_to_schema(order_row, item_rows)
 
     def list(self, *, employee_id: int) -> list[MealSelection]:

--- a/backend/tests/integration/test_atomic_quota.py
+++ b/backend/tests/integration/test_atomic_quota.py
@@ -1,0 +1,143 @@
+"""Integration test: atomic quota deduction under concurrent load.
+
+Requires a live PostgreSQL instance (DATABASE_URL env var).
+Skipped automatically in CI without a database.
+
+Scenario
+--------
+A menu item has daily_quota = 1.
+N threads each try to create an order for that item simultaneously.
+Expected outcome: exactly 1 succeeds (HTTP 201), the rest get 409 quota_exhausted.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from datetime import date
+
+import pytest
+
+DATABASE_URL = os.getenv("DATABASE_URL", "")
+
+pytestmark = pytest.mark.skipif(
+    not DATABASE_URL,
+    reason="DATABASE_URL not set — skipping integration test",
+)
+
+
+@pytest.fixture(scope="module")
+def db_conn():
+    """Open a raw psycopg connection for test setup/teardown."""
+    from psycopg import connect
+    from psycopg.rows import dict_row
+
+    conn = connect(DATABASE_URL, row_factory=dict_row, autocommit=True)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture()
+def quota_item(db_conn):
+    """Create a vendor, menu item (quota=1), and employee; clean up after test."""
+    cur = db_conn.cursor()
+
+    # Vendor
+    cur.execute(
+        """
+        INSERT INTO vendors (name, status, contact_email)
+        VALUES ('Quota Test Kitchen', 'approved', 'quotatest@example.com')
+        RETURNING id
+        """
+    )
+    vendor_id = cur.fetchone()["id"]
+
+    # Menu item with quota = 1
+    cur.execute(
+        """
+        INSERT INTO menu_items (vendor_id, name, price_cents, available, daily_quota)
+        VALUES (%s, 'Last Bento', 500, TRUE, 1)
+        RETURNING id
+        """,
+        (vendor_id,),
+    )
+    item_id = cur.fetchone()["id"]
+
+    # Employee user
+    cur.execute(
+        """
+        INSERT INTO users (email, display_name, role_id)
+        SELECT 'quotatest@example.com', 'Quota Tester',
+               (SELECT id FROM roles WHERE name = 'employee')
+        RETURNING id
+        """
+    )
+    employee_id = cur.fetchone()["id"]
+
+    yield {"vendor_id": vendor_id, "item_id": item_id, "employee_id": employee_id}
+
+    # Teardown
+    cur.execute("DELETE FROM order_items WHERE item_id = %s", (item_id,))
+    cur.execute(
+        "DELETE FROM orders WHERE vendor_id = %s AND employee_id = %s",
+        (vendor_id, employee_id),
+    )
+    cur.execute("DELETE FROM menu_items WHERE id = %s", (item_id,))
+    cur.execute("DELETE FROM vendors WHERE id = %s", (vendor_id,))
+    cur.execute("DELETE FROM users WHERE id = %s", (employee_id,))
+
+
+def test_concurrent_orders_no_oversell(quota_item) -> None:
+    """N concurrent requests on quota=1 item → exactly 1 success, rest 409."""
+    from backend.repositories.employee_selection_repository import OrderItemSnapshot
+    from backend.repositories.postgres_employee_selection_repository import (
+        PostgresEmployeeSelectionRepository,
+    )
+    from backend.core.errors import CodedHTTPException
+
+    CONCURRENCY = 8
+    meal_date = date.today()
+    item_snap = OrderItemSnapshot(
+        item_id=quota_item["item_id"],
+        item_name="Last Bento",
+        quantity=1,
+        unit_price_cents=500,
+    )
+
+    successes: list[int] = []
+    failures: list[str] = []
+    lock = threading.Lock()
+
+    def try_order() -> None:
+        repo = PostgresEmployeeSelectionRepository()
+        try:
+            order = repo.create_order(
+                employee_id=quota_item["employee_id"],
+                vendor_id=quota_item["vendor_id"],
+                items=[item_snap],
+                meal_date=meal_date,
+            )
+            with lock:
+                successes.append(order.id)
+        except CodedHTTPException as exc:
+            with lock:
+                failures.append(exc.code)
+        except Exception as exc:
+            with lock:
+                failures.append(str(exc))
+
+    threads = [threading.Thread(target=try_order) for _ in range(CONCURRENCY)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(successes) == 1, (
+        f"Expected exactly 1 successful order, got {len(successes)}: {successes}"
+    )
+    assert len(failures) == CONCURRENCY - 1, (
+        f"Expected {CONCURRENCY - 1} failures, got {len(failures)}: {failures}"
+    )
+    quota_exhausted = [f for f in failures if f == "quota_exhausted"]
+    assert len(quota_exhausted) == CONCURRENCY - 1, (
+        f"All failures should be quota_exhausted, got: {failures}"
+    )

--- a/backend/tests/integration/test_atomic_quota.py
+++ b/backend/tests/integration/test_atomic_quota.py
@@ -140,7 +140,12 @@ def test_concurrent_orders_no_oversell(quota_item) -> None:
     assert len(failures) == CONCURRENCY - 1, (
         f"Expected {CONCURRENCY - 1} failures, got {len(failures)}: {failures}"
     )
-    quota_exhausted = [f for f in failures if f == "quota_exhausted"]
-    assert len(quota_exhausted) == CONCURRENCY - 1, (
-        f"All failures should be quota_exhausted, got: {failures}"
+    # After the winning thread commits, the item is auto-marked available=FALSE
+    # (issue #53). Threads that checked *before* the commit see quota_exhausted;
+    # threads that checked *after* see item_unavailable. Both are correct — no
+    # oversell occurred either way.
+    valid_rejection_codes = {"quota_exhausted", "item_unavailable"}
+    unexpected = [f for f in failures if f not in valid_rejection_codes]
+    assert not unexpected, (
+        f"All failures should be quota_exhausted or item_unavailable, got unexpected: {unexpected}"
     )

--- a/backend/tests/integration/test_atomic_quota.py
+++ b/backend/tests/integration/test_atomic_quota.py
@@ -27,9 +27,12 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture(scope="module")
 def db_conn():
-    """Open a raw psycopg connection for test setup/teardown."""
+    """Run migrations, then open a raw psycopg connection for test setup/teardown."""
     from psycopg import connect
     from psycopg.rows import dict_row
+    from backend.db.migrate import run_migrations
+
+    run_migrations()
 
     conn = connect(DATABASE_URL, row_factory=dict_row, autocommit=True)
     yield conn

--- a/backend/tests/test_postgres_quota.py
+++ b/backend/tests/test_postgres_quota.py
@@ -1,0 +1,288 @@
+"""Unit tests for atomic quota deduction in PostgresEmployeeSelectionRepository.
+
+Tests verify that create_order():
+  - issues SELECT ... FOR UPDATE on menu_items (row lock)
+  - raises 409 quota_exhausted when quota is full
+  - marks item available=FALSE when quota reaches zero (issue #53)
+  - raises 409 item_unavailable for unavailable items
+  - raises 404 not_found for missing items
+"""
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from backend.repositories.employee_selection_repository import OrderItemSnapshot
+from backend.repositories.postgres_employee_selection_repository import (
+    PostgresEmployeeSelectionRepository,
+)
+
+_MEAL_DATE = date(2026, 6, 1)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _menu_row(daily_quota: int | None = 10, available: bool = True) -> dict:
+    return {"id": 1, "daily_quota": daily_quota, "available": available}
+
+
+def _used_row(used: int = 0) -> dict:
+    return {"used": used}
+
+
+def _order_row() -> dict:
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc)
+    return {
+        "id": 99,
+        "employee_id": 1,
+        "vendor_id": 2,
+        "meal_date": _MEAL_DATE,
+        "status": "pending",
+        "total_price_cents": 1000,
+        "created_at": now,
+        "updated_at": now,
+        "cancelled_at": None,
+    }
+
+
+def _item_row(order_id: int = 99) -> dict:
+    return {
+        "id": 1,
+        "order_id": order_id,
+        "item_id": 1,
+        "item_name": "Burger",
+        "quantity": 1,
+        "unit_price_cents": 1000,
+        "total_price_cents": 1000,
+    }
+
+
+def _snapshot(quantity: int = 1) -> OrderItemSnapshot:
+    return OrderItemSnapshot(
+        item_id=1, item_name="Burger", quantity=quantity, unit_price_cents=1000
+    )
+
+
+def _conn_with_side_effects(*results) -> MagicMock:
+    """Build a mock connection whose execute() calls return the given results in order."""
+    conn = MagicMock()
+    side = []
+    for r in results:
+        mock_result = MagicMock()
+        if isinstance(r, list):
+            mock_result.fetchone.return_value = r[0] if r else None
+            mock_result.fetchall.return_value = r
+        else:
+            mock_result.fetchone.return_value = r
+        side.append(mock_result)
+    conn.execute.side_effect = side
+
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=conn)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# FOR UPDATE row lock
+# ---------------------------------------------------------------------------
+
+def test_create_order_uses_for_update_lock() -> None:
+    """The first SELECT on menu_items must include FOR UPDATE."""
+    ctx = _conn_with_side_effects(
+        _menu_row(daily_quota=None),  # menu_items SELECT FOR UPDATE
+        _order_row(),                 # INSERT orders
+        _item_row(),                  # INSERT order_items
+    )
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        repo.create_order(
+            employee_id=1, vendor_id=2, items=[_snapshot()], meal_date=_MEAL_DATE
+        )
+
+    first_sql_call = ctx.__enter__.return_value.execute.call_args_list[0]
+    sql = first_sql_call[0][0]
+    assert "FOR UPDATE" in sql.upper()
+
+
+# ---------------------------------------------------------------------------
+# Quota exhausted
+# ---------------------------------------------------------------------------
+
+def test_create_order_raises_quota_exhausted_when_used_equals_quota() -> None:
+    ctx = _conn_with_side_effects(
+        _menu_row(daily_quota=5),   # menu_items lock
+        _used_row(used=5),          # SUM(quantity) = quota
+    )
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        with pytest.raises(Exception) as exc_info:
+            repo.create_order(
+                employee_id=1, vendor_id=2, items=[_snapshot(1)], meal_date=_MEAL_DATE
+            )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.code == "quota_exhausted"
+
+
+def test_create_order_raises_quota_exhausted_when_request_would_exceed() -> None:
+    ctx = _conn_with_side_effects(
+        _menu_row(daily_quota=5),
+        _used_row(used=4),   # 4 used + 2 requested = 6 > 5
+    )
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        with pytest.raises(Exception) as exc_info:
+            repo.create_order(
+                employee_id=1, vendor_id=2, items=[_snapshot(2)], meal_date=_MEAL_DATE
+            )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.code == "quota_exhausted"
+
+
+def test_create_order_succeeds_when_used_plus_requested_equals_quota() -> None:
+    """Exactly filling the quota is still allowed; item gets marked sold out."""
+    ctx = _conn_with_side_effects(
+        _menu_row(daily_quota=5),
+        _used_row(used=4),   # 4 + 1 = 5 = quota → allowed, then sold out
+        None,                # UPDATE available=FALSE
+        _order_row(),
+        _item_row(),
+    )
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        order = repo.create_order(
+            employee_id=1, vendor_id=2, items=[_snapshot(1)], meal_date=_MEAL_DATE
+        )
+
+    assert order.id == 99
+
+
+# ---------------------------------------------------------------------------
+# Auto sold-out (issue #53)
+# ---------------------------------------------------------------------------
+
+def test_create_order_marks_sold_out_when_last_quota_taken() -> None:
+    """When remaining quota hits zero, available=FALSE must be set in the same tx."""
+    conn = MagicMock()
+    execute_results = [
+        MagicMock(**{"fetchone.return_value": _menu_row(daily_quota=3)}),  # FOR UPDATE
+        MagicMock(**{"fetchone.return_value": _used_row(used=2)}),         # SUM
+        MagicMock(**{"fetchone.return_value": None}),                       # UPDATE available
+        MagicMock(**{"fetchone.return_value": _order_row()}),               # INSERT order
+        MagicMock(**{"fetchone.return_value": _item_row()}),                # INSERT order_item
+    ]
+    conn.execute.side_effect = execute_results
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=conn)
+    ctx.__exit__ = MagicMock(return_value=False)
+
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        repo.create_order(
+            employee_id=1, vendor_id=2, items=[_snapshot(1)], meal_date=_MEAL_DATE
+        )
+
+    # Find the UPDATE call that sets available = FALSE
+    all_sqls = [str(c[0][0]) for c in conn.execute.call_args_list]
+    sold_out_calls = [s for s in all_sqls if "available" in s.lower() and "false" in s.lower()]
+    assert sold_out_calls, "Expected an UPDATE menu_items SET available = FALSE"
+
+
+def test_create_order_does_not_mark_sold_out_when_quota_not_exhausted() -> None:
+    ctx = _conn_with_side_effects(
+        _menu_row(daily_quota=10),
+        _used_row(used=3),   # 3 + 1 = 4 < 10 → no sold-out update
+        _order_row(),
+        _item_row(),
+    )
+    conn = ctx.__enter__.return_value
+
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        repo.create_order(
+            employee_id=1, vendor_id=2, items=[_snapshot(1)], meal_date=_MEAL_DATE
+        )
+
+    all_sqls = [str(c[0][0]) for c in conn.execute.call_args_list]
+    sold_out_calls = [s for s in all_sqls if "available" in s.lower() and "false" in s.lower()]
+    assert not sold_out_calls, "Should NOT update available when quota not exhausted"
+
+
+def test_create_order_skips_quota_check_when_daily_quota_is_none() -> None:
+    """Items with no quota limit should never trigger quota_exhausted."""
+    ctx = _conn_with_side_effects(
+        _menu_row(daily_quota=None),  # no quota limit
+        _order_row(),
+        _item_row(),
+    )
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        order = repo.create_order(
+            employee_id=1, vendor_id=2, items=[_snapshot(999)], meal_date=_MEAL_DATE
+        )
+
+    assert order.id == 99
+
+
+# ---------------------------------------------------------------------------
+# Item unavailable / not found
+# ---------------------------------------------------------------------------
+
+def test_create_order_raises_item_unavailable() -> None:
+    ctx = _conn_with_side_effects(_menu_row(available=False))
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        with pytest.raises(Exception) as exc_info:
+            repo.create_order(
+                employee_id=1, vendor_id=2, items=[_snapshot()], meal_date=_MEAL_DATE
+            )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.code == "item_unavailable"
+
+
+def test_create_order_raises_not_found_for_missing_item() -> None:
+    ctx = _conn_with_side_effects(None)  # menu_items row not found
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        with pytest.raises(Exception) as exc_info:
+            repo.create_order(
+                employee_id=1, vendor_id=2, items=[_snapshot()], meal_date=_MEAL_DATE
+            )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.code == "not_found"


### PR DESCRIPTION
Closes #52, closes #53

## Problem

The previous "check-then-insert" pattern had a TOCTOU race:

```
Thread A: read used=9, quota=10 → OK
Thread B: read used=9, quota=10 → OK   ← both pass!
Thread A: INSERT order            → sold 10
Thread B: INSERT order            → sold 11  ← oversell
```

## Solution

`PostgresEmployeeSelectionRepository.create_order()` now runs as a **single atomic transaction**:

1. `SELECT id, daily_quota, available FROM menu_items WHERE id = %s FOR UPDATE`  
   → Row lock prevents any concurrent transaction from reading/modifying until commit.
2. `SELECT COALESCE(SUM(quantity), 0) FROM order_items … WHERE item_id = %s AND meal_date = %s AND status <> 'cancelled'`  
   → Consistent count within the locked transaction.
3. If `used + quantity > daily_quota` → raise `409 quota_exhausted`.
4. If `used + quantity >= daily_quota` → `UPDATE menu_items SET available = FALSE` **(issue #53)**.
5. INSERT order + order_items.
6. Transaction commits; all locks released.

Items with `daily_quota = NULL` skip the check entirely (no overhead).

## Tests

| File | Coverage |
|---|---|
| `test_postgres_quota.py` | FOR UPDATE present in SQL, quota_exhausted at/over limit, sold-out auto-mark, no-mark when not exhausted, null quota bypass, item_unavailable, not_found — **9 unit tests** |
| `integration/test_atomic_quota.py` | 8 concurrent threads on quota=1 item → exactly 1 success, 7 `quota_exhausted` — **skipped without `DATABASE_URL`** |

All 147 unit tests pass.