### PR TITLE
feat(vendor): vendor order management API (#50)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from backend.routes import (
     vendor_application,
     vendor_categories,
     vendor_menu,
+    vendor_orders,
     vendor_profile,
 )
 
@@ -61,6 +62,7 @@ def create_app() -> FastAPI:
     app.include_router(vendor_profile.router)
     app.include_router(vendor_categories.router)
     app.include_router(vendor_menu.router)
+    app.include_router(vendor_orders.router)
     app.include_router(employee_ordering.router)
 
     Instrumentator(should_instrument_requests_inprogress=True).instrument(app).expose(app)

--- a/backend/repositories/employee_selection_repository.py
+++ b/backend/repositories/employee_selection_repository.py
@@ -172,6 +172,35 @@ class EmployeeSelectionRepository:
             selections.extend(self._order_to_selection_schemas(order.id))
         return selections
 
+    def list_orders_by_vendor(self, *, vendor_id: int) -> list[EmployeeOrder]:
+        rows = [r for r in self._orders.values() if r.vendor_id == vendor_id]
+        rows.sort(key=lambda r: r.id)
+        return [self._order_to_schema(r) for r in rows]
+
+    def get_order_for_vendor(self, *, vendor_id: int, order_id: int) -> EmployeeOrder | None:
+        order = self._orders.get(order_id)
+        if order is None or order.vendor_id != vendor_id:
+            return None
+        return self._order_to_schema(order)
+
+    def update_order_status(self, *, vendor_id: int, order_id: int, new_status: str) -> EmployeeOrder | None:
+        order = self._orders.get(order_id)
+        if order is None or order.vendor_id != vendor_id:
+            return None
+        now = datetime.now(timezone.utc)
+        cancelled_at = now if new_status == "cancelled" else order.cancelled_at
+        self._orders[order_id] = _OrderRecord(
+            id=order.id,
+            employee_id=order.employee_id,
+            vendor_id=order.vendor_id,
+            meal_date=order.meal_date,
+            status=new_status,
+            created_at=order.created_at,
+            updated_at=now,
+            cancelled_at=cancelled_at,
+        )
+        return self._order_to_schema(self._orders[order_id])
+
     def list_by_vendor(self, *, vendor_id: int) -> list[MealSelection]:
         selections: list[MealSelection] = []
         for order in sorted(self._orders.values(), key=lambda r: r.id):

--- a/backend/repositories/postgres_employee_selection_repository.py
+++ b/backend/repositories/postgres_employee_selection_repository.py
@@ -130,6 +130,53 @@ class PostgresEmployeeSelectionRepository:
                 )
         return selections
 
+    def list_orders_by_vendor(self, *, vendor_id: int) -> list[EmployeeOrder]:
+        with get_connection() as conn:
+            order_rows = conn.execute(
+                """
+                SELECT id, employee_id, vendor_id, meal_date, status,
+                       total_price_cents, created_at, updated_at, cancelled_at
+                FROM orders
+                WHERE vendor_id = %s
+                ORDER BY id
+                """,
+                (vendor_id,),
+            ).fetchall()
+            return [self._hydrate_order(conn, row) for row in order_rows]
+
+    def get_order_for_vendor(self, *, vendor_id: int, order_id: int) -> EmployeeOrder | None:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT id, employee_id, vendor_id, meal_date, status,
+                       total_price_cents, created_at, updated_at, cancelled_at
+                FROM orders
+                WHERE vendor_id = %s AND id = %s
+                """,
+                (vendor_id, order_id),
+            ).fetchone()
+            if row is None:
+                return None
+            return self._hydrate_order(conn, row)
+
+    def update_order_status(self, *, vendor_id: int, order_id: int, new_status: str) -> EmployeeOrder | None:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                UPDATE orders
+                SET status = %s,
+                    updated_at = NOW(),
+                    cancelled_at = CASE WHEN %s = 'cancelled' THEN NOW() ELSE cancelled_at END
+                WHERE vendor_id = %s AND id = %s
+                RETURNING id, employee_id, vendor_id, meal_date, status,
+                          total_price_cents, created_at, updated_at, cancelled_at
+                """,
+                (new_status, new_status, vendor_id, order_id),
+            ).fetchone()
+            if row is None:
+                return None
+            return self._hydrate_order(conn, row)
+
     def list_by_vendor(self, *, vendor_id: int) -> list[MealSelection]:
         with get_connection() as conn:
             rows = conn.execute(

--- a/backend/routes/vendor_orders.py
+++ b/backend/routes/vendor_orders.py
@@ -1,0 +1,47 @@
+"""/vendor/me/orders — 商家訂單查詢與狀態更新。"""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from backend.core.vendor_identity import require_approved_vendor
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.routes.employee_ordering import get_employee_selection_repository
+from backend.schemas.employee import EmployeeOrder, VendorOrderStatusUpdate
+from backend.services.vendor_order_service import VendorOrderService
+
+router = APIRouter(prefix="/vendor/me/orders", tags=["vendor-self"])
+
+
+def get_vendor_order_service(
+    selection_repo: Annotated[EmployeeSelectionRepository, Depends(get_employee_selection_repository)],
+) -> VendorOrderService:
+    return VendorOrderService(selection_repo)
+
+
+@router.get("", response_model=list[EmployeeOrder])
+def list_vendor_orders(
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
+) -> list[EmployeeOrder]:
+    return service.list_orders(vendor_id)
+
+
+@router.get("/{order_id}", response_model=EmployeeOrder)
+def get_vendor_order(
+    order_id: int,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
+) -> EmployeeOrder:
+    return service.get_order(vendor_id, order_id)
+
+
+@router.patch("/{order_id}/status", response_model=EmployeeOrder)
+def update_vendor_order_status(
+    order_id: int,
+    payload: VendorOrderStatusUpdate,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
+) -> EmployeeOrder:
+    return service.update_status(vendor_id, order_id, payload.status)

--- a/backend/routes/vendor_profile.py
+++ b/backend/routes/vendor_profile.py
@@ -9,10 +9,7 @@ from backend.core.vendor_identity import (
     get_vendor_profile_repository,
     require_approved_vendor,
 )
-from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
-from backend.routes.employee_ordering import get_employee_selection_repository
-from backend.schemas.employee import MealSelection
 from backend.schemas.vendor_self import VendorProfile, VendorProfileUpdate
 from backend.services.vendor_profile_service import VendorProfileService
 
@@ -43,11 +40,3 @@ def patch_profile(
 ) -> VendorProfile:
     """局部更新商家資料；served_facilities 等唯讀欄位若出現在 body 會被忽略。"""
     return service.update(vendor_id, payload)
-
-
-@router.get("/orders", response_model=list[MealSelection])
-def list_vendor_orders(
-    vendor_id: Annotated[int, Depends(require_approved_vendor)],
-    selection_repo: Annotated[EmployeeSelectionRepository, Depends(get_employee_selection_repository)],
-) -> list[MealSelection]:
-    return selection_repo.list_by_vendor(vendor_id=vendor_id)

--- a/backend/schemas/employee.py
+++ b/backend/schemas/employee.py
@@ -54,6 +54,10 @@ class MealSelection(BaseModel):
 OrderStatus = Literal["pending", "confirmed", "preparing", "ready", "delivered", "cancelled"]
 
 
+class VendorOrderStatusUpdate(BaseModel):
+    status: OrderStatus
+
+
 class EmployeeOrderItemCreate(BaseModel):
     item_id: int
     quantity: int = Field(ge=1)

--- a/backend/services/vendor_order_service.py
+++ b/backend/services/vendor_order_service.py
@@ -1,0 +1,43 @@
+"""Vendor order management: list, detail, and status transition."""
+from __future__ import annotations
+
+from backend.core.errors import CodedHTTPException
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.schemas.employee import EmployeeOrder
+
+ALLOWED_TRANSITIONS: dict[str, set[str]] = {
+    "pending": {"confirmed", "cancelled"},
+    "confirmed": {"preparing"},
+    "preparing": {"ready"},
+    "ready": {"delivered"},
+}
+
+
+class VendorOrderService:
+    def __init__(self, selection_repo: EmployeeSelectionRepository) -> None:
+        self._repo = selection_repo
+
+    def list_orders(self, vendor_id: int) -> list[EmployeeOrder]:
+        return self._repo.list_orders_by_vendor(vendor_id=vendor_id)
+
+    def get_order(self, vendor_id: int, order_id: int) -> EmployeeOrder:
+        order = self._repo.get_order_for_vendor(vendor_id=vendor_id, order_id=order_id)
+        if order is None:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
+        return order
+
+    def update_status(self, vendor_id: int, order_id: int, new_status: str) -> EmployeeOrder:
+        order = self.get_order(vendor_id, order_id)
+        allowed = ALLOWED_TRANSITIONS.get(order.status, set())
+        if new_status not in allowed:
+            raise CodedHTTPException(
+                status_code=409,
+                code="invalid_status_transition",
+                detail=f"cannot transition from '{order.status}' to '{new_status}'",
+            )
+        updated = self._repo.update_order_status(
+            vendor_id=vendor_id, order_id=order_id, new_status=new_status
+        )
+        if updated is None:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
+        return updated

--- a/backend/tests/integration/test_vendor_orders_db.py
+++ b/backend/tests/integration/test_vendor_orders_db.py
@@ -1,0 +1,238 @@
+"""Integration tests for vendor order endpoints against a real PostgreSQL database.
+
+Run with DATABASE_URL set:
+    DATABASE_URL=postgresql://... pytest backend/tests/integration/test_vendor_orders_db.py -v
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.db.connection import get_connection
+from backend.main import app
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def client():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("DATABASE_URL not set")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def seeded_ids():
+    """Return (vendor_id, employee_id) for the rows seeded by migrations."""
+    with get_connection() as conn:
+        vendor = conn.execute(
+            "SELECT id FROM vendors WHERE name = 'Sunny Kitchen'"
+        ).fetchone()
+        employee = conn.execute(
+            "SELECT id FROM users WHERE email = 'employee@corpmeal.local'"
+        ).fetchone()
+    assert vendor is not None, "Sunny Kitchen vendor not found — did migrations run?"
+    assert employee is not None, "employee@corpmeal.local not found — did migrations run?"
+    return vendor["id"], employee["id"]
+
+
+@pytest.fixture(autouse=True)
+def clean_orders():
+    """Remove orders inserted during each test so tests don't interfere."""
+    yield
+    with get_connection() as conn:
+        conn.execute("DELETE FROM order_items")
+        conn.execute("DELETE FROM orders")
+        conn.execute("DELETE FROM vendors WHERE name LIKE 'IntTest%'")
+        conn.commit()
+
+
+def _vh(vendor_id: int) -> dict[str, str]:
+    return {"x-user-role": "vendor_manager", "x-vendor-id": str(vendor_id)}
+
+
+def _insert_order(vendor_id: int, employee_id: int) -> int:
+    with get_connection() as conn:
+        row = conn.execute(
+            "INSERT INTO orders (employee_id, vendor_id, total_price_cents) "
+            "VALUES (%s, %s, 0) RETURNING id",
+            (employee_id, vendor_id),
+        ).fetchone()
+        conn.commit()
+    return row["id"]
+
+
+# ---------------------------------------------------------------------------
+# GET /vendor/me/orders
+# ---------------------------------------------------------------------------
+
+
+def test_list_orders_returns_own_orders(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+    order_id = _insert_order(vendor_id, employee_id)
+
+    resp = client.get("/vendor/me/orders", headers=_vh(vendor_id))
+    assert resp.status_code == 200
+    ids = [o["id"] for o in resp.json()]
+    assert order_id in ids
+
+
+def test_list_orders_excludes_other_vendor(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+
+    with get_connection() as conn:
+        other = conn.execute(
+            "INSERT INTO vendors (name, status) VALUES ('IntTest Other', 'approved') RETURNING id"
+        ).fetchone()
+        conn.commit()
+    _insert_order(other["id"], employee_id)
+
+    resp = client.get("/vendor/me/orders", headers=_vh(vendor_id))
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# GET /vendor/me/orders/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_order_returns_detail(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+    order_id = _insert_order(vendor_id, employee_id)
+
+    resp = client.get(f"/vendor/me/orders/{order_id}", headers=_vh(vendor_id))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == order_id
+    assert body["status"] == "pending"
+    assert "items" in body
+
+
+def test_get_order_404_for_other_vendors_order(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+
+    with get_connection() as conn:
+        other = conn.execute(
+            "INSERT INTO vendors (name, status) VALUES ('IntTest Other2', 'approved') RETURNING id"
+        ).fetchone()
+        conn.commit()
+    order_id = _insert_order(other["id"], employee_id)
+
+    resp = client.get(f"/vendor/me/orders/{order_id}", headers=_vh(vendor_id))
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# PATCH /vendor/me/orders/{id}/status
+# ---------------------------------------------------------------------------
+
+
+def test_patch_status_pending_to_confirmed_persists(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+    order_id = _insert_order(vendor_id, employee_id)
+
+    resp = client.patch(
+        f"/vendor/me/orders/{order_id}/status",
+        headers=_vh(vendor_id),
+        json={"status": "confirmed"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "confirmed"
+
+    with get_connection() as conn:
+        row = conn.execute("SELECT status FROM orders WHERE id = %s", (order_id,)).fetchone()
+    assert row["status"] == "confirmed"
+
+
+def test_patch_status_full_transition_chain(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+    order_id = _insert_order(vendor_id, employee_id)
+
+    for status in ("confirmed", "preparing", "ready", "delivered"):
+        resp = client.patch(
+            f"/vendor/me/orders/{order_id}/status",
+            headers=_vh(vendor_id),
+            json={"status": status},
+        )
+        assert resp.status_code == 200, f"failed at transition to {status}"
+        assert resp.json()["status"] == status
+
+    with get_connection() as conn:
+        row = conn.execute("SELECT status FROM orders WHERE id = %s", (order_id,)).fetchone()
+    assert row["status"] == "delivered"
+
+
+def test_patch_status_pending_to_cancelled(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+    order_id = _insert_order(vendor_id, employee_id)
+
+    resp = client.patch(
+        f"/vendor/me/orders/{order_id}/status",
+        headers=_vh(vendor_id),
+        json={"status": "cancelled"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "cancelled"
+    assert body["cancelled_at"] is not None
+
+
+def test_patch_status_invalid_transition_returns_409(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+    order_id = _insert_order(vendor_id, employee_id)
+
+    resp = client.patch(
+        f"/vendor/me/orders/{order_id}/status",
+        headers=_vh(vendor_id),
+        json={"status": "delivered"},  # pending → delivered not allowed
+    )
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "invalid_status_transition"
+
+
+def test_patch_status_terminal_state_rejects_further_transitions(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+    order_id = _insert_order(vendor_id, employee_id)
+
+    client.patch(
+        f"/vendor/me/orders/{order_id}/status",
+        headers=_vh(vendor_id),
+        json={"status": "cancelled"},
+    )
+
+    resp = client.patch(
+        f"/vendor/me/orders/{order_id}/status",
+        headers=_vh(vendor_id),
+        json={"status": "confirmed"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "invalid_status_transition"
+
+
+def test_patch_status_404_for_other_vendors_order(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+
+    with get_connection() as conn:
+        other = conn.execute(
+            "INSERT INTO vendors (name, status) VALUES ('IntTest Other3', 'approved') RETURNING id"
+        ).fetchone()
+        conn.commit()
+    order_id = _insert_order(other["id"], employee_id)
+
+    resp = client.patch(
+        f"/vendor/me/orders/{order_id}/status",
+        headers=_vh(vendor_id),
+        json={"status": "confirmed"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"

--- a/backend/tests/test_vendor_orders.py
+++ b/backend/tests/test_vendor_orders.py
@@ -1,0 +1,194 @@
+"""GET /vendor/me/orders, GET /vendor/me/orders/{id}, PATCH /vendor/me/orders/{id}/status."""
+from fastapi.testclient import TestClient
+
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.routes.employee_ordering import get_employee_selection_repository
+
+
+def _seed_vendor_repo() -> VendorProfileRepository:
+    repo = VendorProfileRepository()
+    repo.seed(VendorRecord(id=1, name="Alice Bento", status="approved", address="No. 1"))
+    repo.seed(VendorRecord(id=2, name="Bob Noodles", status="approved", address="No. 2"))
+    return repo
+
+
+def _client(
+    vendor_repo: VendorProfileRepository,
+    selection_repo: EmployeeSelectionRepository,
+) -> TestClient:
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
+    app.dependency_overrides[get_employee_selection_repository] = lambda: selection_repo
+    return TestClient(app)
+
+
+def _vh(vid: int = 1) -> dict[str, str]:
+    return {"x-user-role": "vendor_manager", "x-vendor-id": str(vid)}
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+# --- list ---
+
+def test_list_returns_orders_for_own_vendor() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+    # another vendor's order should not appear
+    selection_repo.create_order(employee_id=20, vendor_id=2, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).get("/vendor/me/orders", headers=_vh(1))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["vendor_id"] == 1
+    assert body[0]["employee_id"] == 10
+    assert "items" in body[0]
+    assert "status" in body[0]
+
+
+def test_list_returns_empty_when_no_orders() -> None:
+    resp = _client(_seed_vendor_repo(), EmployeeSelectionRepository()).get(
+        "/vendor/me/orders", headers=_vh(1)
+    )
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_list_requires_vendor_manager_role() -> None:
+    resp = _client(_seed_vendor_repo(), EmployeeSelectionRepository()).get(
+        "/vendor/me/orders", headers={"x-user-role": "employee", "x-vendor-id": "1"}
+    )
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "forbidden"
+
+
+# --- detail ---
+
+def test_get_order_returns_full_order() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).get(
+        f"/vendor/me/orders/{order.id}", headers=_vh(1)
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == order.id
+    assert body["employee_id"] == 10
+    assert body["status"] == "pending"
+
+
+def test_get_order_404_for_other_vendors_order() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(employee_id=20, vendor_id=2, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).get(
+        f"/vendor/me/orders/{order.id}", headers=_vh(1)
+    )
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"
+
+
+def test_get_order_404_for_nonexistent_order() -> None:
+    resp = _client(_seed_vendor_repo(), EmployeeSelectionRepository()).get(
+        "/vendor/me/orders/9999", headers=_vh(1)
+    )
+    assert resp.status_code == 404
+
+
+# --- status update ---
+
+def test_patch_status_pending_to_confirmed() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).patch(
+        f"/vendor/me/orders/{order.id}/status",
+        headers=_vh(1),
+        json={"status": "confirmed"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "confirmed"
+
+
+def test_patch_status_pending_to_cancelled() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).patch(
+        f"/vendor/me/orders/{order.id}/status",
+        headers=_vh(1),
+        json={"status": "cancelled"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "cancelled"
+    assert body["cancelled_at"] is not None
+
+
+def test_patch_status_full_happy_path() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+    client = _client(vendor_repo, selection_repo)
+
+    for next_status in ("confirmed", "preparing", "ready", "delivered"):
+        resp = client.patch(
+            f"/vendor/me/orders/{order.id}/status",
+            headers=_vh(1),
+            json={"status": next_status},
+        )
+        assert resp.status_code == 200, f"failed at transition to {next_status}"
+        assert resp.json()["status"] == next_status
+
+
+def test_patch_status_rejects_invalid_transition() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).patch(
+        f"/vendor/me/orders/{order.id}/status",
+        headers=_vh(1),
+        json={"status": "delivered"},  # pending → delivered is not allowed
+    )
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "invalid_status_transition"
+
+
+def test_patch_status_rejects_transition_from_terminal_state() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+    selection_repo.update_order_status(vendor_id=1, order_id=order.id, new_status="delivered")
+
+    resp = _client(vendor_repo, selection_repo).patch(
+        f"/vendor/me/orders/{order.id}/status",
+        headers=_vh(1),
+        json={"status": "confirmed"},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "invalid_status_transition"
+
+
+def test_patch_status_404_for_other_vendors_order() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(employee_id=20, vendor_id=2, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).patch(
+        f"/vendor/me/orders/{order.id}/status",
+        headers=_vh(1),
+        json={"status": "confirmed"},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"

--- a/backend/tests/test_vendor_profile.py
+++ b/backend/tests/test_vendor_profile.py
@@ -1,11 +1,9 @@
-"""GET / PATCH /vendor/me/profile and GET /vendor/me/orders."""
+"""GET / PATCH /vendor/me/profile."""
 from fastapi.testclient import TestClient
 
 from backend.core.vendor_identity import get_vendor_profile_repository
 from backend.main import app
-from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
-from backend.routes.employee_ordering import get_employee_selection_repository
 
 
 def _seed() -> VendorProfileRepository:
@@ -66,65 +64,3 @@ def test_unauthenticated_role_403() -> None:
         headers={"x-user-role": "employee", "x-vendor-id": "1"},
     )
     assert response.status_code == 403
-
-
-# --- /vendor/me/orders ---
-
-
-def _orders_client(
-    vendor_repo: VendorProfileRepository,
-    selection_repo: EmployeeSelectionRepository,
-) -> TestClient:
-    app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
-    app.dependency_overrides[get_employee_selection_repository] = lambda: selection_repo
-    return TestClient(app)
-
-
-def test_list_vendor_orders_returns_own_selections() -> None:
-    vendor_repo = _seed()
-    selection_repo = EmployeeSelectionRepository()
-    selection_repo.create(employee_id=10, vendor_id=1, item_id=5, item_name="Rice Bowl", quantity=2, unit_price_cents=120)
-    selection_repo.create(employee_id=11, vendor_id=1, item_id=6, item_name="Tea", quantity=1, unit_price_cents=40)
-
-    resp = _orders_client(vendor_repo, selection_repo).get(
-        "/vendor/me/orders", headers=_vendor_headers(1)
-    )
-
-    assert resp.status_code == 200
-    body = resp.json()
-    assert len(body) == 2
-    assert body[0]["item_name"] == "Rice Bowl"
-    assert body[0]["total_price_cents"] == 240
-    assert body[1]["item_name"] == "Tea"
-
-
-def test_list_vendor_orders_excludes_other_vendors_selections() -> None:
-    vendor_repo = _seed()
-    selection_repo = EmployeeSelectionRepository()
-    selection_repo.create(employee_id=10, vendor_id=2, item_id=9, item_name="Other Bento", quantity=1, unit_price_cents=100)
-
-    resp = _orders_client(vendor_repo, selection_repo).get(
-        "/vendor/me/orders", headers=_vendor_headers(1)
-    )
-
-    assert resp.status_code == 200
-    assert resp.json() == []
-
-
-def test_list_vendor_orders_returns_empty_when_no_orders() -> None:
-    resp = _orders_client(_seed(), EmployeeSelectionRepository()).get(
-        "/vendor/me/orders", headers=_vendor_headers(1)
-    )
-
-    assert resp.status_code == 200
-    assert resp.json() == []
-
-
-def test_list_vendor_orders_requires_vendor_manager_role() -> None:
-    resp = _orders_client(_seed(), EmployeeSelectionRepository()).get(
-        "/vendor/me/orders",
-        headers={"x-user-role": "employee", "x-vendor-id": "1"},
-    )
-
-    assert resp.status_code == 403
-    assert resp.json()["code"] == "forbidden"

--- a/frontend/src/api/vendor.js
+++ b/frontend/src/api/vendor.js
@@ -20,6 +20,18 @@ export function getMyOrders() {
   return apiFetch("/vendor/me/orders");
 }
 
+export function getMyOrder(orderId) {
+  return apiFetch(`/vendor/me/orders/${orderId}`);
+}
+
+export function updateOrderStatus(orderId, status) {
+  return apiFetch(`/vendor/me/orders/${orderId}/status`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ status }),
+  });
+}
+
 export function createMenuItem(data) {
   return apiFetch("/vendor/me/menu", {
     method: "POST",

--- a/frontend/src/pages/vendor/VendorOrdersPage.jsx
+++ b/frontend/src/pages/vendor/VendorOrdersPage.jsx
@@ -2,31 +2,38 @@ import { useEffect, useState } from "react";
 import { getMyOrders } from "../../api/vendor";
 import { formatPrice } from "../../utils/format";
 
-function formatTime(isoString) {
-  const d = new Date(isoString);
-  return d.toLocaleTimeString("zh-TW", { hour: "2-digit", minute: "2-digit", hour12: false });
-}
+const STATUS_LABEL = {
+  pending: "待確認",
+  confirmed: "已確認",
+  preparing: "備餐中",
+  ready: "可取餐",
+  delivered: "已完成",
+  cancelled: "已取消",
+};
 
 function useVendorOrders() {
-  const [selections, setSelections] = useState([]);
+  const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
     getMyOrders()
-      .then(setSelections)
+      .then(setOrders)
       .catch((err) => setError(err.message ?? "無法載入訂單"))
       .finally(() => setLoading(false));
   }, []);
 
-  return { selections, loading, error };
+  return { orders, loading, error };
 }
 
 export default function VendorOrdersPage() {
-  const { selections, loading, error } = useVendorOrders();
+  const { orders, loading, error } = useVendorOrders();
 
-  const totalRevenue = selections.reduce((sum, s) => sum + s.total_price_cents, 0);
-  const totalItems = selections.reduce((sum, s) => sum + s.quantity, 0);
+  const totalRevenue = orders.reduce((sum, o) => sum + o.total_price_cents, 0);
+  const totalItems = orders.reduce(
+    (sum, o) => sum + o.items.reduce((s, item) => s + item.quantity, 0),
+    0,
+  );
 
   return (
     <div>
@@ -39,16 +46,16 @@ export default function VendorOrdersPage() {
 
       {error && <p className="error-state">{error}</p>}
 
-      {!loading && !error && selections.length === 0 && (
+      {!loading && !error && orders.length === 0 && (
         <p className="empty-state">今日尚未收到任何訂單。</p>
       )}
 
-      {!loading && !error && selections.length > 0 && (
+      {!loading && !error && orders.length > 0 && (
         <>
           <div style={{ display: "flex", gap: 16, marginBottom: 24 }}>
             <div className="panel" style={{ flex: 1, padding: "16px 20px" }}>
               <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>訂單數</p>
-              <p style={{ margin: "4px 0 0", fontWeight: 700, fontSize: 22 }}>{selections.length}</p>
+              <p style={{ margin: "4px 0 0", fontWeight: 700, fontSize: 22 }}>{orders.length}</p>
             </div>
             <div className="panel" style={{ flex: 1, padding: "16px 20px" }}>
               <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>總份數</p>
@@ -64,7 +71,7 @@ export default function VendorOrdersPage() {
             <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "140px 1fr 80px 100px 100px 80px",
+                gridTemplateColumns: "60px 140px 1fr 80px 100px 90px",
                 padding: "10px 20px",
                 borderBottom: "1px solid var(--line)",
                 color: "var(--muted)",
@@ -74,41 +81,64 @@ export default function VendorOrdersPage() {
                 letterSpacing: "0.05em",
               }}
             >
+              <span>#</span>
               <span>來源</span>
               <span>品項</span>
               <span style={{ textAlign: "right" }}>數量</span>
-              <span style={{ textAlign: "right" }}>單價</span>
               <span style={{ textAlign: "right" }}>小計</span>
-              <span style={{ textAlign: "right" }}>時間</span>
+              <span style={{ textAlign: "right" }}>狀態</span>
             </div>
 
-            {selections.map((s, idx) => (
-              <div
-                key={s.id}
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "140px 1fr 80px 100px 100px 80px",
-                  alignItems: "center",
-                  padding: "14px 20px",
-                  borderBottom: idx < selections.length - 1 ? "1px solid var(--line)" : "none",
-                }}
-              >
-                <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>
-                  {s.employee_name ?? `員工 #${s.employee_id}`}
-                </p>
-                <p style={{ margin: 0, fontWeight: 500 }}>{s.item_name}</p>
-                <p style={{ margin: 0, textAlign: "right" }}>× {s.quantity}</p>
-                <p style={{ margin: 0, textAlign: "right", color: "var(--muted)" }}>
-                  {formatPrice(s.unit_price_cents)}
-                </p>
-                <p style={{ margin: 0, textAlign: "right", fontWeight: 600 }}>
-                  {formatPrice(s.total_price_cents)}
-                </p>
-                <p style={{ margin: 0, textAlign: "right", color: "var(--muted)", fontSize: 13 }}>
-                  {formatTime(s.created_at)}
-                </p>
-              </div>
-            ))}
+            {orders.map((order, orderIdx) =>
+              order.items.map((item, itemIdx) => (
+                <div
+                  key={`${order.id}-${item.id}`}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: "60px 140px 1fr 80px 100px 90px",
+                    alignItems: "center",
+                    padding: "14px 20px",
+                    borderBottom:
+                      orderIdx < orders.length - 1 || itemIdx < order.items.length - 1
+                        ? "1px solid var(--line)"
+                        : "none",
+                  }}
+                >
+                  {itemIdx === 0 ? (
+                    <p style={{ margin: 0, fontSize: 12, color: "var(--muted)" }}>#{order.id}</p>
+                  ) : (
+                    <span />
+                  )}
+                  <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>
+                    {`員工 #${order.employee_id}`}
+                  </p>
+                  <p style={{ margin: 0, fontWeight: 500 }}>{item.item_name}</p>
+                  <p style={{ margin: 0, textAlign: "right" }}>× {item.quantity}</p>
+                  <p style={{ margin: 0, textAlign: "right", fontWeight: 600 }}>
+                    {formatPrice(item.total_price_cents)}
+                  </p>
+                  {itemIdx === 0 ? (
+                    <p
+                      style={{
+                        margin: 0,
+                        textAlign: "right",
+                        fontSize: 12,
+                        color:
+                          order.status === "cancelled"
+                            ? "var(--error, #e53)"
+                            : order.status === "delivered"
+                              ? "var(--muted)"
+                              : "inherit",
+                      }}
+                    >
+                      {STATUS_LABEL[order.status] ?? order.status}
+                    </p>
+                  ) : (
+                    <span />
+                  )}
+                </div>
+              )),
+            )}
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary

- Upgrade `GET /vendor/me/orders` to return order-level response (nested items, status field) instead of flat MealSelection list
- Add `GET /vendor/me/orders/:id` for full order detail
- Add `PATCH /vendor/me/orders/:id/status` with state machine enforcement

## State Machine

```
pending → confirmed | cancelled
confirmed → preparing
preparing → ready
ready → delivered
delivered / cancelled → (terminal)
```

## Test plan

- [x] 11 unit tests (in-memory repo, no DB required)
- [x] 10 integration tests (DB-gated, run in CI against real PostgreSQL)
- [x] Cross-vendor isolation (another vendor's order returns 404)
- [x] Invalid transition returns `409 invalid_status_transition`
- [x] Terminal state blocks further transitions

Closes #50