### PR TITLE
feat(vendor): vendor order detail page and processing UI

### DIFF
--- a/frontend/src/pages/vendor/VendorOrderDetailPage.jsx
+++ b/frontend/src/pages/vendor/VendorOrderDetailPage.jsx
@@ -1,0 +1,268 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { getMyOrder, updateOrderStatus } from "../../api/vendor";
+import { formatPrice } from "../../utils/format";
+
+const STATUS_LABEL = {
+  pending: "待確認",
+  confirmed: "已確認",
+  preparing: "備餐中",
+  ready: "可取餐",
+  delivered: "已完成",
+  cancelled: "已取消",
+};
+
+const STATUS_COLOR = {
+  pending: { background: "rgba(180,140,0,0.10)", color: "#9a7800" },
+  confirmed: { background: "rgba(47,100,200,0.10)", color: "#2b5cc8" },
+  preparing: { background: "rgba(200,92,44,0.10)", color: "var(--brand)" },
+  ready: { background: "rgba(47,125,74,0.12)", color: "var(--success)" },
+  delivered: { background: "rgba(23,33,43,0.07)", color: "var(--muted)" },
+  cancelled: { background: "rgba(200,92,44,0.08)", color: "var(--brand-deep)" },
+};
+
+const NEXT_ACTIONS = {
+  pending: [
+    { status: "confirmed", label: "確認接單", variant: "confirm" },
+    { status: "cancelled", label: "拒絕訂單", variant: "danger" },
+  ],
+  confirmed: [{ status: "preparing", label: "開始備餐", variant: "primary" }],
+  preparing: [{ status: "ready", label: "備餐完成", variant: "primary" }],
+  ready: [{ status: "delivered", label: "標記已送達", variant: "primary" }],
+};
+
+const ACTION_STYLE = {
+  primary: {
+    background: "linear-gradient(135deg, var(--brand) 0%, #d77431 100%)",
+    color: "#fffaf1",
+    border: "none",
+  },
+  confirm: {
+    background: "rgba(47,125,74,0.15)",
+    color: "var(--success)",
+    border: "none",
+  },
+  danger: {
+    background: "rgba(200,92,44,0.12)",
+    color: "var(--brand)",
+    border: "none",
+  },
+};
+
+function StatusBadge({ status }) {
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "4px 14px",
+        borderRadius: 99,
+        fontSize: 13,
+        fontWeight: 600,
+        ...(STATUS_COLOR[status] ?? {}),
+      }}
+    >
+      {STATUS_LABEL[status] ?? status}
+    </span>
+  );
+}
+
+export default function VendorOrderDetailPage() {
+  const { orderId } = useParams();
+  const navigate = useNavigate();
+  const [order, setOrder] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [actionError, setActionError] = useState(null);
+
+  useEffect(() => {
+    getMyOrder(orderId)
+      .then(setOrder)
+      .catch((err) => setError(err.message ?? "無法載入訂單"))
+      .finally(() => setLoading(false));
+  }, [orderId]);
+
+  async function handleAction(newStatus) {
+    setSubmitting(true);
+    setActionError(null);
+    try {
+      const updated = await updateOrderStatus(orderId, newStatus);
+      setOrder(updated);
+    } catch (err) {
+      setActionError(err.message ?? "操作失敗");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (loading) return <p className="loading-state">載入訂單中...</p>;
+  if (error) return <p className="error-state">{error}</p>;
+  if (!order) return null;
+
+  const actions = NEXT_ACTIONS[order.status] ?? [];
+
+  return (
+    <div>
+      <div className="page-header">
+        <button
+          type="button"
+          className="back-button"
+          onClick={() => navigate("/vendor/orders")}
+        >
+          ← 返回列表
+        </button>
+        <p className="eyebrow" style={{ marginTop: 16 }}>Vendor · Order Detail</p>
+        <div style={{ display: "flex", alignItems: "center", gap: 14, marginTop: 8 }}>
+          <h2 style={{ margin: 0 }}>訂單 #{order.id}</h2>
+          <StatusBadge status={order.status} />
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 300px", gap: 20, alignItems: "start" }}>
+        {/* 左欄：訂單明細 */}
+        <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
+          <div style={{ padding: "18px 24px", borderBottom: "1px solid var(--line)" }}>
+            <p className="eyebrow">訂單明細</p>
+          </div>
+
+          {/* 表頭 */}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 60px 100px 110px",
+              padding: "10px 24px",
+              borderBottom: "1px solid var(--line)",
+              color: "var(--muted)",
+              fontSize: 12,
+              fontWeight: 600,
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+            }}
+          >
+            <span>品項</span>
+            <span style={{ textAlign: "right" }}>數量</span>
+            <span style={{ textAlign: "right" }}>單價</span>
+            <span style={{ textAlign: "right" }}>小計</span>
+          </div>
+
+          {order.items.length === 0 && (
+            <p style={{ padding: "20px 24px", color: "var(--muted)", fontSize: 14 }}>此訂單無品項。</p>
+          )}
+
+          {order.items.map((item, idx) => (
+            <div
+              key={item.id}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr 60px 100px 110px",
+                alignItems: "center",
+                padding: "14px 24px",
+                borderBottom: idx < order.items.length - 1 ? "1px solid var(--line)" : "none",
+              }}
+            >
+              <p style={{ margin: 0, fontWeight: 500 }}>{item.item_name}</p>
+              <p style={{ margin: 0, textAlign: "right", color: "var(--muted)" }}>×{item.quantity}</p>
+              <p style={{ margin: 0, textAlign: "right", color: "var(--muted)", fontSize: 13 }}>
+                {formatPrice(item.unit_price_cents)}
+              </p>
+              <p style={{ margin: 0, textAlign: "right", fontWeight: 600 }}>
+                {formatPrice(item.total_price_cents)}
+              </p>
+            </div>
+          ))}
+
+          {/* 合計 */}
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              padding: "14px 24px",
+              borderTop: "1px solid var(--line)",
+              background: "rgba(23,33,43,0.02)",
+            }}
+          >
+            <p style={{ margin: 0, fontWeight: 700 }}>合計</p>
+            <p style={{ margin: 0, fontWeight: 800, fontSize: 18, color: "var(--brand)" }}>
+              {formatPrice(order.total_price_cents)}
+            </p>
+          </div>
+        </div>
+
+        {/* 右欄：訂單資訊 + 操作 */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+          {/* 訂單資訊 */}
+          <div className="panel">
+            <p className="eyebrow" style={{ marginBottom: 14 }}>訂單資訊</p>
+            <InfoRow label="訂單編號" value={`#${order.id}`} />
+            <InfoRow label="員工" value={`員工 #${order.employee_id}`} />
+            {order.meal_date && <InfoRow label="用餐日期" value={order.meal_date} />}
+            <InfoRow
+              label="建立時間"
+              value={new Date(order.created_at).toLocaleString("zh-TW")}
+            />
+            {order.cancelled_at && (
+              <InfoRow
+                label="取消時間"
+                value={new Date(order.cancelled_at).toLocaleString("zh-TW")}
+              />
+            )}
+            <div style={{ marginTop: 12 }}>
+              <p style={{ margin: "0 0 6px", fontSize: 13, color: "var(--muted)", fontWeight: 600 }}>
+                狀態
+              </p>
+              <StatusBadge status={order.status} />
+            </div>
+          </div>
+
+          {/* 操作按鈕 */}
+          {actions.length > 0 && (
+            <div className="panel">
+              <p className="eyebrow" style={{ marginBottom: 14 }}>操作</p>
+
+              {actionError && (
+                <p style={{ color: "var(--brand)", fontSize: 13, marginBottom: 10 }}>
+                  {actionError}
+                </p>
+              )}
+
+              <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+                {actions.map((action) => (
+                  <button
+                    key={action.status}
+                    type="button"
+                    disabled={submitting}
+                    onClick={() => handleAction(action.status)}
+                    style={{
+                      padding: "10px 0",
+                      borderRadius: "var(--radius-md)",
+                      fontWeight: 600,
+                      fontSize: 14,
+                      cursor: submitting ? "not-allowed" : "pointer",
+                      opacity: submitting ? 0.7 : 1,
+                      transition: "opacity 140ms ease",
+                      ...ACTION_STYLE[action.variant],
+                    }}
+                  >
+                    {action.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function InfoRow({ label, value }) {
+  return (
+    <div style={{ display: "flex", gap: 12, marginBottom: 10, alignItems: "flex-start" }}>
+      <span style={{ width: 80, flexShrink: 0, fontSize: 13, color: "var(--muted)", fontWeight: 600 }}>
+        {label}
+      </span>
+      <span style={{ fontSize: 14 }}>{value}</span>
+    </div>
+  );
+}

--- a/frontend/src/pages/vendor/VendorOrdersPage.jsx
+++ b/frontend/src/pages/vendor/VendorOrdersPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { getMyOrders } from "../../api/vendor";
 import { formatPrice } from "../../utils/format";
 
@@ -11,7 +12,41 @@ const STATUS_LABEL = {
   cancelled: "已取消",
 };
 
-function useVendorOrders() {
+const STATUS_COLOR = {
+  pending: { background: "rgba(180,140,0,0.10)", color: "#9a7800" },
+  confirmed: { background: "rgba(47,100,200,0.10)", color: "#2b5cc8" },
+  preparing: { background: "rgba(200,92,44,0.10)", color: "var(--brand)" },
+  ready: { background: "rgba(47,125,74,0.12)", color: "var(--success)" },
+  delivered: { background: "rgba(23,33,43,0.07)", color: "var(--muted)" },
+  cancelled: { background: "rgba(200,92,44,0.08)", color: "var(--brand-deep)" },
+};
+
+function StatusBadge({ status }) {
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "3px 12px",
+        borderRadius: 99,
+        fontSize: 12,
+        fontWeight: 600,
+        whiteSpace: "nowrap",
+        ...(STATUS_COLOR[status] ?? {}),
+      }}
+    >
+      {STATUS_LABEL[status] ?? status}
+    </span>
+  );
+}
+
+function itemsSummary(items) {
+  if (!items || items.length === 0) return "—";
+  const first = items[0].item_name;
+  return items.length > 1 ? `${first} 等 ${items.length} 項` : first;
+}
+
+export default function VendorOrdersPage() {
+  const navigate = useNavigate();
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -22,12 +57,6 @@ function useVendorOrders() {
       .catch((err) => setError(err.message ?? "無法載入訂單"))
       .finally(() => setLoading(false));
   }, []);
-
-  return { orders, loading, error };
-}
-
-export default function VendorOrdersPage() {
-  const { orders, loading, error } = useVendorOrders();
 
   const totalRevenue = orders.reduce((sum, o) => sum + o.total_price_cents, 0);
   const totalItems = orders.reduce(
@@ -43,7 +72,6 @@ export default function VendorOrdersPage() {
       </div>
 
       {loading && <p className="loading-state">載入訂單中...</p>}
-
       {error && <p className="error-state">{error}</p>}
 
       {!loading && !error && orders.length === 0 && (
@@ -71,7 +99,7 @@ export default function VendorOrdersPage() {
             <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "60px 140px 1fr 80px 100px 90px",
+                gridTemplateColumns: "56px 120px 1fr 110px 100px 36px",
                 padding: "10px 20px",
                 borderBottom: "1px solid var(--line)",
                 color: "var(--muted)",
@@ -84,61 +112,48 @@ export default function VendorOrdersPage() {
               <span>#</span>
               <span>來源</span>
               <span>品項</span>
-              <span style={{ textAlign: "right" }}>數量</span>
-              <span style={{ textAlign: "right" }}>小計</span>
+              <span style={{ textAlign: "right" }}>合計</span>
               <span style={{ textAlign: "right" }}>狀態</span>
+              <span />
             </div>
 
-            {orders.map((order, orderIdx) =>
-              order.items.map((item, itemIdx) => (
-                <div
-                  key={`${order.id}-${item.id}`}
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: "60px 140px 1fr 80px 100px 90px",
-                    alignItems: "center",
-                    padding: "14px 20px",
-                    borderBottom:
-                      orderIdx < orders.length - 1 || itemIdx < order.items.length - 1
-                        ? "1px solid var(--line)"
-                        : "none",
-                  }}
-                >
-                  {itemIdx === 0 ? (
-                    <p style={{ margin: 0, fontSize: 12, color: "var(--muted)" }}>#{order.id}</p>
-                  ) : (
-                    <span />
-                  )}
-                  <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>
-                    {`員工 #${order.employee_id}`}
-                  </p>
-                  <p style={{ margin: 0, fontWeight: 500 }}>{item.item_name}</p>
-                  <p style={{ margin: 0, textAlign: "right" }}>× {item.quantity}</p>
-                  <p style={{ margin: 0, textAlign: "right", fontWeight: 600 }}>
-                    {formatPrice(item.total_price_cents)}
-                  </p>
-                  {itemIdx === 0 ? (
-                    <p
-                      style={{
-                        margin: 0,
-                        textAlign: "right",
-                        fontSize: 12,
-                        color:
-                          order.status === "cancelled"
-                            ? "var(--error, #e53)"
-                            : order.status === "delivered"
-                              ? "var(--muted)"
-                              : "inherit",
-                      }}
-                    >
-                      {STATUS_LABEL[order.status] ?? order.status}
-                    </p>
-                  ) : (
-                    <span />
-                  )}
+            {orders.map((order, idx) => (
+              <button
+                key={order.id}
+                type="button"
+                onClick={() => navigate(`/vendor/orders/${order.id}`)}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "56px 120px 1fr 110px 100px 36px",
+                  alignItems: "center",
+                  width: "100%",
+                  padding: "14px 20px",
+                  border: "none",
+                  borderBottom: idx < orders.length - 1 ? "1px solid var(--line)" : "none",
+                  background: "transparent",
+                  cursor: "pointer",
+                  textAlign: "left",
+                  transition: "background 120ms ease",
+                }}
+                onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(23,33,43,0.03)")}
+                onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+              >
+                <p style={{ margin: 0, fontSize: 12, color: "var(--muted)" }}>#{order.id}</p>
+                <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>
+                  員工 #{order.employee_id}
+                </p>
+                <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>
+                  {itemsSummary(order.items)}
+                </p>
+                <p style={{ margin: 0, textAlign: "right", fontWeight: 600 }}>
+                  {formatPrice(order.total_price_cents)}
+                </p>
+                <div style={{ textAlign: "right" }}>
+                  <StatusBadge status={order.status} />
                 </div>
-              )),
-            )}
+                <p style={{ margin: 0, textAlign: "right", color: "var(--muted)", fontSize: 16 }}>›</p>
+              </button>
+            ))}
           </div>
         </>
       )}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -20,6 +20,7 @@ import VendorApplyPage from "../pages/vendor/VendorApplyPage";
 import VendorHomePage from "../pages/vendor/VendorHomePage";
 import VendorMenuFormPage from "../pages/vendor/VendorMenuFormPage";
 import VendorMenuListPage from "../pages/vendor/VendorMenuListPage";
+import VendorOrderDetailPage from "../pages/vendor/VendorOrderDetailPage";
 import VendorOrdersPage from "../pages/vendor/VendorOrdersPage";
 import VendorRevenuePage from "../pages/vendor/VendorRevenuePage";
 import ProtectedRoute from "./ProtectedRoute";
@@ -27,7 +28,7 @@ import RoleRoute from "./RoleRoute";
 import { VendorMenuProvider } from "../vendor/VendorMenuContext";
 
 function HomeRedirect() {
-  const { user, isAuthenticated } = useAuth();
+  const { user, isAuthenticated } = useAuth(); //取得登入狀態和使用者資訊
 
   if (!isAuthenticated || !user) {
     return <Navigate replace to="/login" />;
@@ -83,6 +84,7 @@ export function AppRouter() {
                   <Route element={<VendorMenuFormPage />} path="menu/new" />
                   <Route element={<VendorMenuFormPage />} path="menu/:itemId/edit" />
                   <Route element={<VendorOrdersPage />} path="orders" />
+                  <Route element={<VendorOrderDetailPage />} path="orders/:orderId" />
                   <Route element={<VendorRevenuePage />} path="revenue" />
                 </Route>
               </Route>


### PR DESCRIPTION
## Summary

Adds a vendor-facing order detail page and refactors the order list to enable vendors to view full order information and advance order status step by step.

## Changes

### New: `VendorOrderDetailPage`
- Route: `/vendor/orders/:orderId`
- Displays a full line-item breakdown (item name, quantity, unit price, subtotal) with a total at the bottom
- Right-side info panel shows order metadata: order ID, employee, meal date, created time
- Action buttons are rendered dynamically based on the current order status:
  - `pending` → Confirm / Reject
  - `confirmed` → Start Preparing
  - `preparing` → Mark Ready
  - `ready` → Mark Delivered
- Status transitions call `updateOrderStatus()` and reflect immediately in the UI without a page reload

### Refactor: `VendorOrdersPage`
- Order list changed from **one row per item** to **one row per order**; items are summarised (e.g. _Fried Chicken + 2 more_)
- Each row is now a clickable `<button>` that navigates to the detail page
- Added `StatusBadge` component with colour-coded chips per status for quick visual scanning
- Column layout updated: removed per-item quantity column, added order total

### Router: `router/index.jsx`
- Registered `orders/:orderId` as a child route under `/vendor/orders`, mapped to `VendorOrderDetailPage`

## How to Test

1. Log in as `vendor_manager`
2. Navigate to **Order Management** — verify orders appear one-per-row with correct status badges
3. Click any order row — verify the detail page loads with correct line items and totals
4. Click an action button (e.g. **Confirm Order**) — verify the status badge updates immediately