### PR TITLE
feat(orders): complete order failure error model

### DIFF
--- a/backend/core/order_failure_codes.py
+++ b/backend/core/order_failure_codes.py
@@ -1,0 +1,5 @@
+"""Machine-readable failure codes for employee order placement."""
+
+ITEM_UNAVAILABLE = "ITEM_UNAVAILABLE"
+QUOTA_EXHAUSTED = "QUOTA_EXHAUSTED"
+CONCURRENT_CONFLICT = "CONCURRENT_CONFLICT"

--- a/backend/repositories/postgres_employee_selection_repository.py
+++ b/backend/repositories/postgres_employee_selection_repository.py
@@ -3,9 +3,28 @@ from __future__ import annotations
 from datetime import date
 
 from backend.core.errors import CodedHTTPException
+from backend.core.order_failure_codes import (
+    CONCURRENT_CONFLICT,
+    ITEM_UNAVAILABLE,
+    QUOTA_EXHAUSTED,
+)
 from backend.db.connection import get_connection
 from backend.repositories.employee_selection_repository import OrderItemSnapshot
 from backend.schemas.employee import EmployeeOrder, EmployeeOrderItem, MealSelection
+
+try:
+    from psycopg import errors as psycopg_errors
+except ImportError:  # pragma: no cover - psycopg is present in deployed Postgres environments.
+    psycopg_errors = None
+
+if psycopg_errors is None:
+    _PSYCOPG_CONFLICT_ERRORS: tuple[type[BaseException], ...] = ()
+else:
+    _PSYCOPG_CONFLICT_ERRORS = (
+        psycopg_errors.DeadlockDetected,
+        psycopg_errors.LockNotAvailable,
+        psycopg_errors.SerializationFailure,
+    )
 
 
 def _selection_to_schema(row) -> MealSelection:
@@ -79,24 +98,28 @@ class PostgresEmployeeSelectionRepository:
             # of this transaction, preventing concurrent transactions from
             # passing the quota check simultaneously (eliminates TOCTOU race).
             for item_snap in items:
-                menu_row = conn.execute(
-                    """
-                    SELECT id, daily_quota, available
-                    FROM menu_items
-                    WHERE id = %s
-                    FOR UPDATE
-                    """,
-                    (item_snap.item_id,),
-                ).fetchone()
+                try:
+                    menu_row = conn.execute(
+                        """
+                        SELECT id, daily_quota, available
+                        FROM menu_items
+                        WHERE id = %s
+                        FOR UPDATE
+                        """,
+                        (item_snap.item_id,),
+                    ).fetchone()
+                except _PSYCOPG_CONFLICT_ERRORS as exc:
+                    raise CodedHTTPException(
+                        status_code=409,
+                        code=CONCURRENT_CONFLICT,
+                        detail="order could not be placed due to a concurrent update; please try again",
+                    ) from exc
 
                 if menu_row is None:
                     raise CodedHTTPException(
                         status_code=404, code="not_found", detail="menu item not found"
                     )
-                if not menu_row["available"]:
-                    raise CodedHTTPException(
-                        status_code=409, code="item_unavailable", detail="menu item unavailable"
-                    )
+                used = None
 
                 if menu_row["daily_quota"] is not None:
                     # Count already-ordered quantity within the same locked
@@ -114,10 +137,23 @@ class PostgresEmployeeSelectionRepository:
                     ).fetchone()
                     used = int(used_row["used"])
 
+                    if not menu_row["available"]:
+                        if used >= menu_row["daily_quota"]:
+                            raise CodedHTTPException(
+                                status_code=409,
+                                code=QUOTA_EXHAUSTED,
+                                detail="daily quota exhausted for this item",
+                            )
+                        raise CodedHTTPException(
+                            status_code=409,
+                            code=ITEM_UNAVAILABLE,
+                            detail="menu item unavailable",
+                        )
+
                     if used + item_snap.quantity > menu_row["daily_quota"]:
                         raise CodedHTTPException(
                             status_code=409,
-                            code="quota_exhausted",
+                            code=QUOTA_EXHAUSTED,
                             detail="daily quota exhausted for this item",
                         )
 
@@ -133,6 +169,13 @@ class PostgresEmployeeSelectionRepository:
                             """,
                             (item_snap.item_id,),
                         )
+
+                if not menu_row["available"]:
+                    raise CodedHTTPException(
+                        status_code=409,
+                        code=ITEM_UNAVAILABLE,
+                        detail="menu item unavailable",
+                    )
 
             # ── Step 2: Insert order and line items ──────────────────────────
             total_price_cents = sum(s.quantity * s.unit_price_cents for s in items)

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -5,6 +5,7 @@ import random
 from datetime import date, timedelta
 
 from backend.core.errors import CodedHTTPException
+from backend.core.order_failure_codes import ITEM_UNAVAILABLE, QUOTA_EXHAUSTED
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository, OrderItemSnapshot
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
@@ -217,13 +218,19 @@ class EmployeeOrderingService:
             item = self.menu_item_repository.get(vendor_id=vendor_id, item_id=requested.item_id)
             if item is None:
                 raise CodedHTTPException(status_code=404, code="not_found", detail="menu item not found")
-            if not item.available:
-                raise CodedHTTPException(status_code=409, code="item_unavailable", detail="menu item unavailable")
             used_quantity = used_by_item.get(item.id, 0)
+            if not item.available:
+                if item.daily_quota is not None and used_quantity >= item.daily_quota:
+                    raise CodedHTTPException(
+                        status_code=409,
+                        code=QUOTA_EXHAUSTED,
+                        detail="quantity exceeds remaining daily quota",
+                    )
+                raise CodedHTTPException(status_code=409, code=ITEM_UNAVAILABLE, detail="menu item unavailable")
             if item.daily_quota is not None and used_quantity + requested_by_item[item.id] > item.daily_quota:
                 raise CodedHTTPException(
                     status_code=409,
-                    code="quantity_exceeds_daily_quota",
+                    code=QUOTA_EXHAUSTED,
                     detail="quantity exceeds remaining daily quota",
                 )
 

--- a/backend/tests/integration/test_atomic_quota.py
+++ b/backend/tests/integration/test_atomic_quota.py
@@ -7,7 +7,7 @@ Scenario
 --------
 A menu item has daily_quota = 1.
 N threads each try to create an order for that item simultaneously.
-Expected outcome: exactly 1 succeeds (HTTP 201), the rest get 409 quota_exhausted.
+Expected outcome: exactly 1 succeeds (HTTP 201), the rest get 409 QUOTA_EXHAUSTED.
 """
 from __future__ import annotations
 
@@ -140,12 +140,10 @@ def test_concurrent_orders_no_oversell(quota_item) -> None:
     assert len(failures) == CONCURRENCY - 1, (
         f"Expected {CONCURRENCY - 1} failures, got {len(failures)}: {failures}"
     )
-    # After the winning thread commits, the item is auto-marked available=FALSE
-    # (issue #53). Threads that checked *before* the commit see quota_exhausted;
-    # threads that checked *after* see item_unavailable. Both are correct — no
-    # oversell occurred either way.
-    valid_rejection_codes = {"quota_exhausted", "item_unavailable"}
+    # After the winning thread commits, the item is auto-marked available=FALSE,
+    # but order placement still reports the race-lost case as quota exhaustion.
+    valid_rejection_codes = {"QUOTA_EXHAUSTED"}
     unexpected = [f for f in failures if f not in valid_rejection_codes]
     assert not unexpected, (
-        f"All failures should be quota_exhausted or item_unavailable, got unexpected: {unexpected}"
+        f"All failures should be QUOTA_EXHAUSTED, got unexpected: {unexpected}"
     )

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -5,7 +5,7 @@ from fastapi.testclient import TestClient
 
 from backend.core.vendor_identity import get_vendor_profile_repository
 from backend.main import app
-from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository, OrderItemSnapshot
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
 from backend.routes.employee_ordering import get_employee_selection_repository
@@ -199,7 +199,7 @@ def test_create_order_sums_duplicate_item_quantities_for_quota() -> None:
     )
 
     assert resp.status_code == 409
-    assert resp.json()["code"] == "quantity_exceeds_daily_quota"
+    assert resp.json()["code"] == "QUOTA_EXHAUSTED"
 
 
 def test_create_order_tracks_quota_by_meal_date() -> None:
@@ -225,7 +225,7 @@ def test_create_order_tracks_quota_by_meal_date() -> None:
     )
 
     assert same_date.status_code == 409
-    assert same_date.json()["code"] == "quantity_exceeds_daily_quota"
+    assert same_date.json()["code"] == "QUOTA_EXHAUSTED"
     assert other_date.status_code == 201
     assert other_date.json()["meal_date"] == other_meal_date
 
@@ -354,7 +354,41 @@ def test_select_unavailable_item_returns_409() -> None:
     )
 
     assert resp.status_code == 409
-    assert resp.json()["code"] == "item_unavailable"
+    assert resp.json()["code"] == "ITEM_UNAVAILABLE"
+
+
+def test_select_auto_sold_out_item_returns_quota_exhausted() -> None:
+    client, item_repo, selection_repo = _setup()
+    item = item_repo.create(
+        vendor_id=1,
+        name="Last Bento",
+        price_cents=120,
+        available=False,
+        daily_quota=1,
+    )
+    meal_date = date.today()
+    selection_repo.create_order(
+        employee_id=200,
+        vendor_id=1,
+        meal_date=meal_date,
+        items=[
+            OrderItemSnapshot(
+                item_id=item.id,
+                item_name=item.name,
+                quantity=1,
+                unit_price_cents=item.price_cents,
+            )
+        ],
+    )
+
+    resp = client.post(
+        "/employee/vendors/1/selections",
+        headers=_h(),
+        json={"item_id": item.id, "quantity": 1, "meal_date": meal_date.isoformat()},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "QUOTA_EXHAUSTED"
 
 
 def test_select_quantity_over_daily_quota_returns_409() -> None:
@@ -368,7 +402,7 @@ def test_select_quantity_over_daily_quota_returns_409() -> None:
     )
 
     assert resp.status_code == 409
-    assert resp.json()["code"] == "quantity_exceeds_daily_quota"
+    assert resp.json()["code"] == "QUOTA_EXHAUSTED"
 
 
 def test_employee_endpoints_require_employee_role() -> None:

--- a/backend/tests/test_postgres_quota.py
+++ b/backend/tests/test_postgres_quota.py
@@ -2,9 +2,9 @@
 
 Tests verify that create_order():
   - issues SELECT ... FOR UPDATE on menu_items (row lock)
-  - raises 409 quota_exhausted when quota is full
+  - raises 409 QUOTA_EXHAUSTED when quota is full
   - marks item available=FALSE when quota reaches zero (issue #53)
-  - raises 409 item_unavailable for unavailable items
+  - raises 409 ITEM_UNAVAILABLE for unavailable items
   - raises 404 not_found for missing items
 """
 from __future__ import annotations
@@ -133,7 +133,7 @@ def test_create_order_raises_quota_exhausted_when_used_equals_quota() -> None:
             )
 
     assert exc_info.value.status_code == 409
-    assert exc_info.value.code == "quota_exhausted"
+    assert exc_info.value.code == "QUOTA_EXHAUSTED"
 
 
 def test_create_order_raises_quota_exhausted_when_request_would_exceed() -> None:
@@ -152,7 +152,7 @@ def test_create_order_raises_quota_exhausted_when_request_would_exceed() -> None
             )
 
     assert exc_info.value.status_code == 409
-    assert exc_info.value.code == "quota_exhausted"
+    assert exc_info.value.code == "QUOTA_EXHAUSTED"
 
 
 def test_create_order_succeeds_when_used_plus_requested_equals_quota() -> None:
@@ -234,7 +234,7 @@ def test_create_order_does_not_mark_sold_out_when_quota_not_exhausted() -> None:
 
 
 def test_create_order_skips_quota_check_when_daily_quota_is_none() -> None:
-    """Items with no quota limit should never trigger quota_exhausted."""
+    """Items with no quota limit should never trigger QUOTA_EXHAUSTED."""
     ctx = _conn_with_side_effects(
         _menu_row(daily_quota=None),  # no quota limit
         _order_row(),
@@ -257,7 +257,7 @@ def test_create_order_skips_quota_check_when_daily_quota_is_none() -> None:
 # ---------------------------------------------------------------------------
 
 def test_create_order_raises_item_unavailable() -> None:
-    ctx = _conn_with_side_effects(_menu_row(available=False))
+    ctx = _conn_with_side_effects(_menu_row(daily_quota=None, available=False))
     with patch(
         "backend.repositories.postgres_employee_selection_repository.get_connection",
         return_value=ctx,
@@ -269,7 +269,71 @@ def test_create_order_raises_item_unavailable() -> None:
             )
 
     assert exc_info.value.status_code == 409
-    assert exc_info.value.code == "item_unavailable"
+    assert exc_info.value.code == "ITEM_UNAVAILABLE"
+
+
+def test_create_order_returns_quota_exhausted_when_auto_sold_out_item_is_full() -> None:
+    ctx = _conn_with_side_effects(
+        _menu_row(daily_quota=5, available=False),
+        _used_row(used=5),
+    )
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        with pytest.raises(Exception) as exc_info:
+            repo.create_order(
+                employee_id=1, vendor_id=2, items=[_snapshot()], meal_date=_MEAL_DATE
+            )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.code == "QUOTA_EXHAUSTED"
+
+
+def test_create_order_returns_item_unavailable_when_vendor_disabled_before_quota_full() -> None:
+    ctx = _conn_with_side_effects(
+        _menu_row(daily_quota=5, available=False),
+        _used_row(used=3),
+    )
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        with pytest.raises(Exception) as exc_info:
+            repo.create_order(
+                employee_id=1, vendor_id=2, items=[_snapshot()], meal_date=_MEAL_DATE
+            )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.code == "ITEM_UNAVAILABLE"
+
+
+def test_create_order_translates_lock_conflict_to_concurrent_conflict() -> None:
+    from backend.repositories import postgres_employee_selection_repository as repo_module
+
+    if not repo_module._PSYCOPG_CONFLICT_ERRORS:
+        pytest.skip("psycopg is not installed")
+
+    conn = MagicMock()
+    conn.execute.side_effect = repo_module._PSYCOPG_CONFLICT_ERRORS[0]("lock conflict")
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=conn)
+    ctx.__exit__ = MagicMock(return_value=False)
+
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        with pytest.raises(Exception) as exc_info:
+            repo.create_order(
+                employee_id=1, vendor_id=2, items=[_snapshot()], meal_date=_MEAL_DATE
+            )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.code == "CONCURRENT_CONFLICT"
 
 
 def test_create_order_raises_not_found_for_missing_item() -> None:

--- a/frontend/src/pages/employee/CartPage.jsx
+++ b/frontend/src/pages/employee/CartPage.jsx
@@ -5,8 +5,19 @@ import { useCart } from "../../cart/CartContext";
 import { formatPrice } from "../../utils/format";
 
 function errorMessage(item, err) {
-  if (err.code === "item_unavailable") return `${item.item.name} 已停止供應`;
-  if (err.code === "quantity_exceeds_daily_quota") return `${item.item.name} 數量超過今日配額`;
+  if (err.code === "ITEM_UNAVAILABLE" || err.code === "item_unavailable") {
+    return `${item.item.name} 已停止供應`;
+  }
+  if (
+    err.code === "QUOTA_EXHAUSTED" ||
+    err.code === "quantity_exceeds_daily_quota" ||
+    err.code === "quota_exhausted"
+  ) {
+    return `${item.item.name} 今日配額已售完，請調整數量或選其他餐點`;
+  }
+  if (err.code === "CONCURRENT_CONFLICT") {
+    return `${item.item.name} 下單時有人同時更新庫存，請再試一次`;
+  }
   return `${item.item.name} 送出失敗，請稍後再試`;
 }
 


### PR DESCRIPTION
## Summary
- add stable order failure codes: ITEM_UNAVAILABLE, QUOTA_EXHAUSTED, CONCURRENT_CONFLICT
- return QUOTA_EXHAUSTED for race-lost / auto sold-out last-item cases
- update employee cart error messages for the new failure codes
- cover service, Postgres quota, and concurrent quota expectations in tests

## Tests
- .\.venv\Scripts\python.exe -m pytest backend/tests/test_employee_ordering.py backend/tests/test_postgres_quota.py --basetemp=.pytest_tmp_issue54
- .\.venv\Scripts\python.exe -m pytest backend/tests --basetemp=.pytest_tmp_issue54

Closes #54