### PR TITLE
feat(notifications): add async in-app order notifications

### DIFF
--- a/backend/db/migrations/005_notifications.sql
+++ b/backend/db/migrations/005_notifications.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS notifications (
+  id BIGSERIAL PRIMARY KEY,
+  recipient_user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type VARCHAR(80) NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  sent_at TIMESTAMPTZ,
+  read_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_recipient_unread
+  ON notifications (recipient_user_id, sent_at DESC, id DESC)
+  WHERE read_at IS NULL;

--- a/backend/main.py
+++ b/backend/main.py
@@ -16,6 +16,7 @@ from backend.routes import (
     committee_reviews,
     employee_ordering,
     health,
+    notifications,
     vendor_application,
     vendor_categories,
     vendor_menu,
@@ -64,6 +65,7 @@ def create_app() -> FastAPI:
     app.include_router(vendor_menu.router)
     app.include_router(vendor_orders.router)
     app.include_router(employee_ordering.router)
+    app.include_router(notifications.router)
 
     Instrumentator(should_instrument_requests_inprogress=True).instrument(app).expose(app)
     return app

--- a/backend/repositories/notification_repository.py
+++ b/backend/repositories/notification_repository.py
@@ -1,0 +1,67 @@
+"""In-memory notification persistence for tests and local no-DB mode."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from itertools import count
+from typing import Any
+
+from backend.schemas.notification import Notification
+
+
+@dataclass
+class _NotificationRecord:
+    id: int
+    recipient_user_id: int
+    type: str
+    payload: dict[str, Any]
+    sent_at: datetime | None
+    read_at: datetime | None
+    created_at: datetime
+
+
+class NotificationRepository:
+    def __init__(self) -> None:
+        self._notifications: dict[int, _NotificationRecord] = {}
+        self._id_seq = count(1)
+
+    def create(
+        self,
+        *,
+        recipient_user_id: int,
+        type: str,
+        payload: dict[str, Any],
+    ) -> Notification:
+        now = datetime.now(timezone.utc)
+        record = _NotificationRecord(
+            id=next(self._id_seq),
+            recipient_user_id=recipient_user_id,
+            type=type,
+            payload=dict(payload),
+            sent_at=now,
+            read_at=None,
+            created_at=now,
+        )
+        self._notifications[record.id] = record
+        return self._to_schema(record)
+
+    def list_unread(self, *, recipient_user_id: int) -> list[Notification]:
+        rows = [
+            row
+            for row in self._notifications.values()
+            if row.recipient_user_id == recipient_user_id and row.read_at is None
+        ]
+        rows.sort(key=lambda row: (row.sent_at or row.created_at, row.id), reverse=True)
+        return [self._to_schema(row) for row in rows]
+
+    @staticmethod
+    def _to_schema(record: _NotificationRecord) -> Notification:
+        return Notification(
+            id=record.id,
+            recipient_user_id=record.recipient_user_id,
+            type=record.type,
+            payload=dict(record.payload),
+            sent_at=record.sent_at,
+            read_at=record.read_at,
+            created_at=record.created_at,
+        )

--- a/backend/repositories/postgres_notification_repository.py
+++ b/backend/repositories/postgres_notification_repository.py
@@ -1,0 +1,46 @@
+"""PostgreSQL notification persistence."""
+from __future__ import annotations
+
+from typing import Any
+
+from psycopg.types.json import Jsonb
+
+from backend.db.connection import get_connection
+from backend.schemas.notification import Notification
+
+
+def _notification_to_schema(row) -> Notification:
+    return Notification(**dict(row))
+
+
+class PostgresNotificationRepository:
+    def create(
+        self,
+        *,
+        recipient_user_id: int,
+        type: str,
+        payload: dict[str, Any],
+    ) -> Notification:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                INSERT INTO notifications (recipient_user_id, type, payload, sent_at)
+                VALUES (%s, %s, %s, NOW())
+                RETURNING id, recipient_user_id, type, payload, sent_at, read_at, created_at
+                """,
+                (recipient_user_id, type, Jsonb(payload)),
+            ).fetchone()
+        return _notification_to_schema(row)
+
+    def list_unread(self, *, recipient_user_id: int) -> list[Notification]:
+        with get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, recipient_user_id, type, payload, sent_at, read_at, created_at
+                FROM notifications
+                WHERE recipient_user_id = %s AND read_at IS NULL
+                ORDER BY sent_at DESC NULLS LAST, id DESC
+                """,
+                (recipient_user_id,),
+            ).fetchall()
+        return [_notification_to_schema(row) for row in rows]

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, Query, status
 
 from backend.core.config import settings
 from backend.core.employee_identity import require_employee, require_employee_role
@@ -13,6 +13,7 @@ from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.postgres_employee_selection_repository import PostgresEmployeeSelectionRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
 from backend.routes.vendor_menu import get_menu_item_repository
+from backend.routes.notifications import get_notification_service
 from backend.schemas.employee import (
     EmployeeMenuItem,
     EmployeeOrder,
@@ -24,6 +25,7 @@ from backend.schemas.employee import (
     RandomMealDrawRequest,
 )
 from backend.services.employee_ordering_service import EmployeeOrderingService
+from backend.services.notification_service import NotificationService
 
 router = APIRouter(prefix="/employee", tags=["employee"])
 
@@ -86,20 +88,28 @@ def draw_random_meal(
 def select_meal(
     vendor_id: int,
     payload: MealSelectionCreate,
+    background_tasks: BackgroundTasks,
     employee_id: Annotated[int, Depends(require_employee)],
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+    notification_service: Annotated[NotificationService, Depends(get_notification_service)],
 ) -> MealSelection:
-    return service.select_meal(employee_id, vendor_id, payload)
+    selection = service.select_meal(employee_id, vendor_id, payload)
+    background_tasks.add_task(notification_service.create_order_placed_for_selection, selection)
+    return selection
 
 
 @router.post("/vendors/{vendor_id}/orders", response_model=EmployeeOrder, status_code=status.HTTP_201_CREATED)
 def create_order(
     vendor_id: int,
     payload: EmployeeOrderCreate,
+    background_tasks: BackgroundTasks,
     employee_id: Annotated[int, Depends(require_employee)],
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+    notification_service: Annotated[NotificationService, Depends(get_notification_service)],
 ) -> EmployeeOrder:
-    return service.create_order(employee_id, vendor_id, payload)
+    order = service.create_order(employee_id, vendor_id, payload)
+    background_tasks.add_task(notification_service.create_order_placed, order)
+    return order
 
 
 @router.get("/me/selections", response_model=list[MealSelection])

--- a/backend/routes/notifications.py
+++ b/backend/routes/notifications.py
@@ -1,0 +1,41 @@
+"""Current-user notification APIs."""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from backend.core.config import settings
+from backend.core.employee_identity import require_employee
+from backend.repositories.notification_repository import NotificationRepository
+from backend.repositories.postgres_notification_repository import PostgresNotificationRepository
+from backend.schemas.notification import Notification
+from backend.services.notification_service import NotificationService
+
+router = APIRouter(prefix="/me", tags=["notifications"])
+
+_notification_repo = NotificationRepository()
+_postgres_notification_repo = PostgresNotificationRepository()
+
+
+def get_notification_repository() -> NotificationRepository | PostgresNotificationRepository:
+    if settings.database_url:
+        return _postgres_notification_repo
+    return _notification_repo
+
+
+def get_notification_service(
+    repository: Annotated[
+        NotificationRepository | PostgresNotificationRepository,
+        Depends(get_notification_repository),
+    ],
+) -> NotificationService:
+    return NotificationService(repository)
+
+
+@router.get("/notifications", response_model=list[Notification])
+def list_my_notifications(
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[NotificationService, Depends(get_notification_service)],
+) -> list[Notification]:
+    return service.list_unread(employee_id)

--- a/backend/routes/vendor_orders.py
+++ b/backend/routes/vendor_orders.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends
 
 from backend.core.vendor_identity import require_approved_vendor
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.routes.employee_ordering import get_employee_selection_repository
+from backend.routes.notifications import get_notification_service
 from backend.schemas.employee import EmployeeOrder, VendorOrderStatusUpdate
+from backend.services.notification_service import NotificationService
 from backend.services.vendor_order_service import VendorOrderService
 
 router = APIRouter(prefix="/vendor/me/orders", tags=["vendor-self"])
@@ -41,7 +43,11 @@ def get_vendor_order(
 def update_vendor_order_status(
     order_id: int,
     payload: VendorOrderStatusUpdate,
+    background_tasks: BackgroundTasks,
     vendor_id: Annotated[int, Depends(require_approved_vendor)],
     service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
+    notification_service: Annotated[NotificationService, Depends(get_notification_service)],
 ) -> EmployeeOrder:
-    return service.update_status(vendor_id, order_id, payload.status)
+    order = service.update_status(vendor_id, order_id, payload.status)
+    background_tasks.add_task(notification_service.create_order_status_updated, order)
+    return order

--- a/backend/schemas/notification.py
+++ b/backend/schemas/notification.py
@@ -1,0 +1,17 @@
+"""Notification response schemas."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class Notification(BaseModel):
+    id: int
+    recipient_user_id: int
+    type: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+    sent_at: datetime | None = None
+    read_at: datetime | None = None
+    created_at: datetime

--- a/backend/services/notification_service.py
+++ b/backend/services/notification_service.py
@@ -1,0 +1,52 @@
+"""Notification orchestration for order events."""
+from __future__ import annotations
+
+from backend.repositories.notification_repository import NotificationRepository
+from backend.schemas.employee import EmployeeOrder, MealSelection
+from backend.schemas.notification import Notification
+
+
+class NotificationService:
+    def __init__(self, repository: NotificationRepository) -> None:
+        self._repository = repository
+
+    def list_unread(self, recipient_user_id: int) -> list[Notification]:
+        return self._repository.list_unread(recipient_user_id=recipient_user_id)
+
+    def create_order_placed(self, order: EmployeeOrder) -> Notification:
+        return self._repository.create(
+            recipient_user_id=order.employee_id,
+            type="order_placed",
+            payload={
+                "order_id": order.id,
+                "vendor_id": order.vendor_id,
+                "status": order.status,
+                "meal_date": order.meal_date.isoformat() if order.meal_date else None,
+                "total_price_cents": order.total_price_cents,
+            },
+        )
+
+    def create_order_placed_for_selection(self, selection: MealSelection) -> Notification:
+        return self._repository.create(
+            recipient_user_id=selection.employee_id,
+            type="order_placed",
+            payload={
+                "order_id": selection.order_id,
+                "vendor_id": selection.vendor_id,
+                "status": "pending",
+                "meal_date": selection.meal_date.isoformat() if selection.meal_date else None,
+                "total_price_cents": selection.total_price_cents,
+            },
+        )
+
+    def create_order_status_updated(self, order: EmployeeOrder) -> Notification:
+        return self._repository.create(
+            recipient_user_id=order.employee_id,
+            type="order_status_updated",
+            payload={
+                "order_id": order.id,
+                "vendor_id": order.vendor_id,
+                "status": order.status,
+                "meal_date": order.meal_date.isoformat() if order.meal_date else None,
+            },
+        )

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,137 @@
+"""In-app notifications for employee order events."""
+from fastapi.testclient import TestClient
+
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.notification_repository import NotificationRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.routes.employee_ordering import get_employee_selection_repository
+from backend.routes.notifications import get_notification_repository
+from backend.routes.vendor_menu import get_menu_item_repository
+
+
+def _setup() -> tuple[TestClient, MenuItemRepository, EmployeeSelectionRepository, NotificationRepository]:
+    vendor_repo = VendorProfileRepository()
+    vendor_repo.seed(VendorRecord(id=1, name="Alice Bento", status="approved"))
+
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+    notification_repo = NotificationRepository()
+
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
+    app.dependency_overrides[get_menu_item_repository] = lambda: item_repo
+    app.dependency_overrides[get_employee_selection_repository] = lambda: selection_repo
+    app.dependency_overrides[get_notification_repository] = lambda: notification_repo
+    return TestClient(app), item_repo, selection_repo, notification_repo
+
+
+def _employee_headers(user_id: int = 100) -> dict[str, str]:
+    return {"x-user-role": "employee", "x-user-id": str(user_id)}
+
+
+def _vendor_headers(vendor_id: int = 1) -> dict[str, str]:
+    return {"x-user-role": "vendor_manager", "x-vendor-id": str(vendor_id)}
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+def test_order_creation_enqueues_unread_notification_for_employee() -> None:
+    client, item_repo, _, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+
+    resp = client.post(
+        "/employee/vendors/1/orders",
+        headers=_employee_headers(100),
+        json={"items": [{"item_id": item.id, "quantity": 2}]},
+    )
+
+    assert resp.status_code == 201
+    order = resp.json()
+
+    notifications = client.get("/me/notifications", headers=_employee_headers(100))
+    assert notifications.status_code == 200
+    body = notifications.json()
+    assert len(body) == 1
+    assert body[0]["recipient_user_id"] == 100
+    assert body[0]["type"] == "order_placed"
+    assert body[0]["read_at"] is None
+    assert body[0]["sent_at"] is not None
+    assert body[0]["payload"] == {
+        "order_id": order["id"],
+        "vendor_id": 1,
+        "status": "pending",
+        "meal_date": order["meal_date"],
+        "total_price_cents": 240,
+    }
+
+
+def test_legacy_meal_selection_enqueues_order_notification() -> None:
+    client, item_repo, _, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+
+    resp = client.post(
+        "/employee/vendors/1/selections",
+        headers=_employee_headers(100),
+        json={"item_id": item.id, "quantity": 1},
+    )
+
+    assert resp.status_code == 201
+    selection = resp.json()
+
+    notifications = client.get("/me/notifications", headers=_employee_headers(100))
+    assert notifications.status_code == 200
+    body = notifications.json()
+    assert len(body) == 1
+    assert body[0]["type"] == "order_placed"
+    assert body[0]["payload"]["order_id"] == selection["order_id"]
+    assert body[0]["payload"]["total_price_cents"] == 120
+
+
+def test_vendor_status_update_enqueues_notification_for_ordering_employee() -> None:
+    client, _, selection_repo, _ = _setup()
+    order = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=None)
+
+    resp = client.patch(
+        f"/vendor/me/orders/{order.id}/status",
+        headers=_vendor_headers(1),
+        json={"status": "confirmed"},
+    )
+
+    assert resp.status_code == 200
+
+    notifications = client.get("/me/notifications", headers=_employee_headers(100))
+    assert notifications.status_code == 200
+    body = notifications.json()
+    assert len(body) == 1
+    assert body[0]["type"] == "order_status_updated"
+    assert body[0]["payload"] == {
+        "order_id": order.id,
+        "vendor_id": 1,
+        "status": "confirmed",
+        "meal_date": None,
+    }
+
+
+def test_my_notifications_returns_only_current_users_unread_notifications() -> None:
+    client, _, _, notification_repo = _setup()
+    notification_repo.create(
+        recipient_user_id=100,
+        type="order_placed",
+        payload={"order_id": 1},
+    )
+    notification_repo.create(
+        recipient_user_id=200,
+        type="order_placed",
+        payload={"order_id": 2},
+    )
+
+    resp = client.get("/me/notifications", headers=_employee_headers(100))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [notification["recipient_user_id"] for notification in body] == [100]
+    assert [notification["payload"]["order_id"] for notification in body] == [1]


### PR DESCRIPTION
## Summary
- add notifications table and Postgres/in-memory repositories
- add GET /me/notifications for current employee unread notifications
- enqueue in-app notifications via FastAPI BackgroundTasks after employee order creation, legacy meal selection, and vendor status updates

## Tests
- pytest backend/tests/test_notifications.py backend/tests/test_employee_ordering.py backend/tests/test_vendor_orders.py -q
- pytest -p no:cacheprovider backend/tests -q (with TMP/TEMP pointed at repo .tmp/pytest due local Windows temp permissions)

Closes #55