### PR TITLE
Add employee meal order modify and delete

### DIFF
--- a/backend/repositories/employee_selection_repository.py
+++ b/backend/repositories/employee_selection_repository.py
@@ -138,6 +138,46 @@ class EmployeeSelectionRepository:
         )
         return self._order_to_schema(self._orders[order.id])
 
+    def update_order(
+        self,
+        *,
+        employee_id: int,
+        order_id: int,
+        items: list[OrderItemSnapshot],
+        meal_date: date | None = None,
+    ) -> EmployeeOrder | None:
+        order = self._orders.get(order_id)
+        if order is None or order.employee_id != employee_id:
+            return None
+
+        now = datetime.now(timezone.utc)
+        self._orders[order.id] = _OrderRecord(
+            id=order.id,
+            employee_id=order.employee_id,
+            vendor_id=order.vendor_id,
+            meal_date=meal_date,
+            status=order.status,
+            created_at=order.created_at,
+            updated_at=now,
+            cancelled_at=order.cancelled_at,
+        )
+
+        for item_id in [r.id for r in self._items.values() if r.order_id == order.id]:
+            del self._items[item_id]
+
+        for item in items:
+            rec = _OrderItemRecord(
+                id=next(self._item_id_seq),
+                order_id=order.id,
+                item_id=item.item_id,
+                item_name=item.item_name,
+                quantity=item.quantity,
+                unit_price_cents=item.unit_price_cents,
+            )
+            self._items[rec.id] = rec
+
+        return self._order_to_schema(self._orders[order.id])
+
     def create(
         self,
         *,
@@ -210,12 +250,18 @@ class EmployeeSelectionRepository:
         return selections
 
     def item_quantities_for_date(
-        self, *, meal_date: date, vendor_ids: list[int] | None = None
+        self,
+        *,
+        meal_date: date,
+        vendor_ids: list[int] | None = None,
+        exclude_order_id: int | None = None,
     ) -> dict[int, int]:
         vendor_filter = set(vendor_ids) if vendor_ids is not None else None
         quantities: dict[int, int] = {}
         for order in self._orders.values():
             if order.meal_date != meal_date or order.status == "cancelled":
+                continue
+            if exclude_order_id is not None and order.id == exclude_order_id:
                 continue
             if vendor_filter is not None and order.vendor_id not in vendor_filter:
                 continue

--- a/backend/repositories/postgres_employee_selection_repository.py
+++ b/backend/repositories/postgres_employee_selection_repository.py
@@ -355,14 +355,143 @@ class PostgresEmployeeSelectionRepository:
                     return None
             return self._hydrate_order(conn, row)
 
+    def update_order(
+        self,
+        *,
+        employee_id: int,
+        order_id: int,
+        items: list[OrderItemSnapshot],
+        meal_date: date | None = None,
+    ) -> EmployeeOrder | None:
+        with get_connection() as conn:
+            order_row = conn.execute(
+                """
+                SELECT id, employee_id, vendor_id, meal_date, status,
+                       total_price_cents, created_at, updated_at, cancelled_at
+                FROM orders
+                WHERE employee_id = %s AND id = %s
+                FOR UPDATE
+                """,
+                (employee_id, order_id),
+            ).fetchone()
+            if order_row is None:
+                return None
+
+            for item_snap in items:
+                try:
+                    menu_row = conn.execute(
+                        """
+                        SELECT id, daily_quota, available
+                        FROM menu_items
+                        WHERE id = %s
+                        FOR UPDATE
+                        """,
+                        (item_snap.item_id,),
+                    ).fetchone()
+                except _PSYCOPG_CONFLICT_ERRORS as exc:
+                    raise CodedHTTPException(
+                        status_code=409,
+                        code=CONCURRENT_CONFLICT,
+                        detail="order could not be updated due to a concurrent update; please try again",
+                    ) from exc
+
+                if menu_row is None:
+                    raise CodedHTTPException(
+                        status_code=404, code="not_found", detail="menu item not found"
+                    )
+
+                if menu_row["daily_quota"] is not None:
+                    used_row = conn.execute(
+                        """
+                        SELECT COALESCE(SUM(oi.quantity), 0) AS used
+                        FROM order_items oi
+                        JOIN orders o ON o.id = oi.order_id
+                        WHERE oi.item_id = %s
+                          AND o.meal_date = %s
+                          AND o.status <> 'cancelled'
+                          AND o.id <> %s
+                        """,
+                        (item_snap.item_id, meal_date, order_id),
+                    ).fetchone()
+                    used = int(used_row["used"])
+
+                    if not menu_row["available"] and used >= menu_row["daily_quota"]:
+                        raise CodedHTTPException(
+                            status_code=409,
+                            code=QUOTA_EXHAUSTED,
+                            detail="daily quota exhausted for this item",
+                        )
+
+                    if menu_row["available"] and used + item_snap.quantity > menu_row["daily_quota"]:
+                        raise CodedHTTPException(
+                            status_code=409,
+                            code=QUOTA_EXHAUSTED,
+                            detail="daily quota exhausted for this item",
+                        )
+
+                if not menu_row["available"]:
+                    raise CodedHTTPException(
+                        status_code=409,
+                        code=ITEM_UNAVAILABLE,
+                        detail="menu item unavailable",
+                    )
+
+            total_price_cents = sum(s.quantity * s.unit_price_cents for s in items)
+            row = conn.execute(
+                """
+                UPDATE orders
+                SET meal_date = %s,
+                    total_price_cents = %s,
+                    updated_at = NOW()
+                WHERE employee_id = %s AND id = %s
+                RETURNING id, employee_id, vendor_id, meal_date, status,
+                          total_price_cents, created_at, updated_at, cancelled_at
+                """,
+                (meal_date, total_price_cents, employee_id, order_id),
+            ).fetchone()
+
+            conn.execute("DELETE FROM order_items WHERE order_id = %s", (order_id,))
+            item_rows = []
+            for item_snap in items:
+                item_rows.append(
+                    conn.execute(
+                        """
+                        INSERT INTO order_items (
+                            order_id, item_id, item_name, quantity,
+                            unit_price_cents, total_price_cents
+                        )
+                        VALUES (%s, %s, %s, %s, %s, %s)
+                        RETURNING id, order_id, item_id, item_name, quantity,
+                                  unit_price_cents, total_price_cents
+                        """,
+                        (
+                            order_id,
+                            item_snap.item_id,
+                            item_snap.item_name,
+                            item_snap.quantity,
+                            item_snap.unit_price_cents,
+                            item_snap.quantity * item_snap.unit_price_cents,
+                        ),
+                    ).fetchone()
+                )
+
+        return _order_to_schema(row, item_rows)
+
     def item_quantities_for_date(
-        self, *, meal_date: date, vendor_ids: list[int] | None = None
+        self,
+        *,
+        meal_date: date,
+        vendor_ids: list[int] | None = None,
+        exclude_order_id: int | None = None,
     ) -> dict[int, int]:
         where = ["o.meal_date = %s", "o.status <> 'cancelled'"]
         values: list[object] = [meal_date]
         if vendor_ids is not None:
             where.append("o.vendor_id = ANY(%s)")
             values.append(vendor_ids)
+        if exclude_order_id is not None:
+            where.append("o.id <> %s")
+            values.append(exclude_order_id)
 
         with get_connection() as conn:
             rows = conn.execute(

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, Query, Response, status
 
 from backend.core.config import settings
 from backend.core.employee_identity import require_employee, require_employee_role
@@ -18,6 +18,7 @@ from backend.schemas.employee import (
     EmployeeMenuItem,
     EmployeeOrder,
     EmployeeOrderCreate,
+    EmployeeOrderUpdate,
     EmployeeVendor,
     MealSelection,
     MealSelectionCreate,
@@ -137,6 +138,16 @@ def get_my_order(
     return service.get_my_order(employee_id, order_id)
 
 
+@router.put("/me/orders/{order_id}", response_model=EmployeeOrder)
+def update_my_order(
+    order_id: int,
+    payload: EmployeeOrderUpdate,
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> EmployeeOrder:
+    return service.update_my_order(employee_id, order_id, payload)
+
+
 @router.post("/me/orders/{order_id}/cancel", response_model=EmployeeOrder)
 def cancel_my_order(
     order_id: int,
@@ -144,3 +155,13 @@ def cancel_my_order(
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
 ) -> EmployeeOrder:
     return service.cancel_my_order(employee_id, order_id)
+
+
+@router.delete("/me/orders/{order_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_my_order(
+    order_id: int,
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> Response:
+    service.cancel_my_order(employee_id, order_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/schemas/employee.py
+++ b/backend/schemas/employee.py
@@ -68,6 +68,11 @@ class EmployeeOrderCreate(BaseModel):
     meal_date: date | None = None
 
 
+class EmployeeOrderUpdate(BaseModel):
+    items: list[EmployeeOrderItemCreate] = Field(min_length=1)
+    meal_date: date | None = None
+
+
 class EmployeeOrderItem(BaseModel):
     id: int
     order_id: int

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -14,6 +14,7 @@ from backend.schemas.employee import (
     EmployeeOrder,
     EmployeeOrderCreate,
     EmployeeOrderItemCreate,
+    EmployeeOrderUpdate,
     EmployeeVendor,
     MealSelection,
     MealSelectionCreate,
@@ -169,6 +170,36 @@ class EmployeeOrderingService:
             raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
         return cancelled
 
+    def update_my_order(
+        self, employee_id: int, order_id: int, payload: EmployeeOrderUpdate
+    ) -> EmployeeOrder:
+        order = self.get_my_order(employee_id, order_id)
+        if order.status != "pending":
+            raise CodedHTTPException(
+                status_code=409,
+                code="order_not_modifiable",
+                detail="only pending orders can be modified",
+            )
+
+        self._get_approved_vendor(order.vendor_id)
+        meal_date = payload.meal_date or order.meal_date or date.today()
+        self._ensure_meal_date_in_window(meal_date)
+        snapshots = self._build_order_items(
+            order.vendor_id,
+            EmployeeOrderCreate(meal_date=meal_date, items=payload.items),
+            meal_date=meal_date,
+            exclude_order_id=order.id,
+        )
+        updated = self.selection_repository.update_order(
+            employee_id=employee_id,
+            order_id=order_id,
+            items=snapshots,
+            meal_date=meal_date,
+        )
+        if updated is None:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
+        return updated
+
     def _get_approved_vendor(self, vendor_id: int) -> VendorRecord:
         vendor = self.vendor_repository.get(vendor_id)
         if vendor is None or vendor.status != "approved":
@@ -201,7 +232,12 @@ class EmployeeOrderingService:
         )
 
     def _build_order_items(
-        self, vendor_id: int, payload: EmployeeOrderCreate, *, meal_date: date
+        self,
+        vendor_id: int,
+        payload: EmployeeOrderCreate,
+        *,
+        meal_date: date,
+        exclude_order_id: int | None = None,
     ) -> list[OrderItemSnapshot]:
         requested_by_item: dict[int, int] = {}
         for requested in payload.items:
@@ -212,6 +248,7 @@ class EmployeeOrderingService:
         used_by_item = self.selection_repository.item_quantities_for_date(
             meal_date=meal_date,
             vendor_ids=[vendor_id],
+            exclude_order_id=exclude_order_id,
         )
         snapshots: list[OrderItemSnapshot] = []
         for requested in payload.items:

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -183,6 +183,98 @@ def test_cancel_pending_order_marks_order_cancelled() -> None:
     assert body["cancelled_at"] is not None
 
 
+def test_update_pending_order_replaces_quantities_and_total() -> None:
+    client, item_repo, _ = _setup()
+    rice = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=5)
+    tea = item_repo.create(vendor_id=1, name="Tea", price_cents=40, daily_quota=5)
+    order = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={
+            "items": [
+                {"item_id": rice.id, "quantity": 1},
+                {"item_id": tea.id, "quantity": 1},
+            ]
+        },
+    ).json()
+
+    resp = client.put(
+        f"/employee/me/orders/{order['id']}",
+        headers=_h(100),
+        json={"items": [{"item_id": rice.id, "quantity": 3}]},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["total_price_cents"] == 360
+    assert [(item["item_name"], item["quantity"]) for item in body["items"]] == [
+        ("Rice Bowl", 3),
+    ]
+
+
+def test_update_pending_order_checks_quota_without_counting_original_order() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=3)
+    meal_date = _meal_date()
+    order = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"meal_date": meal_date, "items": [{"item_id": item.id, "quantity": 2}]},
+    ).json()
+
+    same_quantity = client.put(
+        f"/employee/me/orders/{order['id']}",
+        headers=_h(100),
+        json={"meal_date": meal_date, "items": [{"item_id": item.id, "quantity": 2}]},
+    )
+    increased_quantity = client.put(
+        f"/employee/me/orders/{order['id']}",
+        headers=_h(100),
+        json={"meal_date": meal_date, "items": [{"item_id": item.id, "quantity": 4}]},
+    )
+
+    assert same_quantity.status_code == 200
+    assert increased_quantity.status_code == 409
+    assert increased_quantity.json()["code"] == "QUOTA_EXHAUSTED"
+
+
+def test_update_order_rejects_cancelled_order() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+    order = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"items": [{"item_id": item.id, "quantity": 1}]},
+    ).json()
+    client.post(f"/employee/me/orders/{order['id']}/cancel", headers=_h(100))
+
+    resp = client.put(
+        f"/employee/me/orders/{order['id']}",
+        headers=_h(100),
+        json={"items": [{"item_id": item.id, "quantity": 2}]},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "order_not_modifiable"
+
+
+def test_delete_pending_order_cancels_order() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+    order = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"items": [{"item_id": item.id, "quantity": 1}]},
+    ).json()
+
+    resp = client.delete(f"/employee/me/orders/{order['id']}", headers=_h(100))
+
+    assert resp.status_code == 204
+    detail = client.get(f"/employee/me/orders/{order['id']}", headers=_h(100)).json()
+    assert detail["status"] == "cancelled"
+
+
 def test_create_order_sums_duplicate_item_quantities_for_quota() -> None:
     client, item_repo, _ = _setup()
     item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=2)

--- a/frontend/src/api/employee.js
+++ b/frontend/src/api/employee.js
@@ -34,6 +34,27 @@ export function getMySelections() {
   return withMockFallback(() => apiFetch("/employee/me/selections"), []);
 }
 
+export function getMyOrders() {
+  return withMockFallback(() => apiFetch("/employee/me/orders"), []);
+}
+
+export function updateMyOrder(orderId, { items, mealDate }) {
+  const payload = { items: items.map((item) => ({ item_id: item.itemId, quantity: item.quantity })) };
+  if (mealDate != null) payload.meal_date = mealDate;
+
+  return apiFetch(`/employee/me/orders/${orderId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export function deleteMyOrder(orderId) {
+  return apiFetch(`/employee/me/orders/${orderId}`, {
+    method: "DELETE",
+  });
+}
+
 export function getVendorMenu(vendorId, { available } = {}) {
   const params = new URLSearchParams();
   if (available != null) params.set("available", String(available));

--- a/frontend/src/hooks/useMyOrders.js
+++ b/frontend/src/hooks/useMyOrders.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+import { getMyOrders } from "../api/employee";
+
+export function useMyOrders() {
+  const [orders, setOrders] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getMyOrders()
+      .then((data) => { if (!cancelled) setOrders(data); })
+      .catch((err) => { if (!cancelled) setError(err); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return { orders, setOrders, loading, error };
+}

--- a/frontend/src/pages/employee/OrdersPage.jsx
+++ b/frontend/src/pages/employee/OrdersPage.jsx
@@ -1,5 +1,16 @@
-import { useMySelections } from "../../hooks/useMySelections";
+import { useState } from "react";
+import { deleteMyOrder, updateMyOrder } from "../../api/employee";
+import { useMyOrders } from "../../hooks/useMyOrders";
 import { formatPrice } from "../../utils/format";
+
+const STATUS_LABELS = {
+  pending: "待確認",
+  confirmed: "已確認",
+  preparing: "準備中",
+  ready: "可取餐",
+  delivered: "已完成",
+  cancelled: "已取消",
+};
 
 function formatDate(isoString) {
   const d = new Date(isoString);
@@ -11,8 +22,74 @@ function formatDate(isoString) {
   });
 }
 
+function errorMessage(err) {
+  if (err.code === "QUOTA_EXHAUSTED" || err.code === "quota_exhausted") {
+    return "餐點數量已超過當日剩餘份數。";
+  }
+  if (err.code === "ITEM_UNAVAILABLE" || err.code === "item_unavailable") {
+    return "餐點目前無法訂購。";
+  }
+  if (err.code === "order_not_modifiable" || err.code === "order_not_cancellable") {
+    return "只有待確認的訂單可以修改或刪除。";
+  }
+  return "操作失敗，請稍後再試。";
+}
+
+function draftFromOrder(order) {
+  return Object.fromEntries(order.items.map((item) => [item.id, item.quantity]));
+}
+
 export default function OrdersPage() {
-  const { selections, loading, error } = useMySelections();
+  const { orders, setOrders, loading, error } = useMyOrders();
+  const [editingOrderId, setEditingOrderId] = useState(null);
+  const [draftQuantities, setDraftQuantities] = useState({});
+  const [busyOrderId, setBusyOrderId] = useState(null);
+  const [actionError, setActionError] = useState(null);
+
+  const visibleOrders = orders.filter((order) => order.status !== "cancelled");
+
+  function startEditing(order) {
+    setEditingOrderId(order.id);
+    setDraftQuantities(draftFromOrder(order));
+    setActionError(null);
+  }
+
+  function updateDraft(itemId, quantity) {
+    setDraftQuantities((prev) => ({ ...prev, [itemId]: Math.max(1, quantity) }));
+  }
+
+  async function saveOrder(order) {
+    setBusyOrderId(order.id);
+    setActionError(null);
+    try {
+      const updated = await updateMyOrder(order.id, {
+        mealDate: order.meal_date,
+        items: order.items.map((item) => ({
+          itemId: item.item_id,
+          quantity: draftQuantities[item.id] ?? item.quantity,
+        })),
+      });
+      setOrders((prev) => prev.map((entry) => (entry.id === updated.id ? updated : entry)));
+      setEditingOrderId(null);
+    } catch (err) {
+      setActionError(errorMessage(err));
+    } finally {
+      setBusyOrderId(null);
+    }
+  }
+
+  async function removeOrder(order) {
+    setBusyOrderId(order.id);
+    setActionError(null);
+    try {
+      await deleteMyOrder(order.id);
+      setOrders((prev) => prev.filter((entry) => entry.id !== order.id));
+    } catch (err) {
+      setActionError(errorMessage(err));
+    } finally {
+      setBusyOrderId(null);
+    }
+  }
 
   return (
     <div>
@@ -23,41 +100,151 @@ export default function OrdersPage() {
 
       {loading && <p className="loading-state">載入訂單中...</p>}
 
-      {error && (
-        <p className="error-state">無法載入訂單，請稍後再試。</p>
+      {error && <p className="error-state">無法載入訂單，請稍後再試。</p>}
+      {actionError && <p className="error-state" style={{ marginBottom: 20 }}>{actionError}</p>}
+
+      {!loading && !error && visibleOrders.length === 0 && (
+        <p className="empty-state">尚無目前訂單。</p>
       )}
 
-      {!loading && !error && selections.length === 0 && (
-        <p className="empty-state">尚無訂單紀錄。</p>
-      )}
-
-      {!loading && !error && selections.length > 0 && (
+      {!loading && !error && visibleOrders.length > 0 && (
         <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
-          {selections.map((sel, idx) => (
-            <div
-              key={sel.id}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 16,
-                padding: "16px 20px",
-                borderBottom: idx < selections.length - 1 ? "1px solid var(--line)" : "none",
-              }}
-            >
-              <div style={{ flex: 1 }}>
-                <p style={{ fontWeight: 600, margin: 0 }}>{sel.item_name}</p>
-                <p style={{ color: "var(--muted)", fontSize: 13, margin: "2px 0 0" }}>
-                  {formatDate(sel.created_at)}
-                </p>
+          {visibleOrders.map((order, idx) => {
+            const isEditing = editingOrderId === order.id;
+            const canEdit = order.status === "pending";
+            const total = isEditing
+              ? order.items.reduce(
+                  (sum, item) => sum + item.unit_price_cents * (draftQuantities[item.id] ?? item.quantity),
+                  0,
+                )
+              : order.total_price_cents;
+
+            return (
+              <div
+                key={order.id}
+                style={{
+                  display: "grid",
+                  gap: 14,
+                  padding: "18px 20px",
+                  borderBottom: idx < visibleOrders.length - 1 ? "1px solid var(--line)" : "none",
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
+                  <div>
+                    <p style={{ fontWeight: 700, margin: 0 }}>訂單 #{order.id}</p>
+                    <p style={{ color: "var(--muted)", fontSize: 13, margin: "4px 0 0" }}>
+                      {order.meal_date ? `用餐日 ${order.meal_date}` : formatDate(order.created_at)}
+                    </p>
+                  </div>
+                  <div style={{ textAlign: "right" }}>
+                    <p style={{ fontWeight: 800, margin: 0 }}>{formatPrice(total)}</p>
+                    <p style={{ color: "var(--muted)", fontSize: 13, margin: "4px 0 0" }}>
+                      {STATUS_LABELS[order.status] ?? order.status}
+                    </p>
+                  </div>
+                </div>
+
+                <div style={{ display: "grid", gap: 10 }}>
+                  {order.items.map((item) => (
+                    <div
+                      key={item.id}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        gap: 12,
+                      }}
+                    >
+                      <div>
+                        <p style={{ fontWeight: 600, margin: 0 }}>{item.item_name}</p>
+                        <p style={{ color: "var(--muted)", fontSize: 13, margin: "2px 0 0" }}>
+                          {formatPrice(item.unit_price_cents)} / 份
+                        </p>
+                      </div>
+                      {isEditing ? (
+                        <div className="quantity-stepper" style={{ marginRight: 0 }}>
+                          <button
+                            className="stepper-btn"
+                            type="button"
+                            aria-label="減少數量"
+                            onClick={() => updateDraft(item.id, (draftQuantities[item.id] ?? item.quantity) - 1)}
+                            disabled={(draftQuantities[item.id] ?? item.quantity) <= 1 || busyOrderId === order.id}
+                          >
+                            -
+                          </button>
+                          <span className="stepper-value">{draftQuantities[item.id] ?? item.quantity}</span>
+                          <button
+                            className="stepper-btn"
+                            type="button"
+                            aria-label="增加數量"
+                            onClick={() => updateDraft(item.id, (draftQuantities[item.id] ?? item.quantity) + 1)}
+                            disabled={busyOrderId === order.id}
+                          >
+                            +
+                          </button>
+                        </div>
+                      ) : (
+                        <p style={{ color: "var(--muted)", fontSize: 14, margin: 0 }}>
+                          x {item.quantity}
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+
+                {canEdit && (
+                  <div style={{ display: "flex", justifyContent: "flex-end", gap: 10, flexWrap: "wrap" }}>
+                    {isEditing ? (
+                      <>
+                        <button
+                          className="ghost-button"
+                          type="button"
+                          onClick={() => setEditingOrderId(null)}
+                          disabled={busyOrderId === order.id}
+                          style={{ color: "var(--text)", borderColor: "var(--line)", background: "var(--surface)" }}
+                        >
+                          取消
+                        </button>
+                        <button
+                          className="primary-button"
+                          type="button"
+                          onClick={() => saveOrder(order)}
+                          disabled={busyOrderId === order.id}
+                        >
+                          {busyOrderId === order.id ? "儲存中..." : "儲存修改"}
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          className="ghost-button"
+                          type="button"
+                          onClick={() => startEditing(order)}
+                          disabled={busyOrderId === order.id}
+                          style={{ color: "var(--text)", borderColor: "var(--line)", background: "var(--surface)" }}
+                        >
+                          編輯
+                        </button>
+                        <button
+                          className="ghost-button"
+                          type="button"
+                          onClick={() => removeOrder(order)}
+                          disabled={busyOrderId === order.id}
+                          style={{
+                            color: "var(--brand-deep)",
+                            borderColor: "rgba(200, 92, 44, 0.28)",
+                            background: "rgba(200, 92, 44, 0.08)",
+                          }}
+                        >
+                          {busyOrderId === order.id ? "刪除中..." : "刪除"}
+                        </button>
+                      </>
+                    )}
+                  </div>
+                )}
               </div>
-              <p style={{ color: "var(--muted)", fontSize: 14, margin: 0 }}>
-                × {sel.quantity}
-              </p>
-              <p style={{ width: 90, textAlign: "right", fontWeight: 600, margin: 0 }}>
-                {formatPrice(sel.total_price_cents)}
-              </p>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add employee APIs to update pending orders and delete orders via cancellation
- keep quota validation correct when modifying an existing order
- update employee orders page with edit/delete actions and API helpers

## Tests
- python -m pytest backend/tests/test_employee_ordering.py -q
- python -m pytest backend/tests -q --basetemp=.tmp\\pytest -o cache_dir=.tmp\\pytest-cache

## Notes
- Frontend build was not run locally because node/npm are not installed in this shell.