### PR TITLE
feat(facility): filter employee vendor visibility by facility intersection (#65)

### DIFF
--- a/backend/db/migrations/006_employee_facilities.sql
+++ b/backend/db/migrations/006_employee_facilities.sql
@@ -1,0 +1,50 @@
+-- Issue #65: facility-based employee/vendor visibility
+-- Add employee_facilities join table so each employee can be assigned to one or more
+-- facilities; vendor visibility is then filtered to the intersection of facilities.
+
+CREATE TABLE IF NOT EXISTS employee_facilities (
+  employee_id  BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  facility_id  BIGINT NOT NULL REFERENCES facilities(id) ON DELETE CASCADE,
+  PRIMARY KEY (employee_id, facility_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_employee_facilities_facility_id
+  ON employee_facilities (facility_id);
+
+-- Seed: ensure F12A facility exists (safe if already inserted by other migration)
+INSERT INTO facilities (code, name)
+VALUES ('F12A', 'Fab 12A')
+ON CONFLICT (code) DO NOTHING;
+
+-- Seed: assign the default vendor ("Sunny Kitchen") to F12A, and
+-- the default employee account to F12A so they keep seeing each other.
+-- Uses subqueries to stay ID-agnostic across environments.
+DO $$
+DECLARE
+  v_facility_id BIGINT;
+  v_vendor_id   BIGINT;
+  v_employee_id BIGINT;
+BEGIN
+  SELECT id INTO v_facility_id FROM facilities WHERE code = 'F12A';
+
+  -- Vendor seed (only if "Sunny Kitchen" exists)
+  SELECT id INTO v_vendor_id FROM vendors WHERE name = 'Sunny Kitchen' LIMIT 1;
+  IF v_vendor_id IS NOT NULL AND v_facility_id IS NOT NULL THEN
+    INSERT INTO vendor_facilities (vendor_id, facility_id)
+    VALUES (v_vendor_id, v_facility_id)
+    ON CONFLICT DO NOTHING;
+  END IF;
+
+  -- Employee seed: first user with role "employee"
+  SELECT u.id INTO v_employee_id
+  FROM users u
+  JOIN roles r ON r.id = u.role_id
+  WHERE r.name = 'employee'
+  ORDER BY u.id
+  LIMIT 1;
+  IF v_employee_id IS NOT NULL AND v_facility_id IS NOT NULL THEN
+    INSERT INTO employee_facilities (employee_id, facility_id)
+    VALUES (v_employee_id, v_facility_id)
+    ON CONFLICT DO NOTHING;
+  END IF;
+END $$;

--- a/backend/repositories/postgres_vendor_profile_repository.py
+++ b/backend/repositories/postgres_vendor_profile_repository.py
@@ -149,3 +149,19 @@ class PostgresVendorProfileRepository:
             ).fetchall()
 
         return [Facility(**dict(row)) for row in rows]
+
+    def list_employee_facilities(self, employee_id: int) -> list[Facility]:
+        """回傳員工所屬廠區列表。空列表表示未指派（不限制可見商家）。"""
+        with get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT f.id, f.code, f.name
+                FROM facilities AS f
+                JOIN employee_facilities AS ef ON ef.facility_id = f.id
+                WHERE ef.employee_id = %s
+                ORDER BY f.code, f.id
+                """,
+                (employee_id,),
+            ).fetchall()
+
+        return [Facility(**dict(row)) for row in rows]

--- a/backend/repositories/vendor_profile_repository.py
+++ b/backend/repositories/vendor_profile_repository.py
@@ -4,6 +4,7 @@
 DB 接好後將此檔換成真正的 SQL 實作；route / service 介面不需更動。
 
 `assign_facility` 在實際系統中由委員會模組寫入；這裡保留是給測試/seed 用。
+`assign_employee_facility` 同理，管理端指派後 employee 端唯讀。
 """
 from __future__ import annotations
 
@@ -29,6 +30,8 @@ class VendorProfileRepository:
         self._vendors: dict[int, VendorRecord] = {}
         # vendor_id -> list of Facility
         self._facilities: dict[int, list[Facility]] = {}
+        # employee_id -> list of Facility
+        self._employee_facilities: dict[int, list[Facility]] = {}
 
     # --- seed / write side (admin / committee in real life) ---
 
@@ -41,6 +44,11 @@ class VendorProfileRepository:
         """委員會模組 stub：把廠區指派給商家。"""
         self._facilities.setdefault(vendor_id, [])
         self._facilities[vendor_id].append(Facility(id=facility_id, code=code, name=name))
+
+    def assign_employee_facility(self, employee_id: int, *, facility_id: int, code: str, name: str) -> None:
+        """管理端 stub：把廠區指派給員工。"""
+        self._employee_facilities.setdefault(employee_id, [])
+        self._employee_facilities[employee_id].append(Facility(id=facility_id, code=code, name=name))
 
     # --- read / vendor-self side ---
 
@@ -65,3 +73,7 @@ class VendorProfileRepository:
 
     def list_facilities(self, vendor_id: int) -> list[Facility]:
         return list(self._facilities.get(vendor_id, []))
+
+    def list_employee_facilities(self, employee_id: int) -> list[Facility]:
+        """回傳員工所屬廠區列表。空列表表示未指派（不限制可見商家）。"""
+        return list(self._employee_facilities.get(employee_id, []))

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, BackgroundTasks, Depends, Query, Response, status
 
 from backend.core.config import settings
-from backend.core.employee_identity import require_employee, require_employee_role
+from backend.core.employee_identity import require_employee
 from backend.core.vendor_identity import get_vendor_profile_repository
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.menu_item_repository import MenuItemRepository
@@ -50,39 +50,44 @@ def get_employee_ordering_service(
 
 @router.get("/vendors", response_model=list[EmployeeVendor])
 def list_vendors(
-    _employee_role: Annotated[None, Depends(require_employee_role)],
+    employee_id: Annotated[int, Depends(require_employee)],
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
 ) -> list[EmployeeVendor]:
-    return service.list_vendors()
+    return service.list_vendors(employee_id=employee_id)
 
 
 @router.get("/vendors/{vendor_id}", response_model=EmployeeVendor)
 def get_vendor(
     vendor_id: int,
-    _employee_role: Annotated[None, Depends(require_employee_role)],
+    employee_id: Annotated[int, Depends(require_employee)],
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
 ) -> EmployeeVendor:
-    return service.get_vendor(vendor_id)
+    return service.get_vendor(vendor_id, employee_id=employee_id)
 
 
 @router.get("/vendors/{vendor_id}/menu", response_model=list[EmployeeMenuItem])
 def list_menu(
     vendor_id: int,
-    _employee_role: Annotated[None, Depends(require_employee_role)],
+    employee_id: Annotated[int, Depends(require_employee)],
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
     category_id: Annotated[int | None, Query()] = None,
     available: Annotated[bool | None, Query()] = True,
 ) -> list[EmployeeMenuItem]:
-    return service.list_menu(vendor_id, category_id=category_id, available=available)
+    return service.list_menu(
+        vendor_id,
+        category_id=category_id,
+        available=available,
+        employee_id=employee_id,
+    )
 
 
 @router.post("/random-meals/draw", response_model=RandomMealDraw)
 def draw_random_meal(
     payload: RandomMealDrawRequest,
-    _employee_role: Annotated[None, Depends(require_employee_role)],
+    employee_id: Annotated[int, Depends(require_employee)],
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
 ) -> RandomMealDraw:
-    return service.draw_random_meal(payload)
+    return service.draw_random_meal(payload, employee_id=employee_id)
 
 
 @router.post("/vendors/{vendor_id}/selections", response_model=MealSelection, status_code=status.HTTP_201_CREATED)

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -37,16 +37,36 @@ class EmployeeOrderingService:
         self.menu_item_repository = menu_item_repository
         self.selection_repository = selection_repository
 
-    def list_vendors(self) -> list[EmployeeVendor]:
-        return [self._vendor_to_schema(vendor) for vendor in self.vendor_repository.list(status="approved")]
+    def list_vendors(self, employee_id: int | None = None) -> list[EmployeeVendor]:
+        """回傳員工可見的商家列表。
 
-    def get_vendor(self, vendor_id: int) -> EmployeeVendor:
-        return self._vendor_to_schema(self._get_approved_vendor(vendor_id))
+        過濾規則：
+        - 員工無廠區指派 → 可見所有 approved 商家（向下相容）
+        - 員工有廠區指派 → 只顯示「與員工廠區有交集」的商家
+          - 商家若無廠區設定 → 視為全廠區可見（不限制）
+        """
+        all_vendors = [self._vendor_to_schema(vendor) for vendor in self.vendor_repository.list(status="approved")]
+        if employee_id is None:
+            return all_vendors
+        return self._filter_vendors_by_facility(all_vendors, employee_id)
+
+    def get_vendor(self, vendor_id: int, employee_id: int | None = None) -> EmployeeVendor:
+        vendor = self._vendor_to_schema(self._get_approved_vendor(vendor_id))
+        if employee_id is not None:
+            self._assert_facility_access(vendor, employee_id)
+        return vendor
 
     def list_menu(
-        self, vendor_id: int, *, category_id: int | None = None, available: bool | None = True
+        self,
+        vendor_id: int,
+        *,
+        category_id: int | None = None,
+        available: bool | None = True,
+        employee_id: int | None = None,
     ) -> list[EmployeeMenuItem]:
-        self._get_approved_vendor(vendor_id)
+        vendor = self._vendor_to_schema(self._get_approved_vendor(vendor_id))
+        if employee_id is not None:
+            self._assert_facility_access(vendor, employee_id)
         return [
             self._menu_item_to_schema(item)
             for item in self.menu_item_repository.list(
@@ -102,9 +122,24 @@ class EmployeeOrderingService:
             meal_date=meal_date,
         )
 
-    def draw_random_meal(self, payload: RandomMealDrawRequest) -> RandomMealDraw:
+    def draw_random_meal(
+        self,
+        payload: RandomMealDrawRequest,
+        employee_id: int | None = None,
+    ) -> RandomMealDraw:
         self._ensure_meal_date_in_window(payload.meal_date)
-        approved_vendors = {vendor.id: vendor for vendor in self.vendor_repository.list(status="approved")}
+        all_approved = self.vendor_repository.list(status="approved")
+
+        # Apply facility filter first, then honour caller's vendor_ids list
+        if employee_id is not None:
+            visible = self._filter_vendors_by_facility(
+                [self._vendor_to_schema(v) for v in all_approved], employee_id
+            )
+            visible_ids = {v.id for v in visible}
+            approved_vendors = {v.id: v for v in all_approved if v.id in visible_ids}
+        else:
+            approved_vendors = {vendor.id: vendor for vendor in all_approved}
+
         if payload.vendor_ids is None:
             vendor_ids = list(approved_vendors)
         else:
@@ -199,6 +234,43 @@ class EmployeeOrderingService:
         if updated is None:
             raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
         return updated
+
+    # ------------------------------------------------------------------
+    # Facility helpers
+    # ------------------------------------------------------------------
+
+    def _filter_vendors_by_facility(
+        self, vendors: list[EmployeeVendor], employee_id: int
+    ) -> list[EmployeeVendor]:
+        """過濾商家清單：只保留與員工廠區有交集的商家。
+
+        規則：
+        - 員工無廠區指派 → 不限制，回傳全部
+        - 商家無廠區設定 → 全廠區可見（不限制）
+        - 否則取交集，有交集才回傳
+        """
+        employee_facilities = self.vendor_repository.list_employee_facilities(employee_id)
+        if not employee_facilities:
+            return vendors  # 員工無廠區限制
+        employee_fids = {f.id for f in employee_facilities}
+        result = []
+        for vendor in vendors:
+            if not vendor.served_facilities:
+                result.append(vendor)  # 商家無廠區設定 → 全廠區可見
+            elif any(f.id in employee_fids for f in vendor.served_facilities):
+                result.append(vendor)
+        return result
+
+    def _assert_facility_access(self, vendor: EmployeeVendor, employee_id: int) -> None:
+        """若員工無法存取此商家的廠區，拋出 404（對外不揭露存在性）。"""
+        employee_facilities = self.vendor_repository.list_employee_facilities(employee_id)
+        if not employee_facilities:
+            return  # 員工無廠區限制
+        if not vendor.served_facilities:
+            return  # 商家無廠區限制
+        employee_fids = {f.id for f in employee_facilities}
+        if not any(f.id in employee_fids for f in vendor.served_facilities):
+            raise CodedHTTPException(status_code=404, code="not_found", detail="vendor not found")
 
     def _get_approved_vendor(self, vendor_id: int) -> VendorRecord:
         vendor = self.vendor_repository.get(vendor_id)

--- a/backend/tests/test_employee_facility_filter.py
+++ b/backend/tests/test_employee_facility_filter.py
@@ -1,0 +1,203 @@
+"""Tests for facility-based employee/vendor visibility (issue #65).
+
+Verifies that:
+- Employees assigned to a facility can only browse vendors serving that facility.
+- Employees with no facility assignment can see all approved vendors (backward compat).
+- Vendors with no facility assignment are visible to all employees.
+- Cross-facility employees cannot see or access vendors outside their facility.
+- draw_random_meal respects the same facility filter.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.routes.employee_ordering import get_employee_selection_repository
+from backend.routes.vendor_menu import get_menu_item_repository
+from backend.schemas.employee import RandomMealDrawRequest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _build_repos() -> tuple[VendorProfileRepository, MenuItemRepository, EmployeeSelectionRepository]:
+    vendor_repo = VendorProfileRepository()
+
+    # Vendor 1 — serves F12A only
+    vendor_repo.seed(VendorRecord(id=1, name="Sunny Kitchen", status="approved"))
+    vendor_repo.assign_facility(1, facility_id=10, code="F12A", name="Fab 12A")
+
+    # Vendor 2 — serves F14B only
+    vendor_repo.seed(VendorRecord(id=2, name="Fab 14 Bistro", status="approved"))
+    vendor_repo.assign_facility(2, facility_id=20, code="F14B", name="Fab 14B")
+
+    # Vendor 3 — no facility (visible to everyone)
+    vendor_repo.seed(VendorRecord(id=3, name="Global Canteen", status="approved"))
+
+    # Vendor 4 — pending, never visible
+    vendor_repo.seed(VendorRecord(id=4, name="Not Yet Approved", status="pending"))
+
+    # Employee 101 — belongs to F12A
+    vendor_repo.assign_employee_facility(101, facility_id=10, code="F12A", name="Fab 12A")
+
+    # Employee 102 — belongs to F14B
+    vendor_repo.assign_employee_facility(102, facility_id=20, code="F14B", name="Fab 14B")
+
+    # Employee 103 — no facility (sees everything)
+
+    item_repo = MenuItemRepository()
+    item_repo.create(vendor_id=1, category_id=None, name="Bento", price_cents=100, available=True)
+
+    selection_repo = EmployeeSelectionRepository()
+    return vendor_repo, item_repo, selection_repo
+
+
+def _setup() -> tuple[TestClient, VendorProfileRepository, MenuItemRepository, EmployeeSelectionRepository]:
+    vendor_repo, item_repo, selection_repo = _build_repos()
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
+    app.dependency_overrides[get_menu_item_repository] = lambda: item_repo
+    app.dependency_overrides[get_employee_selection_repository] = lambda: selection_repo
+    return TestClient(app), vendor_repo, item_repo, selection_repo
+
+
+def _h(user_id: int) -> dict[str, str]:
+    return {"x-user-role": "employee", "x-user-id": str(user_id)}
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# list_vendors facility filtering
+# ---------------------------------------------------------------------------
+
+def test_f12a_employee_sees_only_f12a_and_global_vendors() -> None:
+    client, *_ = _setup()
+    resp = client.get("/employee/vendors", headers=_h(101))
+    assert resp.status_code == 200
+    names = {v["name"] for v in resp.json()}
+    assert "Sunny Kitchen" in names        # F12A ✓
+    assert "Global Canteen" in names       # no facility → visible everywhere ✓
+    assert "Fab 14 Bistro" not in names    # F14B — different facility ✗
+
+
+def test_f14b_employee_sees_only_f14b_and_global_vendors() -> None:
+    client, *_ = _setup()
+    resp = client.get("/employee/vendors", headers=_h(102))
+    assert resp.status_code == 200
+    names = {v["name"] for v in resp.json()}
+    assert "Fab 14 Bistro" in names        # F14B ✓
+    assert "Global Canteen" in names       # no facility → visible everywhere ✓
+    assert "Sunny Kitchen" not in names    # F12A — different facility ✗
+
+
+def test_employee_with_no_facility_sees_all_approved_vendors() -> None:
+    client, *_ = _setup()
+    resp = client.get("/employee/vendors", headers=_h(103))
+    assert resp.status_code == 200
+    names = {v["name"] for v in resp.json()}
+    assert names == {"Sunny Kitchen", "Fab 14 Bistro", "Global Canteen"}
+    # Pending vendor never shown
+    assert "Not Yet Approved" not in names
+
+
+def test_pending_vendor_never_shown_regardless_of_facility() -> None:
+    client, *_ = _setup()
+    resp = client.get("/employee/vendors", headers=_h(103))
+    assert resp.status_code == 200
+    names = [v["name"] for v in resp.json()]
+    assert "Not Yet Approved" not in names
+
+
+# ---------------------------------------------------------------------------
+# get_vendor facility guard
+# ---------------------------------------------------------------------------
+
+def test_get_vendor_in_same_facility_returns_200() -> None:
+    client, *_ = _setup()
+    resp = client.get("/employee/vendors/1", headers=_h(101))  # 101=F12A, vendor 1=F12A
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Sunny Kitchen"
+
+
+def test_get_vendor_in_different_facility_returns_404() -> None:
+    client, *_ = _setup()
+    resp = client.get("/employee/vendors/2", headers=_h(101))  # 101=F12A, vendor 2=F14B
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"
+
+
+def test_get_global_vendor_visible_to_any_employee() -> None:
+    client, *_ = _setup()
+    for uid in (101, 102, 103):
+        resp = client.get("/employee/vendors/3", headers=_h(uid))
+        assert resp.status_code == 200, f"Expected 200 for employee {uid}"
+
+
+def test_get_vendor_no_facility_employee_can_access_all() -> None:
+    client, *_ = _setup()
+    for vendor_id in (1, 2, 3):
+        resp = client.get(f"/employee/vendors/{vendor_id}", headers=_h(103))
+        assert resp.status_code == 200, f"Employee 103 should see vendor {vendor_id}"
+
+
+# ---------------------------------------------------------------------------
+# list_menu facility guard
+# ---------------------------------------------------------------------------
+
+def test_list_menu_cross_facility_returns_404() -> None:
+    client, *_ = _setup()
+    resp = client.get("/employee/vendors/2/menu", headers=_h(101))  # 101=F12A, vendor 2=F14B
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"
+
+
+def test_list_menu_same_facility_returns_200() -> None:
+    client, *_ = _setup()
+    resp = client.get("/employee/vendors/1/menu", headers=_h(101))
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# draw_random_meal facility filter
+# ---------------------------------------------------------------------------
+
+def _meal_date(days: int = 0) -> str:
+    return (date.today() + timedelta(days=days)).isoformat()
+
+
+def test_draw_random_meal_respects_facility_filter() -> None:
+    client, vendor_repo, item_repo, _ = _setup()
+    # Add an item to vendor 2 so it's a candidate if visible
+    item_repo.create(vendor_id=2, category_id=None, name="Fab Bowl", price_cents=120, available=True)
+
+    resp = client.post(
+        "/employee/random-meals/draw",
+        json={"meal_date": _meal_date(1)},
+        headers=_h(101),  # F12A employee
+    )
+    assert resp.status_code == 200
+    # Only F12A vendor (id=1) and global (id=3) are candidates → never vendor 2
+    assert resp.json()["vendor"]["id"] != 2
+
+
+def test_draw_random_meal_no_facility_employee_uses_all_vendors() -> None:
+    client, vendor_repo, item_repo, _ = _setup()
+    item_repo.create(vendor_id=2, category_id=None, name="Fab Bowl", price_cents=120, available=True)
+
+    # Employee 103 has no facility → all vendors are candidates; just assert 200
+    resp = client.post(
+        "/employee/random-meals/draw",
+        json={"meal_date": _meal_date(1)},
+        headers=_h(103),
+    )
+    assert resp.status_code == 200

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -41,8 +41,9 @@ def _h(user_id: int = 100) -> dict[str, str]:
     return {"x-user-role": "employee", "x-user-id": str(user_id)}
 
 
-def _browse_h() -> dict[str, str]:
-    return {"x-user-role": "employee"}
+def _browse_h(user_id: int = 999) -> dict[str, str]:
+    """Browse headers — employee role + user-id (facility filter requires identity)."""
+    return {"x-user-role": "employee", "x-user-id": str(user_id)}
 
 
 def _meal_date(days_from_today: int = 0) -> str:


### PR DESCRIPTION
## Summary

Implements issue #65: facility-based employee/vendor visibility.

## What changed

### Migration (`006_employee_facilities.sql`)
- `employee_facilities` join table (employee_id × facility_id)
- Seed: ensure F12A facility exists; assign Sunny Kitchen vendor + first employee to F12A

### Repository
- `VendorProfileRepository` (in-memory): `assign_employee_facility()`, `list_employee_facilities()`
- `PostgresVendorProfileRepository`: `list_employee_facilities(employee_id)` SQL query

### Service (`EmployeeOrderingService`)
Filter logic:
- **Employee has no facility** → sees all approved vendors (backward compatible)
- **Vendor has no facility** → visible to all employees
- **Both have facilities** → only if intersection is non-empty → 404 otherwise

Affected methods: `list_vendors`, `get_vendor`, `list_menu`, `draw_random_meal`

### Routes (`employee_ordering.py`)
- `list_vendors`, `get_vendor`, `list_menu`, `draw_random_meal` now use `require_employee` instead of `require_employee_role` to obtain `employee_id`

## Tests
- **12 new tests** in `test_employee_facility_filter.py`
  - Same-facility: can browse, get, list-menu ✅
  - Cross-facility: 404 on get/list-menu, hidden from list ✅
  - Global vendor (no facility): visible to all ✅
  - No-facility employee: sees all approved vendors ✅
  - `draw_random_meal` respects facility filter ✅
- **0 regressions**: all 179 unit tests pass

## Verification

```
pytest backend/tests/test_employee_facility_filter.py  # 12 passed
pytest backend/tests/ --ignore=backend/tests/integration  # 179 passed
```

Closes #65