### PR TITLE
Add backend facility context for orders

### DIFF
--- a/backend/db/migrations/007_order_facility_context.sql
+++ b/backend/db/migrations/007_order_facility_context.sql
@@ -1,0 +1,8 @@
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS facility_id BIGINT REFERENCES facilities(id);
+
+CREATE INDEX IF NOT EXISTS idx_orders_facility_created
+  ON orders (facility_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_orders_vendor_facility_status_created
+  ON orders (vendor_id, facility_id, status, created_at DESC);

--- a/backend/repositories/employee_selection_repository.py
+++ b/backend/repositories/employee_selection_repository.py
@@ -21,6 +21,7 @@ class _OrderRecord:
     id: int
     employee_id: int
     vendor_id: int
+    facility_id: int | None
     meal_date: date | None
     status: OrderStatus
     created_at: datetime
@@ -56,6 +57,7 @@ def _selection_to_schema(order: _OrderRecord, item: _OrderItemRecord) -> MealSel
         order_id=order.id,
         employee_id=order.employee_id,
         vendor_id=order.vendor_id,
+        facility_id=order.facility_id,
         meal_date=order.meal_date,
         item_id=item.item_id,
         item_name=item.item_name,
@@ -80,12 +82,14 @@ class EmployeeSelectionRepository:
         vendor_id: int,
         items: list[OrderItemSnapshot],
         meal_date: date | None = None,
+        facility_id: int | None = None,
     ) -> EmployeeOrder:
         now = datetime.now(timezone.utc)
         order = _OrderRecord(
             id=next(self._order_id_seq),
             employee_id=employee_id,
             vendor_id=vendor_id,
+            facility_id=facility_id,
             meal_date=meal_date,
             status="pending",
             created_at=now,
@@ -130,6 +134,7 @@ class EmployeeSelectionRepository:
             id=order.id,
             employee_id=order.employee_id,
             vendor_id=order.vendor_id,
+            facility_id=order.facility_id,
             meal_date=order.meal_date,
             status="cancelled",
             created_at=order.created_at,
@@ -145,6 +150,7 @@ class EmployeeSelectionRepository:
         order_id: int,
         items: list[OrderItemSnapshot],
         meal_date: date | None = None,
+        facility_id: int | None = None,
     ) -> EmployeeOrder | None:
         order = self._orders.get(order_id)
         if order is None or order.employee_id != employee_id:
@@ -155,6 +161,7 @@ class EmployeeSelectionRepository:
             id=order.id,
             employee_id=order.employee_id,
             vendor_id=order.vendor_id,
+            facility_id=facility_id,
             meal_date=meal_date,
             status=order.status,
             created_at=order.created_at,
@@ -188,11 +195,13 @@ class EmployeeSelectionRepository:
         quantity: int,
         unit_price_cents: int,
         meal_date: date | None = None,
+        facility_id: int | None = None,
     ) -> MealSelection:
         order = self.create_order(
             employee_id=employee_id,
             vendor_id=vendor_id,
             meal_date=meal_date,
+            facility_id=facility_id,
             items=[
                 OrderItemSnapshot(
                     item_id=item_id,
@@ -212,8 +221,10 @@ class EmployeeSelectionRepository:
             selections.extend(self._order_to_selection_schemas(order.id))
         return selections
 
-    def list_orders_by_vendor(self, *, vendor_id: int) -> list[EmployeeOrder]:
+    def list_orders_by_vendor(self, *, vendor_id: int, facility_id: int | None = None) -> list[EmployeeOrder]:
         rows = [r for r in self._orders.values() if r.vendor_id == vendor_id]
+        if facility_id is not None:
+            rows = [r for r in rows if r.facility_id == facility_id]
         rows.sort(key=lambda r: r.id)
         return [self._order_to_schema(r) for r in rows]
 
@@ -233,6 +244,7 @@ class EmployeeSelectionRepository:
             id=order.id,
             employee_id=order.employee_id,
             vendor_id=order.vendor_id,
+            facility_id=order.facility_id,
             meal_date=order.meal_date,
             status=new_status,
             created_at=order.created_at,
@@ -278,6 +290,7 @@ class EmployeeSelectionRepository:
             id=order.id,
             employee_id=order.employee_id,
             vendor_id=order.vendor_id,
+            facility_id=order.facility_id,
             meal_date=order.meal_date,
             status=order.status,
             items=schema_items,

--- a/backend/repositories/postgres_employee_selection_repository.py
+++ b/backend/repositories/postgres_employee_selection_repository.py
@@ -55,11 +55,13 @@ class PostgresEmployeeSelectionRepository:
         quantity: int,
         unit_price_cents: int,
         meal_date: date | None = None,
+        facility_id: int | None = None,
     ) -> MealSelection:
         order = self.create_order(
             employee_id=employee_id,
             vendor_id=vendor_id,
             meal_date=meal_date,
+            facility_id=facility_id,
             items=[
                 OrderItemSnapshot(
                     item_id=item_id,
@@ -75,6 +77,7 @@ class PostgresEmployeeSelectionRepository:
             order_id=order.id,
             employee_id=order.employee_id,
             vendor_id=order.vendor_id,
+            facility_id=order.facility_id,
             meal_date=order.meal_date,
             item_id=item.item_id,
             item_name=item.item_name,
@@ -91,6 +94,7 @@ class PostgresEmployeeSelectionRepository:
         vendor_id: int,
         items: list[OrderItemSnapshot],
         meal_date: date | None = None,
+        facility_id: int | None = None,
     ) -> EmployeeOrder:
         with get_connection() as conn:
             # ── Step 1: Acquire row locks and validate quota atomically ──────
@@ -181,12 +185,12 @@ class PostgresEmployeeSelectionRepository:
             total_price_cents = sum(s.quantity * s.unit_price_cents for s in items)
             order_row = conn.execute(
                 """
-                INSERT INTO orders (employee_id, vendor_id, meal_date, total_price_cents)
-                VALUES (%s, %s, %s, %s)
-                RETURNING id, employee_id, vendor_id, meal_date, status,
+                INSERT INTO orders (employee_id, vendor_id, facility_id, meal_date, total_price_cents)
+                VALUES (%s, %s, %s, %s, %s)
+                RETURNING id, employee_id, vendor_id, facility_id, meal_date, status,
                           total_price_cents, created_at, updated_at, cancelled_at
                 """,
-                (employee_id, vendor_id, meal_date, total_price_cents),
+                (employee_id, vendor_id, facility_id, meal_date, total_price_cents),
             ).fetchone()
             order_id = order_row["id"]
 
@@ -226,6 +230,7 @@ class PostgresEmployeeSelectionRepository:
                         order_id=order.id,
                         employee_id=order.employee_id,
                         vendor_id=order.vendor_id,
+                        facility_id=order.facility_id,
                         meal_date=order.meal_date,
                         item_id=item.item_id,
                         item_name=item.item_name,
@@ -237,17 +242,22 @@ class PostgresEmployeeSelectionRepository:
                 )
         return selections
 
-    def list_orders_by_vendor(self, *, vendor_id: int) -> list[EmployeeOrder]:
+    def list_orders_by_vendor(self, *, vendor_id: int, facility_id: int | None = None) -> list[EmployeeOrder]:
+        where = ["vendor_id = %s"]
+        values: list[object] = [vendor_id]
+        if facility_id is not None:
+            where.append("facility_id = %s")
+            values.append(facility_id)
         with get_connection() as conn:
             order_rows = conn.execute(
-                """
-                SELECT id, employee_id, vendor_id, meal_date, status,
+                f"""
+                SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
                        total_price_cents, created_at, updated_at, cancelled_at
                 FROM orders
-                WHERE vendor_id = %s
+                WHERE {" AND ".join(where)}
                 ORDER BY id
                 """,
-                (vendor_id,),
+                values,
             ).fetchall()
             return [self._hydrate_order(conn, row) for row in order_rows]
 
@@ -255,7 +265,7 @@ class PostgresEmployeeSelectionRepository:
         with get_connection() as conn:
             row = conn.execute(
                 """
-                SELECT id, employee_id, vendor_id, meal_date, status,
+                SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
                        total_price_cents, created_at, updated_at, cancelled_at
                 FROM orders
                 WHERE vendor_id = %s AND id = %s
@@ -275,7 +285,7 @@ class PostgresEmployeeSelectionRepository:
                     updated_at = NOW(),
                     cancelled_at = CASE WHEN %s = 'cancelled' THEN NOW() ELSE cancelled_at END
                 WHERE vendor_id = %s AND id = %s
-                RETURNING id, employee_id, vendor_id, meal_date, status,
+                RETURNING id, employee_id, vendor_id, facility_id, meal_date, status,
                           total_price_cents, created_at, updated_at, cancelled_at
                 """,
                 (new_status, new_status, vendor_id, order_id),
@@ -289,7 +299,7 @@ class PostgresEmployeeSelectionRepository:
             rows = conn.execute(
                 """
                 SELECT oi.id, o.id AS order_id, o.employee_id, o.vendor_id,
-                       o.meal_date, oi.item_id, oi.item_name, oi.quantity,
+                       o.facility_id, o.meal_date, oi.item_id, oi.item_name, oi.quantity,
                        oi.unit_price_cents, o.created_at
                 FROM orders o
                 JOIN order_items oi ON oi.order_id = o.id
@@ -304,7 +314,7 @@ class PostgresEmployeeSelectionRepository:
         with get_connection() as conn:
             order_rows = conn.execute(
                 """
-                SELECT id, employee_id, vendor_id, meal_date, status,
+                SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
                        total_price_cents, created_at, updated_at, cancelled_at
                 FROM orders
                 WHERE employee_id = %s
@@ -318,7 +328,7 @@ class PostgresEmployeeSelectionRepository:
         with get_connection() as conn:
             row = conn.execute(
                 """
-                SELECT id, employee_id, vendor_id, meal_date, status,
+                SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
                        total_price_cents, created_at, updated_at, cancelled_at
                 FROM orders
                 WHERE employee_id = %s AND id = %s
@@ -336,7 +346,7 @@ class PostgresEmployeeSelectionRepository:
                 UPDATE orders
                 SET status = 'cancelled', updated_at = NOW(), cancelled_at = NOW()
                 WHERE employee_id = %s AND id = %s AND status = 'pending'
-                RETURNING id, employee_id, vendor_id, meal_date, status,
+                RETURNING id, employee_id, vendor_id, facility_id, meal_date, status,
                           total_price_cents, created_at, updated_at, cancelled_at
                 """,
                 (employee_id, order_id),
@@ -344,7 +354,7 @@ class PostgresEmployeeSelectionRepository:
             if row is None:
                 row = conn.execute(
                     """
-                    SELECT id, employee_id, vendor_id, meal_date, status,
+                    SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
                            total_price_cents, created_at, updated_at, cancelled_at
                     FROM orders
                     WHERE employee_id = %s AND id = %s
@@ -362,11 +372,12 @@ class PostgresEmployeeSelectionRepository:
         order_id: int,
         items: list[OrderItemSnapshot],
         meal_date: date | None = None,
+        facility_id: int | None = None,
     ) -> EmployeeOrder | None:
         with get_connection() as conn:
             order_row = conn.execute(
                 """
-                SELECT id, employee_id, vendor_id, meal_date, status,
+                SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
                        total_price_cents, created_at, updated_at, cancelled_at
                 FROM orders
                 WHERE employee_id = %s AND id = %s
@@ -441,13 +452,14 @@ class PostgresEmployeeSelectionRepository:
                 """
                 UPDATE orders
                 SET meal_date = %s,
+                    facility_id = %s,
                     total_price_cents = %s,
                     updated_at = NOW()
                 WHERE employee_id = %s AND id = %s
-                RETURNING id, employee_id, vendor_id, meal_date, status,
+                RETURNING id, employee_id, vendor_id, facility_id, meal_date, status,
                           total_price_cents, created_at, updated_at, cancelled_at
                 """,
-                (meal_date, total_price_cents, employee_id, order_id),
+                (meal_date, facility_id, total_price_cents, employee_id, order_id),
             ).fetchone()
 
             conn.execute("DELETE FROM order_items WHERE order_id = %s", (order_id,))

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -25,6 +25,7 @@ from backend.schemas.employee import (
     RandomMealDraw,
     RandomMealDrawRequest,
 )
+from backend.schemas.vendor_self import Facility
 from backend.services.employee_ordering_service import EmployeeOrderingService
 from backend.services.notification_service import NotificationService
 
@@ -52,8 +53,9 @@ def get_employee_ordering_service(
 def list_vendors(
     employee_id: Annotated[int, Depends(require_employee)],
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+    facility_id: Annotated[int | None, Query()] = None,
 ) -> list[EmployeeVendor]:
-    return service.list_vendors(employee_id=employee_id)
+    return service.list_vendors(employee_id=employee_id, facility_id=facility_id)
 
 
 @router.get("/vendors/{vendor_id}", response_model=EmployeeVendor)
@@ -61,8 +63,9 @@ def get_vendor(
     vendor_id: int,
     employee_id: Annotated[int, Depends(require_employee)],
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+    facility_id: Annotated[int | None, Query()] = None,
 ) -> EmployeeVendor:
-    return service.get_vendor(vendor_id, employee_id=employee_id)
+    return service.get_vendor(vendor_id, employee_id=employee_id, facility_id=facility_id)
 
 
 @router.get("/vendors/{vendor_id}/menu", response_model=list[EmployeeMenuItem])
@@ -72,13 +75,23 @@ def list_menu(
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
     category_id: Annotated[int | None, Query()] = None,
     available: Annotated[bool | None, Query()] = True,
+    facility_id: Annotated[int | None, Query()] = None,
 ) -> list[EmployeeMenuItem]:
     return service.list_menu(
         vendor_id,
         category_id=category_id,
         available=available,
         employee_id=employee_id,
+        facility_id=facility_id,
     )
+
+
+@router.get("/me/facilities", response_model=list[Facility])
+def list_my_facilities(
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> list[Facility]:
+    return service.list_employee_facilities(employee_id)
 
 
 @router.post("/random-meals/draw", response_model=RandomMealDraw)

--- a/backend/routes/vendor_orders.py
+++ b/backend/routes/vendor_orders.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import APIRouter, BackgroundTasks, Depends, Query
 
-from backend.core.vendor_identity import require_approved_vendor
+from backend.core.vendor_identity import get_vendor_profile_repository, require_approved_vendor
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository
 from backend.routes.employee_ordering import get_employee_selection_repository
 from backend.routes.notifications import get_notification_service
 from backend.schemas.employee import EmployeeOrder, VendorOrderStatusUpdate
@@ -18,16 +19,18 @@ router = APIRouter(prefix="/vendor/me/orders", tags=["vendor-self"])
 
 def get_vendor_order_service(
     selection_repo: Annotated[EmployeeSelectionRepository, Depends(get_employee_selection_repository)],
+    vendor_repo: Annotated[VendorProfileRepository, Depends(get_vendor_profile_repository)],
 ) -> VendorOrderService:
-    return VendorOrderService(selection_repo)
+    return VendorOrderService(selection_repo, vendor_repo)
 
 
 @router.get("", response_model=list[EmployeeOrder])
 def list_vendor_orders(
     vendor_id: Annotated[int, Depends(require_approved_vendor)],
     service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
+    facility_id: Annotated[int | None, Query()] = None,
 ) -> list[EmployeeOrder]:
-    return service.list_orders(vendor_id)
+    return service.list_orders(vendor_id, facility_id=facility_id)
 
 
 @router.get("/{order_id}", response_model=EmployeeOrder)

--- a/backend/routes/vendor_profile.py
+++ b/backend/routes/vendor_profile.py
@@ -10,7 +10,7 @@ from backend.core.vendor_identity import (
     require_approved_vendor,
 )
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
-from backend.schemas.vendor_self import VendorProfile, VendorProfileUpdate
+from backend.schemas.vendor_self import Facility, VendorProfile, VendorProfileUpdate
 from backend.services.vendor_profile_service import VendorProfileService
 
 router = APIRouter(prefix="/vendor/me", tags=["vendor-self"])
@@ -30,6 +30,14 @@ def get_profile(
 ) -> VendorProfile:
     """取得目前登入商家的資料 (含唯讀的 served_facilities 廠區清單)。"""
     return service.get(vendor_id)
+
+
+@router.get("/facilities", response_model=list[Facility])
+def list_my_facilities(
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorProfileService, Depends(get_vendor_profile_service)],
+) -> list[Facility]:
+    return service.get(vendor_id).served_facilities
 
 
 @router.patch("/profile", response_model=VendorProfile)

--- a/backend/schemas/employee.py
+++ b/backend/schemas/employee.py
@@ -35,6 +35,7 @@ class MealSelectionCreate(BaseModel):
     item_id: int
     quantity: int = Field(ge=1)
     meal_date: date | None = None
+    facility_id: int | None = None
 
 
 class MealSelection(BaseModel):
@@ -42,6 +43,7 @@ class MealSelection(BaseModel):
     order_id: int | None = None
     employee_id: int
     vendor_id: int
+    facility_id: int | None = None
     meal_date: date | None = None
     item_id: int
     item_name: str
@@ -66,11 +68,13 @@ class EmployeeOrderItemCreate(BaseModel):
 class EmployeeOrderCreate(BaseModel):
     items: list[EmployeeOrderItemCreate] = Field(min_length=1)
     meal_date: date | None = None
+    facility_id: int | None = None
 
 
 class EmployeeOrderUpdate(BaseModel):
     items: list[EmployeeOrderItemCreate] = Field(min_length=1)
     meal_date: date | None = None
+    facility_id: int | None = None
 
 
 class EmployeeOrderItem(BaseModel):
@@ -87,6 +91,7 @@ class EmployeeOrder(BaseModel):
     id: int
     employee_id: int
     vendor_id: int
+    facility_id: int | None = None
     meal_date: date | None = None
     status: OrderStatus
     items: list[EmployeeOrderItem]
@@ -99,6 +104,7 @@ class EmployeeOrder(BaseModel):
 class RandomMealDrawRequest(BaseModel):
     meal_date: date
     vendor_ids: list[int] | None = None
+    facility_id: int | None = None
 
 
 class RandomMealDraw(BaseModel):

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -1,4 +1,4 @@
-"""Employee-facing read and meal selection workflow."""
+"""Employee-facing vendor browsing, menu browsing, and ordering workflow."""
 from __future__ import annotations
 
 import random
@@ -21,7 +21,7 @@ from backend.schemas.employee import (
     RandomMealDraw,
     RandomMealDrawRequest,
 )
-from backend.schemas.vendor_self import MenuItem as VendorMenuItem
+from backend.schemas.vendor_self import Facility, MenuItem as VendorMenuItem
 
 MEAL_DATE_WINDOW_DAYS = 7
 
@@ -37,23 +37,25 @@ class EmployeeOrderingService:
         self.menu_item_repository = menu_item_repository
         self.selection_repository = selection_repository
 
-    def list_vendors(self, employee_id: int | None = None) -> list[EmployeeVendor]:
-        """回傳員工可見的商家列表。
-
-        過濾規則：
-        - 員工無廠區指派 → 可見所有 approved 商家（向下相容）
-        - 員工有廠區指派 → 只顯示「與員工廠區有交集」的商家
-          - 商家若無廠區設定 → 視為全廠區可見（不限制）
-        """
-        all_vendors = [self._vendor_to_schema(vendor) for vendor in self.vendor_repository.list(status="approved")]
+    def list_vendors(
+        self,
+        employee_id: int | None = None,
+        facility_id: int | None = None,
+    ) -> list[EmployeeVendor]:
+        vendors = [self._vendor_to_schema(vendor) for vendor in self.vendor_repository.list(status="approved")]
         if employee_id is None:
-            return all_vendors
-        return self._filter_vendors_by_facility(all_vendors, employee_id)
+            return vendors
+        return self._filter_vendors_by_facility(vendors, employee_id, facility_id=facility_id)
 
-    def get_vendor(self, vendor_id: int, employee_id: int | None = None) -> EmployeeVendor:
+    def get_vendor(
+        self,
+        vendor_id: int,
+        employee_id: int | None = None,
+        facility_id: int | None = None,
+    ) -> EmployeeVendor:
         vendor = self._vendor_to_schema(self._get_approved_vendor(vendor_id))
         if employee_id is not None:
-            self._assert_facility_access(vendor, employee_id)
+            self._assert_facility_access(vendor, employee_id, facility_id=facility_id)
         return vendor
 
     def list_menu(
@@ -63,31 +65,38 @@ class EmployeeOrderingService:
         category_id: int | None = None,
         available: bool | None = True,
         employee_id: int | None = None,
+        facility_id: int | None = None,
     ) -> list[EmployeeMenuItem]:
         vendor = self._vendor_to_schema(self._get_approved_vendor(vendor_id))
         if employee_id is not None:
-            self._assert_facility_access(vendor, employee_id)
+            self._assert_facility_access(vendor, employee_id, facility_id=facility_id)
         return [
             self._menu_item_to_schema(item)
             for item in self.menu_item_repository.list(
-                vendor_id=vendor_id, category_id=category_id, available=available
+                vendor_id=vendor_id,
+                category_id=category_id,
+                available=available,
             )
         ]
 
     def select_meal(
-        self, employee_id: int, vendor_id: int, payload: MealSelectionCreate
+        self,
+        employee_id: int,
+        vendor_id: int,
+        payload: MealSelectionCreate,
     ) -> MealSelection:
         order = self.create_order(
             employee_id,
             vendor_id,
             EmployeeOrderCreate(
                 meal_date=payload.meal_date,
+                facility_id=payload.facility_id,
                 items=[
                     EmployeeOrderItemCreate(
                         item_id=payload.item_id,
                         quantity=payload.quantity,
                     )
-                ]
+                ],
             ),
         )
         item = order.items[0]
@@ -96,6 +105,7 @@ class EmployeeOrderingService:
             order_id=order.id,
             employee_id=order.employee_id,
             vendor_id=order.vendor_id,
+            facility_id=order.facility_id,
             meal_date=order.meal_date,
             item_id=item.item_id,
             item_name=item.item_name,
@@ -109,9 +119,13 @@ class EmployeeOrderingService:
         return self.selection_repository.list(employee_id=employee_id)
 
     def create_order(
-        self, employee_id: int, vendor_id: int, payload: EmployeeOrderCreate
+        self,
+        employee_id: int,
+        vendor_id: int,
+        payload: EmployeeOrderCreate,
     ) -> EmployeeOrder:
-        self._get_approved_vendor(vendor_id)
+        vendor = self._vendor_to_schema(self._get_approved_vendor(vendor_id))
+        facility_id = self._resolve_order_facility(employee_id, vendor, payload.facility_id)
         meal_date = payload.meal_date or date.today()
         self._ensure_meal_date_in_window(meal_date)
         snapshots = self._build_order_items(vendor_id, payload, meal_date=meal_date)
@@ -120,6 +134,7 @@ class EmployeeOrderingService:
             vendor_id=vendor_id,
             items=snapshots,
             meal_date=meal_date,
+            facility_id=facility_id,
         )
 
     def draw_random_meal(
@@ -130,10 +145,11 @@ class EmployeeOrderingService:
         self._ensure_meal_date_in_window(payload.meal_date)
         all_approved = self.vendor_repository.list(status="approved")
 
-        # Apply facility filter first, then honour caller's vendor_ids list
         if employee_id is not None:
             visible = self._filter_vendors_by_facility(
-                [self._vendor_to_schema(v) for v in all_approved], employee_id
+                [self._vendor_to_schema(v) for v in all_approved],
+                employee_id,
+                facility_id=payload.facility_id,
             )
             visible_ids = {v.id for v in visible}
             approved_vendors = {v.id: v for v in all_approved if v.id in visible_ids}
@@ -206,7 +222,10 @@ class EmployeeOrderingService:
         return cancelled
 
     def update_my_order(
-        self, employee_id: int, order_id: int, payload: EmployeeOrderUpdate
+        self,
+        employee_id: int,
+        order_id: int,
+        payload: EmployeeOrderUpdate,
     ) -> EmployeeOrder:
         order = self.get_my_order(employee_id, order_id)
         if order.status != "pending":
@@ -216,12 +235,17 @@ class EmployeeOrderingService:
                 detail="only pending orders can be modified",
             )
 
-        self._get_approved_vendor(order.vendor_id)
+        vendor = self._vendor_to_schema(self._get_approved_vendor(order.vendor_id))
         meal_date = payload.meal_date or order.meal_date or date.today()
         self._ensure_meal_date_in_window(meal_date)
+        facility_id = (
+            self._resolve_order_facility(employee_id, vendor, payload.facility_id)
+            if payload.facility_id is not None
+            else order.facility_id
+        )
         snapshots = self._build_order_items(
             order.vendor_id,
-            EmployeeOrderCreate(meal_date=meal_date, items=payload.items),
+            EmployeeOrderCreate(meal_date=meal_date, facility_id=facility_id, items=payload.items),
             meal_date=meal_date,
             exclude_order_id=order.id,
         )
@@ -230,47 +254,109 @@ class EmployeeOrderingService:
             order_id=order_id,
             items=snapshots,
             meal_date=meal_date,
+            facility_id=facility_id,
         )
         if updated is None:
             raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
         return updated
 
-    # ------------------------------------------------------------------
-    # Facility helpers
-    # ------------------------------------------------------------------
+    def list_employee_facilities(self, employee_id: int) -> list[Facility]:
+        return self.vendor_repository.list_employee_facilities(employee_id)
 
     def _filter_vendors_by_facility(
-        self, vendors: list[EmployeeVendor], employee_id: int
+        self,
+        vendors: list[EmployeeVendor],
+        employee_id: int,
+        *,
+        facility_id: int | None = None,
     ) -> list[EmployeeVendor]:
-        """過濾商家清單：只保留與員工廠區有交集的商家。
-
-        規則：
-        - 員工無廠區指派 → 不限制，回傳全部
-        - 商家無廠區設定 → 全廠區可見（不限制）
-        - 否則取交集，有交集才回傳
-        """
         employee_facilities = self.vendor_repository.list_employee_facilities(employee_id)
         if not employee_facilities:
-            return vendors  # 員工無廠區限制
-        employee_fids = {f.id for f in employee_facilities}
+            if facility_id is not None:
+                raise CodedHTTPException(
+                    status_code=403,
+                    code="forbidden",
+                    detail="employee is not assigned to the selected facility",
+                )
+            return vendors
+
+        employee_fids = self._employee_facility_ids(employee_facilities, facility_id)
         result = []
         for vendor in vendors:
             if not vendor.served_facilities:
-                result.append(vendor)  # 商家無廠區設定 → 全廠區可見
+                result.append(vendor)
             elif any(f.id in employee_fids for f in vendor.served_facilities):
                 result.append(vendor)
         return result
 
-    def _assert_facility_access(self, vendor: EmployeeVendor, employee_id: int) -> None:
-        """若員工無法存取此商家的廠區，拋出 404（對外不揭露存在性）。"""
+    def _assert_facility_access(
+        self,
+        vendor: EmployeeVendor,
+        employee_id: int,
+        *,
+        facility_id: int | None = None,
+    ) -> None:
         employee_facilities = self.vendor_repository.list_employee_facilities(employee_id)
         if not employee_facilities:
-            return  # 員工無廠區限制
+            if facility_id is not None:
+                raise CodedHTTPException(
+                    status_code=403,
+                    code="forbidden",
+                    detail="employee is not assigned to the selected facility",
+                )
+            return
         if not vendor.served_facilities:
-            return  # 商家無廠區限制
-        employee_fids = {f.id for f in employee_facilities}
+            return
+        employee_fids = self._employee_facility_ids(employee_facilities, facility_id)
         if not any(f.id in employee_fids for f in vendor.served_facilities):
             raise CodedHTTPException(status_code=404, code="not_found", detail="vendor not found")
+
+    def _resolve_order_facility(
+        self,
+        employee_id: int,
+        vendor: EmployeeVendor,
+        requested_facility_id: int | None,
+    ) -> int | None:
+        employee_facilities = self.vendor_repository.list_employee_facilities(employee_id)
+        if not employee_facilities:
+            if requested_facility_id is not None:
+                raise CodedHTTPException(
+                    status_code=403,
+                    code="forbidden",
+                    detail="employee is not assigned to the selected facility",
+                )
+            return None
+
+        employee_fids = self._employee_facility_ids(employee_facilities, requested_facility_id)
+        vendor_fids = {f.id for f in vendor.served_facilities}
+        candidates = employee_fids if not vendor_fids else employee_fids & vendor_fids
+        if not candidates:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="vendor not found")
+        if requested_facility_id is not None:
+            return requested_facility_id
+        if len(candidates) == 1:
+            return next(iter(candidates))
+        raise CodedHTTPException(
+            status_code=400,
+            code="facility_required",
+            detail="facility_id is required when multiple facilities are available",
+        )
+
+    @staticmethod
+    def _employee_facility_ids(
+        employee_facilities: list[Facility],
+        facility_id: int | None,
+    ) -> set[int]:
+        employee_fids = {f.id for f in employee_facilities}
+        if facility_id is None:
+            return employee_fids
+        if facility_id not in employee_fids:
+            raise CodedHTTPException(
+                status_code=403,
+                code="forbidden",
+                detail="employee is not assigned to the selected facility",
+            )
+        return {facility_id}
 
     def _get_approved_vendor(self, vendor_id: int) -> VendorRecord:
         vendor = self.vendor_repository.get(vendor_id)

--- a/backend/services/vendor_order_service.py
+++ b/backend/services/vendor_order_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from backend.core.errors import CodedHTTPException
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository
 from backend.schemas.employee import EmployeeOrder
 
 ALLOWED_TRANSITIONS: dict[str, set[str]] = {
@@ -14,11 +15,17 @@ ALLOWED_TRANSITIONS: dict[str, set[str]] = {
 
 
 class VendorOrderService:
-    def __init__(self, selection_repo: EmployeeSelectionRepository) -> None:
+    def __init__(
+        self,
+        selection_repo: EmployeeSelectionRepository,
+        vendor_repo: VendorProfileRepository,
+    ) -> None:
         self._repo = selection_repo
+        self._vendor_repo = vendor_repo
 
-    def list_orders(self, vendor_id: int) -> list[EmployeeOrder]:
-        return self._repo.list_orders_by_vendor(vendor_id=vendor_id)
+    def list_orders(self, vendor_id: int, facility_id: int | None = None) -> list[EmployeeOrder]:
+        self._assert_facility_access(vendor_id, facility_id)
+        return self._repo.list_orders_by_vendor(vendor_id=vendor_id, facility_id=facility_id)
 
     def get_order(self, vendor_id: int, order_id: int) -> EmployeeOrder:
         order = self._repo.get_order_for_vendor(vendor_id=vendor_id, order_id=order_id)
@@ -41,3 +48,14 @@ class VendorOrderService:
         if updated is None:
             raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
         return updated
+
+    def _assert_facility_access(self, vendor_id: int, facility_id: int | None) -> None:
+        if facility_id is None:
+            return
+        served_facilities = self._vendor_repo.list_facilities(vendor_id)
+        if not any(f.id == facility_id for f in served_facilities):
+            raise CodedHTTPException(
+                status_code=403,
+                code="forbidden",
+                detail="vendor does not serve the selected facility",
+            )

--- a/backend/tests/integration/test_vendor_orders_db.py
+++ b/backend/tests/integration/test_vendor_orders_db.py
@@ -59,12 +59,12 @@ def _vh(vendor_id: int) -> dict[str, str]:
     return {"x-user-role": "vendor_manager", "x-vendor-id": str(vendor_id)}
 
 
-def _insert_order(vendor_id: int, employee_id: int) -> int:
+def _insert_order(vendor_id: int, employee_id: int, facility_id: int | None = None) -> int:
     with get_connection() as conn:
         row = conn.execute(
-            "INSERT INTO orders (employee_id, vendor_id, total_price_cents) "
-            "VALUES (%s, %s, 0) RETURNING id",
-            (employee_id, vendor_id),
+            "INSERT INTO orders (employee_id, vendor_id, facility_id, total_price_cents) "
+            "VALUES (%s, %s, %s, 0) RETURNING id",
+            (employee_id, vendor_id, facility_id),
         ).fetchone()
         conn.commit()
     return row["id"]
@@ -98,6 +98,22 @@ def test_list_orders_excludes_other_vendor(client, seeded_ids):
     resp = client.get("/vendor/me/orders", headers=_vh(vendor_id))
     assert resp.status_code == 200
     assert resp.json() == []
+
+
+def test_list_orders_filters_by_facility(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+    with get_connection() as conn:
+        facility = conn.execute("SELECT id FROM facilities WHERE code = 'F12A'").fetchone()
+    assert facility is not None
+    order_id = _insert_order(vendor_id, employee_id, facility_id=facility["id"])
+    _insert_order(vendor_id, employee_id)
+
+    resp = client.get(f"/vendor/me/orders?facility_id={facility['id']}", headers=_vh(vendor_id))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [order["id"] for order in body] == [order_id]
+    assert body[0]["facility_id"] == facility["id"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_employee_facility_filter.py
+++ b/backend/tests/test_employee_facility_filter.py
@@ -167,6 +167,34 @@ def test_list_menu_same_facility_returns_200() -> None:
     assert resp.status_code == 200
 
 
+def test_select_meal_persists_employee_facility() -> None:
+    client, _, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, category_id=None, name="Soup", price_cents=80, available=True)
+
+    resp = client.post(
+        "/employee/vendors/1/selections",
+        headers=_h(101),
+        json={"item_id": item.id, "quantity": 1, "facility_id": 10},
+    )
+
+    assert resp.status_code == 201
+    assert resp.json()["facility_id"] == 10
+
+
+def test_select_meal_cross_facility_returns_404() -> None:
+    client, _, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=2, category_id=None, name="Fab Bowl", price_cents=120, available=True)
+
+    resp = client.post(
+        "/employee/vendors/2/selections",
+        headers=_h(101),
+        json={"item_id": item.id, "quantity": 1, "facility_id": 10},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"
+
+
 # ---------------------------------------------------------------------------
 # draw_random_meal facility filter
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -27,6 +27,8 @@ def _setup() -> tuple[TestClient, MenuItemRepository, EmployeeSelectionRepositor
     )
     vendor_repo.seed(VendorRecord(id=2, name="Pending Bento", status="pending"))
     vendor_repo.assign_facility(1, facility_id=10, code="F12A", name="Fab 12A")
+    vendor_repo.assign_employee_facility(100, facility_id=10, code="F12A", name="Fab 12A")
+    vendor_repo.assign_employee_facility(101, facility_id=20, code="F14B", name="Fab 14B")
 
     item_repo = MenuItemRepository()
     selection_repo = EmployeeSelectionRepository()
@@ -78,6 +80,15 @@ def test_get_vendor_returns_public_vendor_information() -> None:
     assert body["contact_phone"] == "0912-000-000"
 
 
+def test_list_my_facilities_returns_employee_assignments() -> None:
+    client, _, _ = _setup()
+
+    resp = client.get("/employee/me/facilities", headers=_h(100))
+
+    assert resp.status_code == 200
+    assert resp.json() == [{"id": 10, "code": "F12A", "name": "Fab 12A"}]
+
+
 def test_pending_vendor_is_hidden_from_employee() -> None:
     client, _, _ = _setup()
 
@@ -114,6 +125,7 @@ def test_select_meal_records_quantity_and_total_price() -> None:
     assert body["order_id"] is not None
     assert body["employee_id"] == 100
     assert body["vendor_id"] == 1
+    assert body["facility_id"] == 10
     assert body["item_id"] == item.id
     assert body["item_name"] == "Rice Bowl"
     assert body["quantity"] == 2
@@ -144,12 +156,41 @@ def test_create_order_records_multiple_items_and_total_price() -> None:
     body = resp.json()
     assert body["employee_id"] == 100
     assert body["vendor_id"] == 1
+    assert body["facility_id"] == 10
     assert body["status"] == "pending"
     assert body["total_price_cents"] == 280
     assert [(item["item_name"], item["quantity"]) for item in body["items"]] == [
         ("Rice Bowl", 2),
         ("Tea", 1),
     ]
+
+
+def test_create_order_rejects_vendor_outside_employee_facility() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+
+    resp = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(101),
+        json={"facility_id": 20, "items": [{"item_id": item.id, "quantity": 1}]},
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"
+
+
+def test_create_order_rejects_unassigned_facility() -> None:
+    client, item_repo, _ = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)
+
+    resp = client.post(
+        "/employee/vendors/1/orders",
+        headers=_h(100),
+        json={"facility_id": 20, "items": [{"item_id": item.id, "quantity": 1}]},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "forbidden"
 
 
 def test_my_orders_are_scoped_by_employee() -> None:

--- a/backend/tests/test_vendor_orders.py
+++ b/backend/tests/test_vendor_orders.py
@@ -12,6 +12,9 @@ def _seed_vendor_repo() -> VendorProfileRepository:
     repo = VendorProfileRepository()
     repo.seed(VendorRecord(id=1, name="Alice Bento", status="approved", address="No. 1"))
     repo.seed(VendorRecord(id=2, name="Bob Noodles", status="approved", address="No. 2"))
+    repo.assign_facility(1, facility_id=10, code="F12A", name="Fab 12A")
+    repo.assign_facility(1, facility_id=20, code="F14B", name="Fab 14B")
+    repo.assign_facility(2, facility_id=20, code="F14B", name="Fab 14B")
     return repo
 
 
@@ -57,6 +60,42 @@ def test_list_returns_empty_when_no_orders() -> None:
     )
     assert resp.status_code == 200
     assert resp.json() == []
+
+
+def test_list_my_facilities_returns_vendor_facilities() -> None:
+    resp = _client(_seed_vendor_repo(), EmployeeSelectionRepository()).get(
+        "/vendor/me/facilities", headers=_vh(1)
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == [
+        {"id": 10, "code": "F12A", "name": "Fab 12A"},
+        {"id": 20, "code": "F14B", "name": "Fab 14B"},
+    ]
+
+
+def test_list_filters_orders_by_facility() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None, facility_id=10)
+    selection_repo.create_order(employee_id=20, vendor_id=1, items=[], meal_date=None, facility_id=20)
+
+    resp = _client(vendor_repo, selection_repo).get("/vendor/me/orders?facility_id=10", headers=_vh(1))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["facility_id"] == 10
+    assert body[0]["employee_id"] == 10
+
+
+def test_list_rejects_unserved_facility_filter() -> None:
+    resp = _client(_seed_vendor_repo(), EmployeeSelectionRepository()).get(
+        "/vendor/me/orders?facility_id=99", headers=_vh(1)
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "forbidden"
 
 
 def test_list_requires_vendor_manager_role() -> None:


### PR DESCRIPTION
## Summary

- add `facility_id` to employee order/selection request and response schemas
- persist order facility context in in-memory and PostgreSQL repositories
- add employee/vendor facility lookup endpoints
- allow vendor order lists to be filtered by facility with backend access validation
- enforce employee facility access when placing orders or confirming random meal selections

## Tests

- `pytest backend/tests/test_employee_ordering.py backend/tests/test_employee_facility_filter.py backend/tests/test_vendor_orders.py`
- `pytest backend/tests --basetemp .pytest-tmp-run -o cache_dir=.pytest-cache-run`

Result: `188 passed, 16 skipped`

Part of #70. This PR establishes the backend facility context needed for the employee/vendor frontend selector work.
