### PR TITLE
Add frontend facility selector context

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "node --test src/api/facilityParams.test.js src/facility/facilitySelection.test.js",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0 --port 4173"
   },

--- a/frontend/src/api/employee.js
+++ b/frontend/src/api/employee.js
@@ -1,4 +1,5 @@
 import { apiFetch } from "./client";
+import { appendFacilityParam, facilityPayload } from "./facilityParams";
 import { MOCK_VENDORS, MOCK_MENU } from "./mockData";
 
 function withMockFallback(apiCall, mockResult) {
@@ -11,22 +12,46 @@ function withMockFallback(apiCall, mockResult) {
   });
 }
 
-export function getVendors() {
-  return withMockFallback(() => apiFetch("/employee/vendors"), MOCK_VENDORS);
+function uniqueMockFacilities() {
+  const byId = new Map();
+  for (const vendor of MOCK_VENDORS) {
+    for (const facility of vendor.served_facilities ?? []) {
+      byId.set(facility.id, facility);
+    }
+  }
+  return Array.from(byId.values());
 }
 
-export function getVendor(vendorId) {
+export function getMyFacilities() {
+  return withMockFallback(() => apiFetch("/employee/me/facilities"), uniqueMockFacilities);
+}
+
+export function getVendors({ facilityId } = {}) {
   return withMockFallback(
-    () => apiFetch(`/employee/vendors/${vendorId}`),
+    () => apiFetch(appendFacilityParam("/employee/vendors", facilityId)),
+    MOCK_VENDORS.filter((vendor) => (
+      facilityId == null || vendor.served_facilities?.some((facility) => facility.id === Number(facilityId))
+    )),
+  );
+}
+
+export function getVendor(vendorId, { facilityId } = {}) {
+  return withMockFallback(
+    () => apiFetch(appendFacilityParam(`/employee/vendors/${vendorId}`, facilityId)),
     MOCK_VENDORS.find((v) => v.id === Number(vendorId)) ?? null,
   );
 }
 
-export function submitSelection(vendorId, { itemId, quantity, mealDate }) {
+export function submitSelection(vendorId, { itemId, quantity, mealDate, facilityId }) {
   return apiFetch(`/employee/vendors/${vendorId}/selections`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ item_id: itemId, quantity, meal_date: mealDate }),
+    body: JSON.stringify({
+      item_id: itemId,
+      quantity,
+      meal_date: mealDate,
+      ...facilityPayload(facilityId),
+    }),
   });
 }
 
@@ -55,21 +80,26 @@ export function deleteMyOrder(orderId) {
   });
 }
 
-export function getVendorMenu(vendorId, { available } = {}) {
+export function getVendorMenu(vendorId, { available, facilityId } = {}) {
   const params = new URLSearchParams();
   if (available != null) params.set("available", String(available));
   const qs = params.toString();
   return withMockFallback(
-    () => apiFetch(`/employee/vendors/${vendorId}/menu${qs ? `?${qs}` : ""}`),
+    () => apiFetch(appendFacilityParam(`/employee/vendors/${vendorId}/menu${qs ? `?${qs}` : ""}`, facilityId)),
     (MOCK_MENU[Number(vendorId)] ?? []).filter(
       (item) => available == null || item.available === available,
     ),
   );
 }
 
-function mockRandomMeal({ mealDate, vendorIds }) {
+function mockRandomMeal({ mealDate, vendorIds, facilityId }) {
   const selectedIds = vendorIds?.length ? vendorIds.map(Number) : MOCK_VENDORS.map((v) => v.id);
-  const candidates = selectedIds.flatMap((vendorId) =>
+  const visibleVendorIds = selectedIds.filter((vendorId) => {
+    if (facilityId == null) return true;
+    const vendor = MOCK_VENDORS.find((v) => v.id === vendorId);
+    return vendor?.served_facilities?.some((facility) => facility.id === Number(facilityId));
+  });
+  const candidates = visibleVendorIds.flatMap((vendorId) =>
     (MOCK_MENU[vendorId] ?? [])
       .filter((item) => item.available && item.daily_quota !== 0)
       .map((item) => ({
@@ -90,8 +120,8 @@ function mockRandomMeal({ mealDate, vendorIds }) {
   return candidates[Math.floor(Math.random() * candidates.length)];
 }
 
-export function drawRandomMeal({ mealDate, vendorIds }) {
-  const payload = { meal_date: mealDate };
+export function drawRandomMeal({ mealDate, vendorIds, facilityId }) {
+  const payload = { meal_date: mealDate, ...facilityPayload(facilityId) };
   if (vendorIds != null) payload.vendor_ids = vendorIds;
   return withMockFallback(
     () => apiFetch("/employee/random-meals/draw", {
@@ -99,6 +129,6 @@ export function drawRandomMeal({ mealDate, vendorIds }) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     }),
-    () => mockRandomMeal({ mealDate, vendorIds }),
+    () => mockRandomMeal({ mealDate, vendorIds, facilityId }),
   );
 }

--- a/frontend/src/api/facilityParams.js
+++ b/frontend/src/api/facilityParams.js
@@ -1,0 +1,9 @@
+export function appendFacilityParam(path, facilityId) {
+  if (facilityId == null || facilityId === "") return path;
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}facility_id=${encodeURIComponent(String(facilityId))}`;
+}
+
+export function facilityPayload(facilityId) {
+  return facilityId == null || facilityId === "" ? {} : { facility_id: Number(facilityId) };
+}

--- a/frontend/src/api/facilityParams.test.js
+++ b/frontend/src/api/facilityParams.test.js
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { appendFacilityParam, facilityPayload } from "./facilityParams.js";
+
+test("appendFacilityParam skips empty facility values", () => {
+  assert.equal(appendFacilityParam("/employee/vendors", null), "/employee/vendors");
+  assert.equal(appendFacilityParam("/employee/vendors", ""), "/employee/vendors");
+});
+
+test("appendFacilityParam appends facility_id to plain paths", () => {
+  assert.equal(appendFacilityParam("/employee/vendors", 10), "/employee/vendors?facility_id=10");
+});
+
+test("appendFacilityParam preserves existing query strings", () => {
+  assert.equal(
+    appendFacilityParam("/employee/vendors/1/menu?available=true", 10),
+    "/employee/vendors/1/menu?available=true&facility_id=10",
+  );
+});
+
+test("facilityPayload serializes selected facility for JSON bodies", () => {
+  assert.deepEqual(facilityPayload(10), { facility_id: 10 });
+  assert.deepEqual(facilityPayload(null), {});
+});

--- a/frontend/src/api/vendor.js
+++ b/frontend/src/api/vendor.js
@@ -1,5 +1,6 @@
 import { apiFetch } from "./client";
-import { MOCK_MENU } from "./mockData";
+import { appendFacilityParam } from "./facilityParams";
+import { MOCK_MENU, MOCK_VENDORS } from "./mockData";
 
 function withMockFallback(apiCall, mockResult) {
   return apiCall().catch(() => mockResult);
@@ -16,8 +17,12 @@ export function getMyMenu() {
   );
 }
 
-export function getMyOrders() {
-  return apiFetch("/vendor/me/orders");
+export function getMyFacilities() {
+  return withMockFallback(() => apiFetch("/vendor/me/facilities"), MOCK_VENDORS[0]?.served_facilities ?? []);
+}
+
+export function getMyOrders({ facilityId } = {}) {
+  return apiFetch(appendFacilityParam("/vendor/me/orders", facilityId));
 }
 
 export function getMyOrder(orderId) {

--- a/frontend/src/facility/FacilityContext.jsx
+++ b/frontend/src/facility/FacilityContext.jsx
@@ -1,0 +1,93 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { getMyFacilities as getEmployeeFacilities } from "../api/employee";
+import { getMyFacilities as getVendorFacilities } from "../api/vendor";
+import { useAuth } from "../auth/AuthContext";
+import { chooseFacilityId } from "./facilitySelection";
+
+const FacilityContext = createContext(null);
+
+function shouldLoadFacilities(user) {
+  if (!user) return false;
+  if (user.role === "employee") return true;
+  if (user.role === "vendor_manager") return user.vendorId != null;
+  return false;
+}
+
+function fetchFacilitiesFor(user) {
+  if (user.role === "employee") return getEmployeeFacilities();
+  if (user.role === "vendor_manager") return getVendorFacilities();
+  return Promise.resolve([]);
+}
+
+export function FacilityProvider({ children }) {
+  const { user } = useAuth();
+  const [facilities, setFacilities] = useState([]);
+  const [selectedFacilityId, setSelectedFacilityId] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setFacilities([]);
+    setSelectedFacilityId(null);
+    setError(null);
+
+    if (!shouldLoadFacilities(user)) {
+      setLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setLoading(true);
+    fetchFacilitiesFor(user)
+      .then((data) => {
+        if (cancelled) return;
+        const nextFacilities = Array.isArray(data) ? data : [];
+        setFacilities(nextFacilities);
+        setSelectedFacilityId((current) => chooseFacilityId(nextFacilities, current));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setFacilities([]);
+        setSelectedFacilityId(null);
+        setError(err);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.id, user?.role, user?.vendorId]);
+
+  const selectedFacility = useMemo(
+    () => facilities.find((facility) => facility.id === selectedFacilityId) ?? null,
+    [facilities, selectedFacilityId],
+  );
+
+  const value = useMemo(
+    () => ({
+      facilities,
+      selectedFacility,
+      selectedFacilityId,
+      loading,
+      error,
+      canSelectFacility: facilities.length > 1,
+      setSelectedFacilityId: (facilityId) => {
+        setSelectedFacilityId(chooseFacilityId(facilities, facilityId));
+      },
+    }),
+    [error, facilities, loading, selectedFacility, selectedFacilityId],
+  );
+
+  return <FacilityContext.Provider value={value}>{children}</FacilityContext.Provider>;
+}
+
+export function useFacility() {
+  const context = useContext(FacilityContext);
+  if (!context) throw new Error("useFacility must be used within FacilityProvider");
+  return context;
+}

--- a/frontend/src/facility/FacilityScopeLabel.jsx
+++ b/frontend/src/facility/FacilityScopeLabel.jsx
@@ -1,0 +1,14 @@
+import { useFacility } from "./FacilityContext";
+import { facilityDisplayName } from "./facilitySelection";
+
+export default function FacilityScopeLabel({ label = "Current facility" }) {
+  const { selectedFacility, loading } = useFacility();
+
+  if (loading || !selectedFacility) return null;
+
+  return (
+    <p className="facility-scope">
+      {label}: <span>{facilityDisplayName(selectedFacility)}</span>
+    </p>
+  );
+}

--- a/frontend/src/facility/facilitySelection.js
+++ b/frontend/src/facility/facilitySelection.js
@@ -1,0 +1,16 @@
+export function chooseFacilityId(facilities, currentId) {
+  if (!Array.isArray(facilities) || facilities.length === 0) return null;
+
+  const normalizedCurrent = currentId == null ? null : Number(currentId);
+  if (normalizedCurrent != null && facilities.some((facility) => facility.id === normalizedCurrent)) {
+    return normalizedCurrent;
+  }
+
+  return facilities[0].id;
+}
+
+export function facilityDisplayName(facility) {
+  if (!facility) return "No facility";
+  if (facility.code && facility.name) return `${facility.code} - ${facility.name}`;
+  return facility.name ?? facility.code ?? `Facility #${facility.id}`;
+}

--- a/frontend/src/facility/facilitySelection.test.js
+++ b/frontend/src/facility/facilitySelection.test.js
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { chooseFacilityId, facilityDisplayName } from "./facilitySelection.js";
+
+const facilities = [
+  { id: 10, code: "F12A", name: "Fab 12A" },
+  { id: 20, code: "F14B", name: "Fab 14B" },
+];
+
+test("chooseFacilityId keeps a valid current facility", () => {
+  assert.equal(chooseFacilityId(facilities, 20), 20);
+  assert.equal(chooseFacilityId(facilities, "20"), 20);
+});
+
+test("chooseFacilityId falls back to the first available facility", () => {
+  assert.equal(chooseFacilityId(facilities, null), 10);
+  assert.equal(chooseFacilityId(facilities, 99), 10);
+});
+
+test("chooseFacilityId returns null when no facilities are available", () => {
+  assert.equal(chooseFacilityId([], 10), null);
+});
+
+test("facilityDisplayName prefers code and name", () => {
+  assert.equal(facilityDisplayName(facilities[0]), "F12A - Fab 12A");
+  assert.equal(facilityDisplayName({ id: 30, name: "Headquarters" }), "Headquarters");
+});

--- a/frontend/src/hooks/useVendor.js
+++ b/frontend/src/hooks/useVendor.js
@@ -1,22 +1,24 @@
 import { useEffect, useState } from "react";
 import { getVendor } from "../api/employee";
 
-export function useVendor(vendorId) {
+export function useVendor(vendorId, filters = {}) {
   const [vendor, setVendor] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  const { facilityId } = filters;
 
   useEffect(() => {
     if (!vendorId) return;
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getVendor(vendorId)
+    getVendor(vendorId, { facilityId })
       .then((data) => { if (!cancelled) setVendor(data); })
       .catch((err) => { if (!cancelled) setError(err); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [vendorId]);
+  }, [vendorId, facilityId]);
 
   return { vendor, loading, error };
 }

--- a/frontend/src/hooks/useVendorMenu.js
+++ b/frontend/src/hooks/useVendorMenu.js
@@ -6,19 +6,19 @@ export function useVendorMenu(vendorId, filters = {}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const { available } = filters;
+  const { available, facilityId } = filters;
 
   useEffect(() => {
     if (!vendorId) return;
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getVendorMenu(vendorId, { available })
+    getVendorMenu(vendorId, { available, facilityId })
       .then((data) => { if (!cancelled) setItems(data); })
       .catch((err) => { if (!cancelled) setError(err); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [vendorId, available]);
+  }, [vendorId, available, facilityId]);
 
   return { items, loading, error };
 }

--- a/frontend/src/hooks/useVendors.js
+++ b/frontend/src/hooks/useVendors.js
@@ -1,21 +1,23 @@
 import { useEffect, useState } from "react";
 import { getVendors } from "../api/employee";
 
-export function useVendors() {
+export function useVendors(filters = {}) {
   const [vendors, setVendors] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  const { facilityId } = filters;
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getVendors()
+    getVendors({ facilityId })
       .then((data) => { if (!cancelled) setVendors(data); })
       .catch((err) => { if (!cancelled) setError(err); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, []);
+  }, [facilityId]);
 
   return { vendors, loading, error };
 }

--- a/frontend/src/layout/Topbar.jsx
+++ b/frontend/src/layout/Topbar.jsx
@@ -1,6 +1,53 @@
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import { useCart } from "../cart/CartContext";
+import { useFacility } from "../facility/FacilityContext";
+import { facilityDisplayName } from "../facility/facilitySelection";
+
+function FacilityControl() {
+  const {
+    facilities,
+    selectedFacility,
+    selectedFacilityId,
+    setSelectedFacilityId,
+    canSelectFacility,
+    loading,
+    error,
+  } = useFacility();
+
+  if (loading) {
+    return <span className="facility-chip">Facility loading</span>;
+  }
+
+  if (error) {
+    return <span className="facility-chip facility-chip-warning">Facility unavailable</span>;
+  }
+
+  if (facilities.length === 0) {
+    return null;
+  }
+
+  if (!canSelectFacility) {
+    return <span className="facility-chip">Facility: {facilityDisplayName(selectedFacility)}</span>;
+  }
+
+  return (
+    <label className="facility-select-label">
+      <span>Facility</span>
+      <select
+        className="facility-select"
+        value={selectedFacilityId ?? ""}
+        onChange={(event) => setSelectedFacilityId(event.target.value)}
+      >
+        {facilities.map((facility) => (
+          <option key={facility.id} value={facility.id}>
+            {facilityDisplayName(facility)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
 
 export default function Topbar() {
   const navigate = useNavigate();
@@ -17,11 +64,12 @@ export default function Topbar() {
         </p>
       </div>
       <div className="topbar-actions">
+        <FacilityControl />
         {user?.role === "employee" && (
           <button
             className="cart-button"
             type="button"
-            aria-label={`購物車，共 ${totalCount} 項`}
+            aria-label={`Cart with ${totalCount} items`}
             onClick={() => navigate("/employee/cart")}
           >
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { AuthProvider } from "./auth/AuthContext";
 import { CartProvider } from "./cart/CartContext";
+import { FacilityProvider } from "./facility/FacilityContext";
 import "./styles/theme.css";
 import "./styles/global.css";
 
@@ -11,9 +12,11 @@ ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter basename={import.meta.env.BASE_URL}>
       <AuthProvider>
-        <CartProvider>
-          <App />
-        </CartProvider>
+        <FacilityProvider>
+          <CartProvider>
+            <App />
+          </CartProvider>
+        </FacilityProvider>
       </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/frontend/src/pages/employee/CartPage.jsx
+++ b/frontend/src/pages/employee/CartPage.jsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { submitSelection } from "../../api/employee";
 import { useCart } from "../../cart/CartContext";
+import { useFacility } from "../../facility/FacilityContext";
+import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { formatPrice } from "../../utils/format";
 
 function errorMessage(item, err) {
@@ -23,6 +25,7 @@ function errorMessage(item, err) {
 
 export default function CartPage() {
   const { items, updateQuantity, removeItem, clearCart, totalCount } = useCart();
+  const { selectedFacilityId } = useFacility();
   const navigate = useNavigate();
 
   const [submitting, setSubmitting] = useState(false);
@@ -43,6 +46,7 @@ export default function CartPage() {
         await submitSelection(cartItem.vendorId, {
           itemId: cartItem.item.id,
           quantity: cartItem.quantity,
+          facilityId: selectedFacilityId,
         });
       } catch (err) {
         errors.push(errorMessage(cartItem, err));
@@ -112,6 +116,7 @@ export default function CartPage() {
   return (
     <div>
       <div className="page-header">
+        <FacilityScopeLabel label="Order facility" />
         <p className="eyebrow">Employee · Cart</p>
         <h2>購物車</h2>
       </div>

--- a/frontend/src/pages/employee/MenuListPage.jsx
+++ b/frontend/src/pages/employee/MenuListPage.jsx
@@ -2,10 +2,13 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import SearchBar from "../../components/employee/SearchBar";
 import VendorCard from "../../components/employee/VendorCard";
+import { useFacility } from "../../facility/FacilityContext";
+import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { useVendors } from "../../hooks/useVendors";
 
 export default function MenuListPage() {
-  const { vendors, loading, error } = useVendors();
+  const { selectedFacilityId } = useFacility();
+  const { vendors, loading, error } = useVendors({ facilityId: selectedFacilityId });
   const [query, setQuery] = useState("");
   const navigate = useNavigate();
 
@@ -17,6 +20,7 @@ export default function MenuListPage() {
   return (
     <div>
       <div className="page-header">
+        <FacilityScopeLabel label="Browsing facility" />
         <p className="eyebrow">Employee · Browse</p>
         <h2>今日供應廠商</h2>
       </div>

--- a/frontend/src/pages/employee/OrdersPage.jsx
+++ b/frontend/src/pages/employee/OrdersPage.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { deleteMyOrder, updateMyOrder } from "../../api/employee";
+import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { useMyOrders } from "../../hooks/useMyOrders";
 import { formatPrice } from "../../utils/format";
 
@@ -94,6 +95,7 @@ export default function OrdersPage() {
   return (
     <div>
       <div className="page-header">
+        <FacilityScopeLabel label="Current facility" />
         <p className="eyebrow">Employee · Orders</p>
         <h2>我的訂單</h2>
       </div>

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -1,6 +1,8 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { drawRandomMeal, submitSelection } from "../../api/employee";
+import { useFacility } from "../../facility/FacilityContext";
+import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { useVendors } from "../../hooks/useVendors";
 import { formatPrice, quotaLabel } from "../../utils/format";
 
@@ -25,7 +27,8 @@ function drawErrorMessage(err) {
 
 export default function RandomMealPage() {
   const navigate = useNavigate();
-  const { vendors, loading, error } = useVendors();
+  const { selectedFacilityId } = useFacility();
+  const { vendors, loading, error } = useVendors({ facilityId: selectedFacilityId });
   const minMealDate = addDaysIso(0);
   const maxMealDate = addDaysIso(6);
   const [mealDate, setMealDate] = useState(minMealDate);
@@ -46,6 +49,12 @@ export default function RandomMealPage() {
     return `${draw.remaining_quantity} left`;
   }, [draw]);
 
+  useEffect(() => {
+    setSelectedVendorIds([]);
+    setDraw(null);
+    setSubmitted(false);
+  }, [selectedFacilityId]);
+
   function toggleVendor(vendorId) {
     setSelectedVendorIds((current) =>
       current.includes(vendorId)
@@ -64,6 +73,7 @@ export default function RandomMealPage() {
       const result = await drawRandomMeal({
         mealDate,
         vendorIds: allVendors ? null : selectedVendorIds,
+        facilityId: selectedFacilityId,
       });
       setDraw(result);
     } catch (err) {
@@ -83,6 +93,7 @@ export default function RandomMealPage() {
         itemId: draw.item.id,
         quantity: 1,
         mealDate,
+        facilityId: selectedFacilityId,
       });
       setSubmitted(true);
     } catch (err) {
@@ -95,6 +106,7 @@ export default function RandomMealPage() {
   return (
     <div>
       <div className="page-header">
+        <FacilityScopeLabel label="Random meal facility" />
         <p className="eyebrow">Employee / Random Meal</p>
         <h2>Let the menu decide</h2>
       </div>

--- a/frontend/src/pages/employee/VendorMenuPage.jsx
+++ b/frontend/src/pages/employee/VendorMenuPage.jsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import MealDetailModal from "../../components/employee/MealDetailModal";
 import MenuItemCard from "../../components/employee/MenuItemCard";
+import { useFacility } from "../../facility/FacilityContext";
+import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { useVendor } from "../../hooks/useVendor";
 import { useVendorMenu } from "../../hooks/useVendorMenu";
 
@@ -16,10 +18,12 @@ export default function VendorMenuPage() {
 
   const [availableFilter, setAvailableFilter] = useState(undefined);
   const [selectedItem, setSelectedItem] = useState(null);
+  const { selectedFacilityId } = useFacility();
 
-  const { vendor, loading: vendorLoading } = useVendor(vendorId);
+  const { vendor, loading: vendorLoading } = useVendor(vendorId, { facilityId: selectedFacilityId });
   const { items, loading: menuLoading, error } = useVendorMenu(vendorId, {
     available: availableFilter,
+    facilityId: selectedFacilityId,
   });
 
   const loading = vendorLoading || menuLoading;
@@ -35,6 +39,7 @@ export default function VendorMenuPage() {
           ← 返回
         </button>
         <div className="menu-page-title">
+          <FacilityScopeLabel label="Menu facility" />
           <p className="eyebrow">Vendor Menu</p>
           <h2>{vendor?.name ?? "載入中..."}</h2>
         </div>

--- a/frontend/src/pages/vendor/VendorMenuListPage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuListPage.jsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { formatPrice, photoUrl } from "../../utils/format";
 import { useVendorMenu } from "../../vendor/VendorMenuContext";
 
@@ -168,6 +169,7 @@ export default function VendorMenuListPage() {
         style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between" }}
       >
         <div>
+          <FacilityScopeLabel label="Managing facility" />
           <p className="eyebrow">Vendor · Menu</p>
           <h2>菜單管理</h2>
         </div>

--- a/frontend/src/pages/vendor/VendorOrdersPage.jsx
+++ b/frontend/src/pages/vendor/VendorOrdersPage.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getMyOrders } from "../../api/vendor";
+import { useFacility } from "../../facility/FacilityContext";
+import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { formatPrice } from "../../utils/format";
 
 const STATUS_LABEL = {
@@ -47,16 +49,19 @@ function itemsSummary(items) {
 
 export default function VendorOrdersPage() {
   const navigate = useNavigate();
+  const { selectedFacilityId } = useFacility();
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   useEffect(() => {
-    getMyOrders()
+    setLoading(true);
+    setError(null);
+    getMyOrders({ facilityId: selectedFacilityId })
       .then(setOrders)
       .catch((err) => setError(err.message ?? "無法載入訂單"))
       .finally(() => setLoading(false));
-  }, []);
+  }, [selectedFacilityId]);
 
   const totalRevenue = orders.reduce((sum, o) => sum + o.total_price_cents, 0);
   const totalItems = orders.reduce(
@@ -67,6 +72,7 @@ export default function VendorOrdersPage() {
   return (
     <div>
       <div className="page-header">
+        <FacilityScopeLabel label="Orders facility" />
         <p className="eyebrow">Vendor · Orders</p>
         <h2>今日訂單</h2>
       </div>

--- a/frontend/src/pages/vendor/VendorRevenuePage.jsx
+++ b/frontend/src/pages/vendor/VendorRevenuePage.jsx
@@ -1,4 +1,5 @@
 import { MOCK_VENDOR_SELECTIONS } from "../../api/mockData";
+import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { formatPrice } from "../../utils/format";
 
 const MOCK_WEEKLY_REVENUE = 284500;
@@ -47,6 +48,7 @@ export default function VendorRevenuePage() {
   return (
     <div>
       <div className="page-header">
+        <FacilityScopeLabel label="Revenue facility" />
         <p className="eyebrow">Vendor · Revenue</p>
         <h2>收益總覽</h2>
       </div>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -726,6 +726,60 @@ p {
   display: flex;
   align-items: center;
   gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.facility-chip,
+.facility-select-label {
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #fef4e6;
+  font-size: 0.84rem;
+  font-weight: 700;
+  padding: 0 14px;
+  white-space: nowrap;
+}
+
+.facility-chip-warning {
+  color: #ffe9b3;
+  border-color: rgba(255, 209, 102, 0.32);
+}
+
+.facility-select-label span {
+  color: rgba(255, 247, 235, 0.72);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.facility-select {
+  max-width: min(260px, 42vw);
+  border: none;
+  outline: none;
+  background: transparent;
+  color: #fff7eb;
+  font: inherit;
+  cursor: pointer;
+}
+
+.facility-select option {
+  color: #17212b;
+}
+
+.facility-scope {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.facility-scope span {
+  color: var(--ink);
+  font-weight: 700;
 }
 
 .cart-button {
@@ -950,5 +1004,14 @@ p {
     align-items: start;
     flex-direction: column;
     gap: 16px;
+  }
+
+  .topbar-actions {
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .facility-select {
+    max-width: 70vw;
   }
 }


### PR DESCRIPTION
## Summary

- add a shared frontend `FacilityProvider` and topbar facility selector
- load employee/vendor facilities from the backend facility endpoints
- pass `facility_id` through employee vendor browsing, menu browsing, random meal draw, and order submission
- pass `facility_id` through vendor order list filtering
- show the current facility on employee/vendor workflow pages
- add node-native tests for facility query serialization and selection fallback behavior

## Tests

- `C:\Users\nol\.vscode-server\cli\servers\Stable-10c8e557c8b9f9ed0a87f61f1c9a44bde731c409\server\node.exe --test src/api/facilityParams.test.js src/facility/facilitySelection.test.js`
  - 8 passed
- `git diff --check`

Not run locally:

- `npm run build` / `npm test` because this shell has no `node`/`npm` on PATH and `frontend/node_modules` is not installed. The node-native tests were run with the VS Code Server bundled `node.exe`.

Closes the frontend selector portion of #70.
