### PR TITLE
ci/cd: GHCR build-once image promotion (Jenkins pulls instead of builds)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+docs
+frontend
+node_modules
+**/__pycache__
+**/*.pyc
+.pytest_cache
+.venv
+venv
+htmlcov
+.coverage
+*.log
+.env
+load
+infra/deploy/SETUP.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,17 @@
-name: Test
+name: CI/CD
 
 on:
   pull_request:
   push:
     branches:
       - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   unit:
@@ -51,3 +57,100 @@ jobs:
             -f backend/db/migrations/001_initial_schema.sql
       - name: Run integration tests
         run: pytest backend/tests/integration -q
+
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.tag.outputs.image_tag }}
+    steps:
+      - name: Compute image tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "image_tag=pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "image_tag=sha-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-push:
+    needs: [integration, meta]
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { name: backend,  context: ".",          file: "backend/Dockerfile" }
+          - { name: frontend, context: "./frontend", file: "./frontend/Dockerfile" }
+          - { name: db,       context: ".",          file: "backend/db/Dockerfile" }
+          - { name: gateway,  context: ".",          file: "infra/caddy/Dockerfile" }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          push: true
+          tags: ghcr.io/mizu5555/mealorder-${{ matrix.name }}:${{ needs.meta.outputs.image_tag }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+  promote:
+    needs: integration
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Re-tag sha image to version
+        run: |
+          SHA="sha-${GITHUB_SHA::12}"
+          VER="${GITHUB_REF_NAME}"
+          for svc in backend frontend db gateway; do
+            docker buildx imagetools create \
+              -t "ghcr.io/mizu5555/mealorder-${svc}:${VER}" \
+              "ghcr.io/mizu5555/mealorder-${svc}:${SHA}"
+          done
+
+  deploy-staging:
+    needs: [build-push, meta]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Jenkins staging
+        run: |
+          curl -fsS -X POST \
+            "${{ secrets.JENKINS_URL }}/job/meal-deploy-staging/buildWithParameters?IMAGE_TAG=${{ needs.meta.outputs.image_tag }}&token=${{ secrets.JENKINS_STAGING_TOKEN }}" \
+            --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}"
+
+  deploy-preview:
+    needs: [build-push, meta]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Jenkins preview
+        env:
+          PR_BRANCH: ${{ github.head_ref }}
+        run: |
+          curl -fsS -X POST \
+            "${{ secrets.JENKINS_URL }}/job/meal-deploy-preview/buildWithParameters?IMAGE_TAG=${{ needs.meta.outputs.image_tag }}&PR_NUMBER=${{ github.event.number }}&PR_BRANCH=${PR_BRANCH}&token=${{ secrets.JENKINS_PREVIEW_TOKEN }}" \
+            --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}"
+
+  deploy-prod:
+    needs: promote
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Jenkins prod
+        run: |
+          curl -fsS -X POST \
+            "${{ secrets.JENKINS_URL }}/job/meal-deploy-prod/buildWithParameters?IMAGE_TAG=${{ github.ref_name }}&token=${{ secrets.JENKINS_PROD_TOKEN }}" \
+            --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Trigger Jenkins staging
         run: |
           curl -fsS -X POST \
-            "${{ secrets.JENKINS_URL }}/job/meal-deploy-staging/buildWithParameters?IMAGE_TAG=${{ needs.meta.outputs.image_tag }}&token=${{ secrets.JENKINS_STAGING_TOKEN }}" \
+            "${{ secrets.JENKINS_URL }}/job/Meal-Ordering-Project/job/meal-deploy-staging/buildWithParameters?IMAGE_TAG=${{ needs.meta.outputs.image_tag }}&token=${{ secrets.JENKINS_STAGING_TOKEN }}" \
             --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}"
 
   deploy-preview:
@@ -142,7 +142,7 @@ jobs:
         run: |
           PR_BRANCH_ENC=$(python3 -c "import urllib.parse,os;print(urllib.parse.quote(os.environ['PR_BRANCH'],safe=''))")
           curl -fsS -X POST \
-            "${{ secrets.JENKINS_URL }}/job/meal-deploy-preview/buildWithParameters?IMAGE_TAG=${{ needs.meta.outputs.image_tag }}&PR_NUMBER=${{ github.event.number }}&PR_BRANCH=${PR_BRANCH_ENC}&token=${{ secrets.JENKINS_PREVIEW_TOKEN }}" \
+            "${{ secrets.JENKINS_URL }}/job/Meal-Ordering-Project/job/meal-deploy-preview/buildWithParameters?IMAGE_TAG=${{ needs.meta.outputs.image_tag }}&PR_NUMBER=${{ github.event.number }}&PR_BRANCH=${PR_BRANCH_ENC}&token=${{ secrets.JENKINS_PREVIEW_TOKEN }}" \
             --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}"
 
   deploy-prod:
@@ -153,5 +153,5 @@ jobs:
       - name: Trigger Jenkins prod
         run: |
           curl -fsS -X POST \
-            "${{ secrets.JENKINS_URL }}/job/meal-deploy-prod/buildWithParameters?IMAGE_TAG=${{ github.ref_name }}&token=${{ secrets.JENKINS_PROD_TOKEN }}" \
+            "${{ secrets.JENKINS_URL }}/job/Meal-Ordering-Project/job/meal-deploy-prod/buildWithParameters?IMAGE_TAG=${{ github.ref_name }}&token=${{ secrets.JENKINS_PROD_TOKEN }}" \
             --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,8 +140,9 @@ jobs:
         env:
           PR_BRANCH: ${{ github.head_ref }}
         run: |
+          PR_BRANCH_ENC=$(python3 -c "import urllib.parse,os;print(urllib.parse.quote(os.environ['PR_BRANCH'],safe=''))")
           curl -fsS -X POST \
-            "${{ secrets.JENKINS_URL }}/job/meal-deploy-preview/buildWithParameters?IMAGE_TAG=${{ needs.meta.outputs.image_tag }}&PR_NUMBER=${{ github.event.number }}&PR_BRANCH=${PR_BRANCH}&token=${{ secrets.JENKINS_PREVIEW_TOKEN }}" \
+            "${{ secrets.JENKINS_URL }}/job/meal-deploy-preview/buildWithParameters?IMAGE_TAG=${{ needs.meta.outputs.image_tag }}&PR_NUMBER=${{ github.event.number }}&PR_BRANCH=${PR_BRANCH_ENC}&token=${{ secrets.JENKINS_PREVIEW_TOKEN }}" \
             --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}"
 
   deploy-prod:

--- a/Jenkinsfile.cleanup
+++ b/Jenkinsfile.cleanup
@@ -28,7 +28,7 @@ pipeline {
 
     stage('Hourly sweep') {
       steps {
-        withCredentials([usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
+        withCredentials([usernamePassword(credentialsId: 'github-token', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
           sh '''
             set -euo pipefail
             bash scripts/sweep-stale-stacks.sh
@@ -39,7 +39,7 @@ pipeline {
 
     stage('Prune GHCR pr-* tags') {
       steps {
-        withCredentials([usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
+        withCredentials([usernamePassword(credentialsId: 'github-token', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
           sh '''
             set -euo pipefail
             OWNER=mizu5555

--- a/Jenkinsfile.cleanup
+++ b/Jenkinsfile.cleanup
@@ -36,5 +36,32 @@ pipeline {
         }
       }
     }
+
+    stage('Prune GHCR pr-* tags') {
+      steps {
+        withCredentials([usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
+          sh '''
+            set -euo pipefail
+            OWNER=mizu5555
+            for svc in backend frontend db gateway; do
+              PKG="mealorder-${svc}"
+              gh api --paginate "/users/${OWNER}/packages/container/${PKG}/versions" \
+                --jq '.[] | {id: .id, tags: .metadata.container.tags}' 2>/dev/null \
+                | jq -c 'select(.tags[]? | startswith("pr-"))' \
+                | while read -r row; do
+                    VID=$(echo "$row" | jq -r '.id')
+                    TAG=$(echo "$row" | jq -r '.tags[] | select(startswith("pr-"))' | head -1)
+                    NUM="${TAG#pr-}"
+                    STATE=$(gh api "/repos/${OWNER}/Corporate-Meal-Ordering-System/pulls/${NUM}" --jq '.state' 2>/dev/null || echo "")
+                    if [ "$STATE" = "closed" ]; then
+                      echo "pruning ${PKG} ${TAG} (PR #${NUM} closed) version=${VID}"
+                      gh api -X DELETE "/users/${OWNER}/packages/container/${PKG}/versions/${VID}" || true
+                    fi
+                  done
+            done
+          '''
+        }
+      }
+    }
   }
 }

--- a/Jenkinsfile.preview
+++ b/Jenkinsfile.preview
@@ -1,6 +1,12 @@
 pipeline {
   agent any
 
+  parameters {
+    string(name: 'IMAGE_TAG',  defaultValue: '', description: 'GHCR image tag, e.g. pr-42')
+    string(name: 'PR_NUMBER',  defaultValue: '', description: 'PR number for slot/comment')
+    string(name: 'PR_BRANCH',  defaultValue: '', description: 'PR head branch for slug')
+  }
+
   options {
     disableConcurrentBuilds()
     timeout(time: 20, unit: 'MINUTES')
@@ -8,97 +14,85 @@ pipeline {
   }
 
   environment {
-    PROJECT_PREFIX  = 'mealorder'
-    PREVIEW_LIMIT   = '3'
-    PUBLIC_BASE     = 'https://nol.cs.nycu.edu.tw'
+    PROJECT_PREFIX = 'mealorder'
+    PREVIEW_LIMIT  = '3'
+    PUBLIC_BASE    = 'https://nol.cs.nycu.edu.tw'
   }
 
   stages {
+    stage('Validate params') {
+      steps {
+        script {
+          if (!params.IMAGE_TAG?.trim() || !params.PR_BRANCH?.trim()) {
+            error('IMAGE_TAG and PR_BRANCH are required (triggered by GitHub Actions).')
+          }
+        }
+      }
+    }
+
     stage('Checkout') {
-      when { changeRequest() }
       steps { checkout scm }
     }
 
     stage('Deploy preview') {
-      when { changeRequest() }
-      environment {
-        BRANCH_RAW = "${env.CHANGE_BRANCH}"
-      }
       steps {
-        withCredentials([usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
+        withCredentials([
+          usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN'),
+          usernamePassword(credentialsId: 'ghcr-pull', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')
+        ]) {
           sh '''
             set -euo pipefail
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
-            if [ -z "${BRANCH_RAW:-}" ]; then
-              echo "BRANCH_RAW empty; refusing to deploy" >&2
-              exit 2
-            fi
-
-            SLUG=$(bash scripts/preview-sanitize-branch.sh "$BRANCH_RAW")
+            SLUG=$(bash scripts/preview-sanitize-branch.sh "$PR_BRANCH")
             if [ -z "$SLUG" ]; then
-              gh pr comment "$CHANGE_ID" --repo "$CHANGE_URL" --body "Preview deploy aborted: branch name '$BRANCH_RAW' produces empty slug." || true
-              echo "empty SLUG from sanitize" >&2
-              exit 2
+              gh pr comment "$PR_NUMBER" --body "Preview aborted: branch '$PR_BRANCH' produces empty slug." || true
+              echo "empty SLUG" >&2; exit 2
             fi
 
             PROJECT="${PROJECT_PREFIX}-${SLUG}"
             ROOT_PATH="/meal-preview/${SLUG}"
+            BASE_PATH="${ROOT_PATH}/"
 
-            docker network inspect preview-net >/dev/null 2>&1 \
-              || docker network create preview-net
+            docker network inspect preview-net >/dev/null 2>&1 || docker network create preview-net
 
-            # Slot check — count active preview stacks excluding stable ones.
             COUNT=$(docker compose ls --filter name=${PROJECT_PREFIX}- --format json \
               | jq --arg p "$PROJECT_PREFIX" --arg this "$PROJECT" '
-                  [.[]
-                    | select(.Name != $this)
-                    | select(.Name != ($p + "-main"))
-                    | select(.Name != ($p + "-staging"))
-                    | select(.Name != ($p + "-prod"))
-                  ] | length')
+                  [.[] | select(.Name != $this)
+                       | select(.Name != ($p + "-main"))
+                       | select(.Name != ($p + "-staging"))
+                       | select(.Name != ($p + "-prod"))] | length')
             if [ "$COUNT" -ge "$PREVIEW_LIMIT" ]; then
-              gh pr comment "$CHANGE_ID" --body "Preview slot full ($COUNT/$PREVIEW_LIMIT). Will retry on next push." || true
-              echo "preview slot full" >&2
-              exit 0
+              gh pr comment "$PR_NUMBER" --body "Preview slot full ($COUNT/$PREVIEW_LIMIT). Retry on next push." || true
+              echo "slot full" >&2; exit 0
             fi
 
-            BRANCH_RAW="$BRANCH_RAW" \
-            ROOT_PATH="$ROOT_PATH" \
-            SLUG="$SLUG" \
+            IMAGE_TAG="${IMAGE_TAG}" BRANCH_RAW="$PR_BRANCH" ROOT_PATH="$ROOT_PATH" BASE_PATH="$BASE_PATH" SLUG="$SLUG" \
             GATEWAY_CONTAINER_NAME="mealorder-${SLUG}-gateway" \
-              docker compose \
-                -p "$PROJECT" \
-                -f docker-compose.yml \
-                -f infra/deploy/docker-compose.preview.yml \
+              docker compose -p "$PROJECT" \
+                -f docker-compose.yml -f infra/deploy/docker-compose.preview.yml \
                 down -v --remove-orphans || true
 
-            BRANCH_RAW="$BRANCH_RAW" \
-            ROOT_PATH="$ROOT_PATH" \
-            BASE_PATH="${ROOT_PATH}/" \
-            SLUG="$SLUG" \
+            IMAGE_TAG="${IMAGE_TAG}" BRANCH_RAW="$PR_BRANCH" ROOT_PATH="$ROOT_PATH" BASE_PATH="$BASE_PATH" SLUG="$SLUG" \
             GATEWAY_CONTAINER_NAME="mealorder-${SLUG}-gateway" \
-              docker compose \
-                -p "$PROJECT" \
-                -f docker-compose.yml \
-                -f infra/deploy/docker-compose.preview.yml \
-                up -d --build
+              docker compose -p "$PROJECT" \
+                -f docker-compose.yml -f infra/deploy/docker-compose.preview.yml pull
+
+            IMAGE_TAG="${IMAGE_TAG}" BRANCH_RAW="$PR_BRANCH" ROOT_PATH="$ROOT_PATH" BASE_PATH="$BASE_PATH" SLUG="$SLUG" \
+            GATEWAY_CONTAINER_NAME="mealorder-${SLUG}-gateway" \
+              docker compose -p "$PROJECT" \
+                -f docker-compose.yml -f infra/deploy/docker-compose.preview.yml up -d
 
             URL="${PUBLIC_BASE}/meal-preview/${SLUG}/"
-
-            # Smoke check — retry health up to 60s.
             ok=0
             for i in $(seq 1 30); do
-              if curl -fsS "${URL}health" >/dev/null; then
-                ok=1
-                break
-              fi
+              if curl -fsS "${URL}health" >/dev/null; then ok=1; break; fi
               sleep 2
             done
-
             if [ "$ok" -eq 1 ]; then
-              gh pr comment "$CHANGE_ID" --body "Preview ready: ${URL} (health: ${URL}health)" || true
+              gh pr comment "$PR_NUMBER" --body "Preview ready: ${URL} (health: ${URL}health)" || true
             else
-              gh pr comment "$CHANGE_ID" --body "Preview deploy reached but /health failed after 60s. Check Jenkins console for ${PROJECT}." || true
+              gh pr comment "$PR_NUMBER" --body "Preview reached but /health failed after 60s. Check Jenkins for ${PROJECT}." || true
               docker compose -p "$PROJECT" logs --tail=200 >&2 || true
               exit 1
             fi
@@ -108,7 +102,5 @@ pipeline {
     }
   }
 
-  post {
-    always { cleanWs() }
-  }
+  post { always { cleanWs() } }
 }

--- a/Jenkinsfile.preview
+++ b/Jenkinsfile.preview
@@ -36,13 +36,10 @@ pipeline {
 
     stage('Deploy preview') {
       steps {
-        withCredentials([
-          usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN'),
-          usernamePassword(credentialsId: 'ghcr-pull', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')
-        ]) {
+        withCredentials([usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
           sh '''
             set -euo pipefail
-            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_USER" --password-stdin
 
             SLUG=$(bash scripts/preview-sanitize-branch.sh "$PR_BRANCH")
             if [ -z "$SLUG" ]; then

--- a/Jenkinsfile.preview
+++ b/Jenkinsfile.preview
@@ -36,7 +36,7 @@ pipeline {
 
     stage('Deploy preview') {
       steps {
-        withCredentials([usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
+        withCredentials([usernamePassword(credentialsId: 'github-token', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
           sh '''
             set -euo pipefail
             echo "$GH_TOKEN" | docker login ghcr.io -u "$GH_USER" --password-stdin

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -37,7 +37,7 @@ pipeline {
 
     stage('GHCR login & pull') {
       steps {
-        withCredentials([usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
+        withCredentials([usernamePassword(credentialsId: 'github-token', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
           sh '''
             set -euo pipefail
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -37,7 +37,7 @@ pipeline {
 
     stage('GHCR login & pull') {
       steps {
-        withCredentials([usernamePassword(credentialsId: 'ghcr-pull', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
+        withCredentials([usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
           sh '''
             set -euo pipefail
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -1,6 +1,10 @@
 pipeline {
   agent any
 
+  parameters {
+    string(name: 'IMAGE_TAG', defaultValue: '', description: 'GHCR version tag to deploy, e.g. v1.2.3')
+  }
+
   options {
     disableConcurrentBuilds()
     timeout(time: 20, unit: 'MINUTES')
@@ -8,21 +12,21 @@ pipeline {
   }
 
   environment {
-    COMPOSE_PROJECT_NAME     = 'mealorder-prod'
-    ROOT_PATH                = '/meal'
-    GATEWAY_CONTAINER_NAME   = 'mealorder-prod-gateway'
-    PUBLIC_HEALTH_URL        = "${env.PUBLIC_HEALTH_URL ?: 'https://nol.cs.nycu.edu.tw/meal/health'}"
+    COMPOSE_PROJECT_NAME   = 'mealorder-prod'
+    ROOT_PATH              = '/meal'
+    BASE_PATH              = '/meal/'
+    GATEWAY_CONTAINER_NAME = 'mealorder-prod-gateway'
+    PUBLIC_HEALTH_URL      = "${env.PUBLIC_HEALTH_URL ?: 'https://nol.cs.nycu.edu.tw/meal/health'}"
   }
 
   stages {
-    stage('Validate tag') {
+    stage('Validate params') {
       steps {
         script {
-          def tag = env.TAG_NAME
-          if (!tag || !(tag ==~ /^v\d+\.\d+\.\d+$/)) {
-            error("Prod pipeline must be triggered by a semver tag matching ^v\\d+\\.\\d+\\.\\d+\$. Got: branch=${env.BRANCH_NAME} tag=${tag}")
+          if (!(params.IMAGE_TAG ==~ /^v\d+\.\d+\.\d+$/)) {
+            error("IMAGE_TAG must be a semver tag matching ^v\\d+\\.\\d+\\.\\d+\$. Got: '${params.IMAGE_TAG}'")
           }
-          echo "Deploying tag ${tag} to production"
+          echo "Deploying ${params.IMAGE_TAG} to production"
         }
       }
     }
@@ -31,46 +35,33 @@ pipeline {
       steps { checkout scm }
     }
 
-    stage('Verify commit') {
+    stage('GHCR login & pull') {
       steps {
-        sh '''
-          set -eu
-          BUILT=$(git rev-parse HEAD)
-          TAG_SHA=$(git ls-remote origin "refs/tags/${TAG_NAME}^{}" | awk '{print $1}')
-          if [ -z "$TAG_SHA" ]; then
-            TAG_SHA=$(git ls-remote origin "refs/tags/${TAG_NAME}" | awk '{print $1}')
-          fi
-          echo "Built  SHA: $BUILT"
-          echo "Tag ${TAG_NAME} -> $TAG_SHA"
-          git log -1 --pretty=format:'subject: %s%nauthor : %an <%ae>%ndate   : %ad' --date=iso
-          echo
-          if [ "$BUILT" != "$TAG_SHA" ]; then
-            echo "WARNING: built SHA does not match tag ${TAG_NAME} on origin"
-          fi
-        '''
+        withCredentials([usernamePassword(credentialsId: 'ghcr-pull', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
+          sh '''
+            set -euo pipefail
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            docker network inspect preview-net >/dev/null 2>&1 || docker network create preview-net
+            IMAGE_TAG="${IMAGE_TAG}" \
+            ROOT_PATH="$ROOT_PATH" BASE_PATH="$BASE_PATH" \
+            GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
+              docker compose -p "$COMPOSE_PROJECT_NAME" \
+                -f docker-compose.yml -f infra/deploy/docker-compose.prod.yml pull
+          '''
+        }
       }
     }
 
-    stage('Build and deploy prod') {
+    stage('Deploy prod') {
       steps {
         sh '''
           set -euo pipefail
-          docker network inspect preview-net >/dev/null 2>&1 \
-            || docker network create preview-net
-          ROOT_PATH="$ROOT_PATH" \
-          BASE_PATH="${ROOT_PATH}/" \
+          IMAGE_TAG="${IMAGE_TAG}" \
+          ROOT_PATH="$ROOT_PATH" BASE_PATH="$BASE_PATH" \
           GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
             docker compose -p "$COMPOSE_PROJECT_NAME" \
-            -f docker-compose.yml \
-            -f infra/deploy/docker-compose.prod.yml \
-            build
-          ROOT_PATH="$ROOT_PATH" \
-          BASE_PATH="${ROOT_PATH}/" \
-          GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
-            docker compose -p "$COMPOSE_PROJECT_NAME" \
-            -f docker-compose.yml \
-            -f infra/deploy/docker-compose.prod.yml \
-            up -d
+              -f docker-compose.yml -f infra/deploy/docker-compose.prod.yml \
+              up -d
         '''
       }
     }
@@ -80,13 +71,10 @@ pipeline {
         sh '''
           set -euo pipefail
           for i in $(seq 1 30); do
-            if curl -fsS "$PUBLIC_HEALTH_URL" >/dev/null; then
-              echo "prod /health OK for ${TAG_NAME}"
-              exit 0
-            fi
+            if curl -fsS "$PUBLIC_HEALTH_URL" >/dev/null; then echo "prod /health OK for ${IMAGE_TAG}"; exit 0; fi
             sleep 2
           done
-          echo "prod /health failed after 60s for ${TAG_NAME}" >&2
+          echo "prod /health failed after 60s for ${IMAGE_TAG}" >&2
           docker compose -p "$COMPOSE_PROJECT_NAME" logs --tail=200 >&2 || true
           exit 1
         '''
@@ -94,7 +82,5 @@ pipeline {
     }
   }
 
-  post {
-    always { cleanWs() }
-  }
+  post { always { cleanWs() } }
 }

--- a/Jenkinsfile.staging
+++ b/Jenkinsfile.staging
@@ -17,7 +17,6 @@ pipeline {
     BASE_PATH              = '/meal-staging/'
     GATEWAY_CONTAINER_NAME = 'mealorder-staging-gateway'
     PUBLIC_HEALTH_URL      = "${env.PUBLIC_HEALTH_URL ?: 'https://nol.cs.nycu.edu.tw/meal-staging/health'}"
-    REGISTRY               = 'ghcr.io/mizu5555'
   }
 
   stages {

--- a/Jenkinsfile.staging
+++ b/Jenkinsfile.staging
@@ -37,7 +37,7 @@ pipeline {
 
     stage('GHCR login & pull') {
       steps {
-        withCredentials([usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
+        withCredentials([usernamePassword(credentialsId: 'github-token', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
           sh '''
             set -euo pipefail
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin

--- a/Jenkinsfile.staging
+++ b/Jenkinsfile.staging
@@ -37,7 +37,7 @@ pipeline {
 
     stage('GHCR login & pull') {
       steps {
-        withCredentials([usernamePassword(credentialsId: 'ghcr-pull', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
+        withCredentials([usernamePassword(credentialsId: 'github-token-eason', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
           sh '''
             set -euo pipefail
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin

--- a/Jenkinsfile.staging
+++ b/Jenkinsfile.staging
@@ -1,6 +1,10 @@
 pipeline {
   agent any
 
+  parameters {
+    string(name: 'IMAGE_TAG', defaultValue: '', description: 'GHCR image tag to deploy, e.g. sha-abc123def456')
+  }
+
   options {
     disableConcurrentBuilds()
     timeout(time: 20, unit: 'MINUTES')
@@ -8,68 +12,73 @@ pipeline {
   }
 
   environment {
-    COMPOSE_PROJECT_NAME     = 'mealorder-staging'
-    ROOT_PATH                = '/meal-staging'
-    GATEWAY_CONTAINER_NAME   = 'mealorder-staging-gateway'
-    PUBLIC_HEALTH_URL        = "${env.PUBLIC_HEALTH_URL ?: 'https://nol.cs.nycu.edu.tw/meal-staging/health'}"
+    COMPOSE_PROJECT_NAME   = 'mealorder-staging'
+    ROOT_PATH              = '/meal-staging'
+    BASE_PATH              = '/meal-staging/'
+    GATEWAY_CONTAINER_NAME = 'mealorder-staging-gateway'
+    PUBLIC_HEALTH_URL      = "${env.PUBLIC_HEALTH_URL ?: 'https://nol.cs.nycu.edu.tw/meal-staging/health'}"
+    REGISTRY               = 'ghcr.io/mizu5555'
   }
 
   stages {
+    stage('Validate params') {
+      steps {
+        script {
+          if (!params.IMAGE_TAG?.trim()) {
+            error('IMAGE_TAG is required. This job must be triggered by GitHub Actions with a built image tag.')
+          }
+          echo "Deploying IMAGE_TAG=${params.IMAGE_TAG} to staging"
+        }
+      }
+    }
+
     stage('Checkout') {
-      when { branch 'main' }
       steps { checkout scm }
     }
 
-    stage('Verify commit') {
-      when { branch 'main' }
+    stage('GHCR login & pull') {
       steps {
-        sh '''
-          set -eu
-          BUILT=$(git rev-parse HEAD)
-          REMOTE=$(git ls-remote origin refs/heads/main | awk '{print $1}')
-          echo "Built  SHA: $BUILT"
-          echo "origin/main: $REMOTE"
-          git log -1 --pretty=format:'subject: %s%nauthor : %an <%ae>%ndate   : %ad' --date=iso
-          echo
-          if [ "$BUILT" != "$REMOTE" ]; then
-            echo "WARNING: building stale commit (behind origin/main)"
-          fi
-        '''
+        withCredentials([usernamePassword(credentialsId: 'ghcr-pull', usernameVariable: 'GHCR_USER', passwordVariable: 'GHCR_TOKEN')]) {
+          sh '''
+            set -euo pipefail
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            docker network inspect preview-net >/dev/null 2>&1 || docker network create preview-net
+            IMAGE_TAG="${IMAGE_TAG}" \
+            ROOT_PATH="$ROOT_PATH" BASE_PATH="$BASE_PATH" \
+            GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
+              docker compose -p "$COMPOSE_PROJECT_NAME" \
+                -f docker-compose.yml -f infra/deploy/docker-compose.staging.yml pull
+          '''
+        }
       }
     }
 
     stage('Reset and deploy staging') {
-      when { branch 'main' }
       steps {
         sh '''
           set -euo pipefail
-          docker network inspect preview-net >/dev/null 2>&1 \
-            || docker network create preview-net
-          docker compose -p "$COMPOSE_PROJECT_NAME" \
-            -f docker-compose.yml \
-            -f infra/deploy/docker-compose.staging.yml \
-            down -v --remove-orphans || true
-          ROOT_PATH="$ROOT_PATH" \
-          BASE_PATH="${ROOT_PATH}/" \
+          IMAGE_TAG="${IMAGE_TAG}" \
+          ROOT_PATH="$ROOT_PATH" BASE_PATH="$BASE_PATH" \
           GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
             docker compose -p "$COMPOSE_PROJECT_NAME" \
-            -f docker-compose.yml \
-            -f infra/deploy/docker-compose.staging.yml \
-            up -d --build
+              -f docker-compose.yml -f infra/deploy/docker-compose.staging.yml \
+              down -v --remove-orphans || true
+          IMAGE_TAG="${IMAGE_TAG}" \
+          ROOT_PATH="$ROOT_PATH" BASE_PATH="$BASE_PATH" \
+          GATEWAY_CONTAINER_NAME="$GATEWAY_CONTAINER_NAME" \
+            docker compose -p "$COMPOSE_PROJECT_NAME" \
+              -f docker-compose.yml -f infra/deploy/docker-compose.staging.yml \
+              up -d
         '''
       }
     }
 
     stage('Smoke check') {
-      when { branch 'main' }
       steps {
         sh '''
           set -euo pipefail
           for i in $(seq 1 30); do
-            if curl -fsS "$PUBLIC_HEALTH_URL" >/dev/null; then
-              echo "staging /health OK"
-              exit 0
-            fi
+            if curl -fsS "$PUBLIC_HEALTH_URL" >/dev/null; then echo "staging /health OK"; exit 0; fi
             sleep 2
           done
           echo "staging /health failed after 60s" >&2
@@ -80,39 +89,17 @@ pipeline {
     }
 
     stage('k6 vendor smoke') {
-      when { branch 'main' }
       steps {
-        // Post-deploy load smoke: drive the vendor golden path against the
-        // freshly deployed staging URL. k6 thresholds (defined in the script)
-        // fail the build if request rate / latency regresses, which surfaces
-        // perf regressions that TestClient cannot — same flow as load/vendor-flow.js
-        // running in PR CI, but against the real environment.
         sh '''
           set -euo pipefail
           BASE_URL="${BASE_URL:-https://nol.cs.nycu.edu.tw/meal-staging}"
           echo "running k6 vendor-flow against $BASE_URL"
-          # Dockerised k6 — no jenkins-service image change required.
-          # Short ramp + low VUS so a deploy gate stays under ~40s.
-          # No VENDOR_ID: the script logs in via /auth/login and reads vendor_id
-          # from the JWT (the deployed gateway strips x-user-role/x-vendor-id, so
-          # header-based auth would 403). Credentials default to the seeded
-          # vendor_manager in 003_auth.sql; override with VENDOR_EMAIL/PASSWORD.
-          docker run --rm -i \
-            -e BASE_URL="$BASE_URL" \
-            -e VUS=3 \
-            -e DURATION=20s \
-            grafana/k6:latest run --insecure-skip-tls-verify - \
-            < load/vendor-flow.js
+          docker run --rm -i -e BASE_URL="$BASE_URL" -e VUS=3 -e DURATION=20s \
+            grafana/k6:latest run --insecure-skip-tls-verify - < load/vendor-flow.js
         '''
-        // No DB cleanup stage: the 'Reset and deploy staging' stage runs
-        // `docker compose down -v`, dropping the Postgres volume on every
-        // deploy, and the k6 script self-cleans its k6-* rows per iteration
-        // plus a teardown() sweep. The shared demo vendor row is never deleted.
       }
     }
   }
 
-  post {
-    always { cleanWs() }
-  }
+  post { always { cleanWs() } }
 }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,19 @@
-FROM python:3.12-slim
-
+FROM python:3.12-slim AS builder
 WORKDIR /app
-
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
-
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 
+FROM python:3.12-slim
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH=/usr/local/bin:$PATH
+COPY --from=builder /install /usr/local
 COPY backend ./backend
-
+RUN useradd --create-home --uid 1000 appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+EXPOSE 8000
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,6 @@ services:
   frontend:
     build:
       context: ./frontend
-      args:
-        BASE_PATH: ${BASE_PATH:-/}
     ports:
       - "3000:80"
     depends_on:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.git
+*.log

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,15 +1,13 @@
 FROM node:20-alpine AS build
 WORKDIR /app
-
-ARG BASE_PATH=/
-ENV BASE_PATH=$BASE_PATH
-
 COPY package.json ./
 RUN npm install
-
 COPY . .
 RUN npm run build
 
 FROM nginx:1.27-alpine
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY docker-entrypoint.sh /usr/local/bin/inject-base-path.sh
+RUN chmod +x /usr/local/bin/inject-base-path.sh
+ENTRYPOINT ["/usr/local/bin/inject-base-path.sh"]

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+# 部署時以 BASE_PATH env 注入路徑前綴；本地/未設時退回根路徑 "/"。
+# 必須以 / 開頭、/ 結尾，例如 /meal-staging/。
+BASE_PATH="${BASE_PATH:-/}"
+case "$BASE_PATH" in
+  /*) : ;;
+  *) BASE_PATH="/$BASE_PATH" ;;
+esac
+case "$BASE_PATH" in
+  */) : ;;
+  *) BASE_PATH="$BASE_PATH/" ;;
+esac
+
+ROOT=/usr/share/nginx/html
+echo "injecting BASE_PATH=$BASE_PATH into static assets"
+find "$ROOT" -type f \( -name '*.js' -o -name '*.html' -o -name '*.css' \) \
+  -exec sed -i "s|/__BASE_PATH__/|${BASE_PATH}|g" {} +
+
+exec nginx -g 'daemon off;'

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
-  base: process.env.BASE_PATH || "/",
+  base: "/__BASE_PATH__/",
   plugins: [react()],
   server: {
     host: "0.0.0.0",

--- a/infra/deploy/SETUP.md
+++ b/infra/deploy/SETUP.md
@@ -184,3 +184,101 @@ curl -sk https://nol.cs.nycu.edu.tw/meal/health
 - [ ] Opening a PR triggers `mealorder-preview`; PR receives a comment with the preview URL
 - [ ] `https://nol.cs.nycu.edu.tw/preview/<slug>/health` returns 200 for the open PR
 - [ ] Closing the PR → within 1 hour, the preview stack is gone (`docker compose ls`)
+
+## 11. GHCR build-once CI/CD setup
+
+This section documents the one-time manual configuration required for the
+build-once flow introduced in the `feature/cicd/ghcr-build-once` branch.
+GitHub Actions builds and pushes images to GHCR once; Jenkins jobs pull and
+deploy without rebuilding.
+
+### 11.1 GitHub repo secrets
+
+Go to **Settings → Secrets and variables → Actions** and add:
+
+| Secret name | Value |
+|---|---|
+| `JENKINS_URL` | NOL Jenkins base URL reachable from GitHub Actions (e.g. `https://nol.cs.nycu.edu.tw/jenkins`) |
+| `JENKINS_USER` | Jenkins username that owns the API token below |
+| `JENKINS_API_TOKEN` | Jenkins API token for `JENKINS_USER` (generate under user → Configure → API Token) |
+| `JENKINS_STAGING_TOKEN` | "Trigger builds remotely" token set on the `meal-deploy-staging` job |
+| `JENKINS_PREVIEW_TOKEN` | "Trigger builds remotely" token set on the `meal-deploy-preview` job |
+| `JENKINS_PROD_TOKEN` | "Trigger builds remotely" token set on the `meal-deploy-prod` job |
+
+### 11.2 Jenkins deploy jobs (replace old multibranch jobs)
+
+Create **three parameterized Pipeline jobs** (not Multibranch) in Jenkins UI.
+The old multibranch jobs (`mealorder-staging`, `mealorder-prod`, `mealorder-preview`)
+must be **disabled or deleted** so they no longer trigger on SCM webhook events
+and do not double-trigger alongside the new token-triggered jobs.
+
+**Common setup for all three jobs:**
+
+- **Pipeline → Pipeline script from SCM**, Git repo `https://github.com/mizu5555/Corporate-Meal-Ordering-System.git`, credentials = your PAT, branch `*/main`.
+- Enable **Trigger builds remotely (e.g., from scripts)** and set the
+  Authentication Token to match the corresponding GitHub secret value.
+- Do **not** enable periodic SCM polling or webhook branch sources — these jobs
+  are triggered exclusively via the remote-build token from GitHub Actions.
+
+**`meal-deploy-staging`**
+
+- Script Path: `Jenkinsfile.staging`
+- Token: same value as `JENKINS_STAGING_TOKEN`
+- String parameter: `IMAGE_TAG` (default empty) — the GHCR image tag to deploy
+
+**`meal-deploy-preview`**
+
+- Script Path: `Jenkinsfile.preview`
+- Token: same value as `JENKINS_PREVIEW_TOKEN`
+- String parameters:
+  - `IMAGE_TAG` — the GHCR image tag to deploy
+  - `PR_NUMBER` — pull request number (used for stack name and URL slug)
+  - `PR_BRANCH` — source branch name
+
+**`meal-deploy-prod`**
+
+- Script Path: `Jenkinsfile.prod`
+- Token: same value as `JENKINS_PROD_TOKEN`
+- String parameter: `IMAGE_TAG` — the GHCR image tag to deploy (semver tag, e.g. `v1.2.3`)
+
+**`meal-deploy-cleanup`** (or `mealorder-cleanup`)
+
+- Keep as-is with its cron trigger; no token trigger needed.
+- Ensure its PAT credential (`gh-pat`) has `delete:packages` scope — see §11.3.
+
+### 11.3 Jenkins credentials
+
+Go to **Manage Jenkins → Credentials** (the appropriate domain/store) and add or update:
+
+| Credential ID | Type | Details |
+|---|---|---|
+| `ghcr-pull` | Username + password | Username = a GitHub account with package read access; password = a PAT with `read:packages` scope. All three deploy jobs use this to `docker login ghcr.io` before pulling images. |
+| `github-token-eason` | Secret text / PAT | **Extend** the existing PAT to include `delete:packages` scope (in addition to whatever scopes it already has). The cleanup job uses this to delete closed-PR `pr-*` images from GHCR. |
+
+### 11.4 GHCR package permissions
+
+After the first GitHub Actions workflow push succeeds, four packages appear under
+the `mizu5555` account: `mealorder-backend`, `mealorder-frontend`, `mealorder-db`,
+`mealorder-gateway`.
+
+For each package:
+
+1. Go to `https://github.com/orgs/mizu5555/packages` (or the user's packages page).
+2. Open the package → **Package settings**.
+3. Under **Manage Actions access**, confirm the `mizu5555/Corporate-Meal-Ordering-System` repo has **Write** access (needed so Actions can push).
+4. Confirm the `ghcr-pull` PAT account has at least **Read** access for pull.
+5. Confirm the `github-token-eason` PAT account has **Read + delete** capability for the cleanup job.
+
+### 11.5 Branch protection — update required status check name
+
+The GitHub Actions workflow `name:` changed from `Test` to `CI/CD` in this
+refactor. If the `main` branch protection rule (or any other branch rule) lists
+`Test` as a required status check, update it:
+
+1. **Settings → Branches → Edit** the protection rule for `main`.
+2. In **Require status checks to pass before merging**, remove `Test` and add
+   the new check name(s) emitted by the `CI/CD` workflow (e.g. `unit-tests`,
+   `integration-tests`, or `build-and-push` — check the Actions tab after the
+   first run for the exact job names).
+3. Save. Without this update the branch protection will either pass vacuously
+   (old check name never fires) or block PRs unexpectedly.

--- a/infra/deploy/SETUP.md
+++ b/infra/deploy/SETUP.md
@@ -257,16 +257,16 @@ and do not double-trigger alongside the new token-triggered jobs.
 **`meal-deploy-cleanup`** (or `mealorder-cleanup`)
 
 - Keep as-is with its cron trigger; no token trigger needed.
-- Ensure its PAT credential (`github-token-eason`) has `delete:packages` scope — see §11.3.
+- Ensure its PAT credential (`github-token`) has `delete:packages` scope — see §11.3.
 
 ### 11.3 Jenkins credentials
 
 Go to **Manage Jenkins → Credentials** (the appropriate domain/store). The existing
-`github-token-eason` credential is reused for everything — no new credential is needed:
+`github-token` credential is reused for everything — no new credential is needed:
 
 | Credential ID | Type | Details |
 |---|---|---|
-| `github-token-eason` | Username + password | The existing credential, reused. **Extend** its backing PAT to include `read:packages` (so all three deploy jobs can `docker login ghcr.io` and pull) and `delete:packages` (so the cleanup job can delete closed-PR `pr-*` images), in addition to its existing `repo` scope (PR comments). Since these are *added* scopes on a classic token, the token string is unchanged — **no Jenkins credential update is required**, only the GitHub scope edit. |
+| `github-token` | Username + password | The existing credential, reused. **Extend** its backing PAT to include `read:packages` (so all three deploy jobs can `docker login ghcr.io` and pull) and `delete:packages` (so the cleanup job can delete closed-PR `pr-*` images), in addition to its existing `repo` scope (PR comments). Since these are *added* scopes on a classic token, the token string is unchanged — **no Jenkins credential update is required**, only the GitHub scope edit. |
 
 ### 11.4 GHCR package permissions
 
@@ -279,7 +279,7 @@ For each package:
 1. Go to `https://github.com/orgs/mizu5555/packages` (or the user's packages page).
 2. Open the package → **Package settings**.
 3. Under **Manage Actions access**, confirm the `mizu5555/Corporate-Meal-Ordering-System` repo has **Write** access (needed so Actions can push).
-4. Confirm the `github-token-eason` PAT account has **Read** (pull) and **delete** (cleanup) capability for the package.
+4. Confirm the `github-token` PAT account has **Read** (pull) and **delete** (cleanup) capability for the package.
 
 ### 11.5 Branch protection — update required status check name
 

--- a/infra/deploy/SETUP.md
+++ b/infra/deploy/SETUP.md
@@ -91,6 +91,8 @@ curl -skI https://nol.cs.nycu.edu.tw/meal/health
 
 ## 4. Jenkins — Staging pipeline (`mealorder-staging`)
 
+> **Deprecated by §11.2 (GHCR build-once).** Keep this job disabled; deploys now use the parameterized token-triggered jobs.
+
 In the Jenkins UI:
 1. **New Item → Multibranch Pipeline**, name `mealorder-staging`.
 2. **Branch Sources → GitHub**, repo `mizu5555/Corporate-Meal-Ordering-System`, credentials = PAT with `repo` + `admin:repo_hook`.
@@ -100,6 +102,8 @@ In the Jenkins UI:
 6. Save → automatic scan triggers first build.
 
 ## 5. Jenkins — Production pipeline (`mealorder-prod`)
+
+> **Deprecated by §11.2 (GHCR build-once).** Keep this job disabled; deploys now use the parameterized token-triggered jobs.
 
 1. **New Item → Multibranch Pipeline**, name `mealorder-prod`.
 2. **Branch Sources → GitHub**, same repo + credentials.
@@ -117,6 +121,8 @@ In the Jenkins UI:
 3. Save → click **Build Now** once (registers the cron declared inside the Jenkinsfile).
 
 ## 6.5 Jenkins — PR preview pipeline (`mealorder-preview`)
+
+> **Deprecated by §11.2 (GHCR build-once).** Keep this job disabled; deploys now use the parameterized token-triggered jobs.
 
 1. **New Item → Multibranch Pipeline**, name `mealorder-preview`.
 2. **Branch Sources → GitHub**, repo `mizu5555/Corporate-Meal-Ordering-System`, credentials = your PAT.
@@ -241,10 +247,17 @@ and do not double-trigger alongside the new token-triggered jobs.
 - Token: same value as `JENKINS_PROD_TOKEN`
 - String parameter: `IMAGE_TAG` — the GHCR image tag to deploy (semver tag, e.g. `v1.2.3`)
 
+> **Note — release tags must point to a commit already on `main`.**
+> The `promote` job re-tags the existing `ghcr.io/mizu5555/mealorder-*:sha-<commit>` image.
+> Create tags on a commit that was already pushed/merged to `main`
+> (e.g. `git tag vX.Y.Z <sha-on-main>`). If the sha image does not exist
+> (tag on a commit that was never built on `main`), `promote` fails with a
+> GHCR `manifest unknown` error and prod is not deployed.
+
 **`meal-deploy-cleanup`** (or `mealorder-cleanup`)
 
 - Keep as-is with its cron trigger; no token trigger needed.
-- Ensure its PAT credential (`gh-pat`) has `delete:packages` scope — see §11.3.
+- Ensure its PAT credential (`github-token-eason`) has `delete:packages` scope — see §11.3.
 
 ### 11.3 Jenkins credentials
 

--- a/infra/deploy/SETUP.md
+++ b/infra/deploy/SETUP.md
@@ -261,12 +261,12 @@ and do not double-trigger alongside the new token-triggered jobs.
 
 ### 11.3 Jenkins credentials
 
-Go to **Manage Jenkins → Credentials** (the appropriate domain/store) and add or update:
+Go to **Manage Jenkins → Credentials** (the appropriate domain/store). The existing
+`github-token-eason` credential is reused for everything — no new credential is needed:
 
 | Credential ID | Type | Details |
 |---|---|---|
-| `ghcr-pull` | Username + password | Username = a GitHub account with package read access; password = a PAT with `read:packages` scope. All three deploy jobs use this to `docker login ghcr.io` before pulling images. |
-| `github-token-eason` | Secret text / PAT | **Extend** the existing PAT to include `delete:packages` scope (in addition to whatever scopes it already has). The cleanup job uses this to delete closed-PR `pr-*` images from GHCR. |
+| `github-token-eason` | Username + password | The existing credential, reused. **Extend** its backing PAT to include `read:packages` (so all three deploy jobs can `docker login ghcr.io` and pull) and `delete:packages` (so the cleanup job can delete closed-PR `pr-*` images), in addition to its existing `repo` scope (PR comments). Since these are *added* scopes on a classic token, the token string is unchanged — **no Jenkins credential update is required**, only the GitHub scope edit. |
 
 ### 11.4 GHCR package permissions
 
@@ -279,8 +279,7 @@ For each package:
 1. Go to `https://github.com/orgs/mizu5555/packages` (or the user's packages page).
 2. Open the package → **Package settings**.
 3. Under **Manage Actions access**, confirm the `mizu5555/Corporate-Meal-Ordering-System` repo has **Write** access (needed so Actions can push).
-4. Confirm the `ghcr-pull` PAT account has at least **Read** access for pull.
-5. Confirm the `github-token-eason` PAT account has **Read + delete** capability for the cleanup job.
+4. Confirm the `github-token-eason` PAT account has **Read** (pull) and **delete** (cleanup) capability for the package.
 
 ### 11.5 Branch protection — update required status check name
 

--- a/infra/deploy/SETUP.md
+++ b/infra/deploy/SETUP.md
@@ -213,10 +213,17 @@ Go to **Settings → Secrets and variables → Actions** and add:
 
 ### 11.2 Jenkins deploy jobs (replace old multibranch jobs)
 
-Create **three parameterized Pipeline jobs** (not Multibranch) in Jenkins UI.
-The old multibranch jobs (`mealorder-staging`, `mealorder-prod`, `mealorder-preview`)
-must be **disabled or deleted** so they no longer trigger on SCM webhook events
-and do not double-trigger alongside the new token-triggered jobs.
+Create **three parameterized Pipeline jobs** (not Multibranch) **inside the
+`Meal-Ordering-Project` folder** in Jenkins UI. The old multibranch jobs
+(`mealorder-staging`, `mealorder-prod`, `mealorder-preview`) must be **disabled or
+deleted** so they no longer trigger on SCM webhook events and do not double-trigger
+alongside the new token-triggered jobs.
+
+> **Job path / trigger URL.** Because the jobs live in the `Meal-Ordering-Project`
+> folder, the remote-trigger URL includes the folder segment:
+> `${JENKINS_URL}/job/Meal-Ordering-Project/job/meal-deploy-<env>/buildWithParameters`.
+> This is exactly what `.github/workflows/test.yml` uses — if you rename the folder
+> or jobs, update those three URLs to match.
 
 **Common setup for all three jobs:**
 
@@ -261,12 +268,18 @@ and do not double-trigger alongside the new token-triggered jobs.
 
 ### 11.3 Jenkins credentials
 
-Go to **Manage Jenkins → Credentials** (the appropriate domain/store). The existing
-`github-token` credential is reused for everything — no new credential is needed:
+Add the credential at **folder scope** so only jobs inside `Meal-Ordering-Project`
+can use it (not every job on the shared Jenkins). Open the `Meal-Ordering-Project`
+folder → left sidebar **Credentials** → add to the folder store (NOT the global
+System store):
 
 | Credential ID | Type | Details |
 |---|---|---|
-| `github-token` | Username + password | The existing credential, reused. **Extend** its backing PAT to include `read:packages` (so all three deploy jobs can `docker login ghcr.io` and pull) and `delete:packages` (so the cleanup job can delete closed-PR `pr-*` images), in addition to its existing `repo` scope (PR comments). Since these are *added* scopes on a classic token, the token string is unchanged — **no Jenkins credential update is required**, only the GitHub scope edit. |
+| `github-token` | Username + password | Username = your GitHub account; password = a classic PAT with `repo` (PR comments) + `read:packages` (all three deploy jobs `docker login ghcr.io` and pull) + `delete:packages` (cleanup job deletes closed-PR `pr-*` images). **ID must be exactly `github-token`** — the Jenkinsfiles reference this id. The ID field only appears when *creating* a credential (it cannot be renamed later). |
+
+> Note: a Jenkins credential ID is immutable. If an older global credential with a
+> personal-name id exists, leave it for the deprecated multibranch jobs and remove it
+> once those are deleted; the new build-once jobs use only this folder-scoped `github-token`.
 
 ### 11.4 GHCR package permissions
 

--- a/infra/deploy/docker-compose.preview.yml
+++ b/infra/deploy/docker-compose.preview.yml
@@ -6,18 +6,24 @@
 #   sweep can map a stack back to a PR via the GitHub API.
 services:
   backend:
+    image: ghcr.io/mizu5555/mealorder-backend:${IMAGE_TAG}
     ports: !reset []
     labels:
       mealorder.branch: ${BRANCH_RAW:-}
   frontend:
+    image: ghcr.io/mizu5555/mealorder-frontend:${IMAGE_TAG}
     ports: !reset []
+    environment:
+      BASE_PATH: ${BASE_PATH}
     labels:
       mealorder.branch: ${BRANCH_RAW:-}
   db:
+    image: ghcr.io/mizu5555/mealorder-db:${IMAGE_TAG}
     ports: !reset []
     labels:
       mealorder.branch: ${BRANCH_RAW:-}
   gateway:
+    image: ghcr.io/mizu5555/mealorder-gateway:${IMAGE_TAG}
     ports: !reset []
     container_name: mealorder-${SLUG:-default}-gateway
     networks: [default, preview-net]

--- a/infra/deploy/docker-compose.prod.yml
+++ b/infra/deploy/docker-compose.prod.yml
@@ -5,6 +5,7 @@
 # (gateway request rate, upstream latency) without exposing it publicly.
 services:
   backend:
+    image: ghcr.io/mizu5555/mealorder-backend:${IMAGE_TAG}
     ports: !reset []
     # See staging override for the rationale: pin Caddy gateway → backend
     # resolution to a single network alias so Docker DNS does not round-robin
@@ -19,10 +20,15 @@ services:
       SERVICE_NAME: mealorder-backend
       LOKI_URL: http://loki:3100
   frontend:
+    image: ghcr.io/mizu5555/mealorder-frontend:${IMAGE_TAG}
     ports: !reset []
+    environment:
+      BASE_PATH: ${BASE_PATH}
   db:
+    image: ghcr.io/mizu5555/mealorder-db:${IMAGE_TAG}
     ports: !reset []
   gateway:
+    image: ghcr.io/mizu5555/mealorder-gateway:${IMAGE_TAG}
     ports: !reset []
     networks: [default, preview-net, grafana_default]
 

--- a/infra/deploy/docker-compose.staging.yml
+++ b/infra/deploy/docker-compose.staging.yml
@@ -5,6 +5,7 @@
 # (gateway request rate, upstream latency) without exposing it publicly.
 services:
   backend:
+    image: ghcr.io/mizu5555/mealorder-backend:${IMAGE_TAG}
     ports: !reset []
     # Per-network aliases pin the Caddy gateway's upstream resolution. `backend`
     # remains reachable as `backend` on grafana_default (Prometheus scrape) and
@@ -30,10 +31,15 @@ services:
       # Scoped to staging so prod stays minimal-privilege.
       - SYS_PTRACE
   frontend:
+    image: ghcr.io/mizu5555/mealorder-frontend:${IMAGE_TAG}
     ports: !reset []
+    environment:
+      BASE_PATH: ${BASE_PATH}
   db:
+    image: ghcr.io/mizu5555/mealorder-db:${IMAGE_TAG}
     ports: !reset []
   gateway:
+    image: ghcr.io/mizu5555/mealorder-gateway:${IMAGE_TAG}
     ports: !reset []
     networks: [default, preview-net, grafana_default]
 


### PR DESCRIPTION
## Summary

Moves CI/CD from "Jenkins builds on the deploy host" to **build once, deploy many**: GitHub Actions builds + pushes images to GHCR, and Jenkins only pulls. The same image digest validated in staging is promoted unchanged to production.

- GitHub Actions (`test.yml` → `CI/CD`): test → build & push 4 images (`backend`/`frontend`/`db`/`gateway`) to `ghcr.io/mizu5555/mealorder-*` (`main`→`:sha-<commit>`, PR→`:pr-<num>`) → trigger the matching parameterized Jenkins job with `IMAGE_TAG`.
- On a `vX.Y.Z` tag: `promote` re-tags the existing `:sha-<commit>` image to `:vX.Y.Z` via `buildx imagetools` (no rebuild) → triggers prod.
- Jenkins `staging`/`prod`/`preview` jobs are now parameterized + token-triggered; they `docker compose pull` + `up -d` (no `--build`, no multibranch SCM trigger).
- `cleanup` prunes GHCR `pr-*` images for closed/merged PRs.
- Image slimming: multi-stage non-root backend + `.dockerignore`.
- frontend `BASE_PATH` moved to **runtime injection** (placeholder base + entrypoint) so one image serves all environments (see #72).

## Why

Previously build and deploy were coupled with no artifact in between, so staging and prod images were rebuilt separately and not guaranteed identical. This aligns the project with the enterprise pattern: cloud CI produces an immutable artifact, on-prem CD pulls and promotes it.

## Manual prerequisites (already configured)

- GitHub repo secrets: `JENKINS_URL`, `JENKINS_USER`, `JENKINS_API_TOKEN`, `JENKINS_{STAGING,PREVIEW,PROD}_TOKEN`.
- Jenkins: 3 parameterized pipeline jobs in the `Meal-Ordering-Project` folder (`meal-deploy-{staging,preview,prod}`), folder-scoped `github-token` credential (`repo` + `read:packages` + `delete:packages`), old multibranch jobs disabled. Full runbook in `infra/deploy/SETUP.md` §11.

## Notes for reviewers

- Deploy jobs check out `*/main`, so full deploy validation works **after this merges** to main; the PR run validates `build-push` (images land in GHCR) + preview.
- `PR_BRANCH` is URL-encoded before the Jenkins trigger.
- frontend caveat (#72): `vite.config.js` base is now a placeholder; standalone `npm run dev` serves under `/__BASE_PATH__/` (docker/nginx production path is unaffected, defaults to `/`).

## Test plan

- [ ] PR build-push pushes `:pr-<num>` images for all 4 services
- [ ] preview deploy comes up, `/health` OK
- [ ] after merge: staging deploys `:sha-<commit>` by pulling; k6 passes
- [ ] tag `v0.1.0`: prod deploys the re-tagged `:v0.1.0`; `:sha-*` and `:v0.1.0` digests match (build-once proven)
- [ ] Jenkins deploy console shows `pull`, never `build`

Closes #71

Closes #72
