### PR TITLE
fix(cd): GHCR image retention (keep newest pr/sha, prune untagged)

### DIFF
--- a/Jenkinsfile.cleanup
+++ b/Jenkinsfile.cleanup
@@ -37,28 +37,54 @@ pipeline {
       }
     }
 
-    stage('Prune GHCR pr-* tags') {
+    stage('Prune GHCR images') {
+      // Retention per package (mealorder-{backend,frontend,db,gateway}):
+      //   - pr-*  : keep newest KEEP_PR
+      //   - sha-* : keep newest KEEP_SHA
+      //   - v*    : keep all (releases) — never touched
+      //   - untagged: deleted (orphaned manifests from overwritten tags; safe
+      //     while images are single-arch — revisit if the build goes multi-arch).
+      // Deletes need the token to have `delete:packages` AND admin on the package
+      // (the packages are owned by the `mizu5555` user). If a delete fails the
+      // stage exits non-zero so the failure is visible, not silently swallowed.
       steps {
         withCredentials([usernamePassword(credentialsId: 'github-token', usernameVariable: 'GH_USER', passwordVariable: 'GH_TOKEN')]) {
           sh '''
             set -euo pipefail
             OWNER=mizu5555
+            KEEP_PR=3
+            KEEP_SHA=5
+            FAILED=0
+
+            ids_untagged() {
+              echo "$1" | jq -r '.[] | select((.metadata.container.tags // []) | length == 0) | .id'
+            }
+            ids_old_for_prefix() {  # $1=versions json  $2=tag prefix  $3=keep newest
+              echo "$1" | jq -r --arg pre "$2" --argjson keep "$3" '
+                [ .[] | select((.metadata.container.tags // []) | any(startswith($pre))) ]
+                | sort_by(.created_at) | reverse | .[$keep:] | .[].id'
+            }
+
             for svc in backend frontend db gateway; do
               PKG="mealorder-${svc}"
-              gh api --paginate "/users/${OWNER}/packages/container/${PKG}/versions" \
-                --jq '.[] | {id: .id, tags: .metadata.container.tags}' 2>/dev/null \
-                | jq -c 'select(.tags[]? | startswith("pr-"))' \
-                | while read -r row; do
-                    VID=$(echo "$row" | jq -r '.id')
-                    TAG=$(echo "$row" | jq -r '.tags[] | select(startswith("pr-"))' | head -1)
-                    NUM="${TAG#pr-}"
-                    STATE=$(gh api "/repos/${OWNER}/Corporate-Meal-Ordering-System/pulls/${NUM}" --jq '.state' 2>/dev/null || echo "")
-                    if [ "$STATE" = "closed" ]; then
-                      echo "pruning ${PKG} ${TAG} (PR #${NUM} closed) version=${VID}"
-                      gh api -X DELETE "/users/${OWNER}/packages/container/${PKG}/versions/${VID}" || true
-                    fi
-                  done
+              ALL=$(gh api --paginate "/users/${OWNER}/packages/container/${PKG}/versions")
+              for VID in $(ids_untagged "$ALL") \
+                         $(ids_old_for_prefix "$ALL" "pr-"  "$KEEP_PR") \
+                         $(ids_old_for_prefix "$ALL" "sha-" "$KEEP_SHA"); do
+                [ -z "$VID" ] && continue
+                if gh api -X DELETE "/users/${OWNER}/packages/container/${PKG}/versions/${VID}"; then
+                  echo "deleted ${PKG} version=${VID}"
+                else
+                  echo "WARNING: failed to delete ${PKG} version=${VID} — token needs delete:packages + admin on the package" >&2
+                  FAILED=$((FAILED + 1))
+                fi
+              done
             done
+
+            if [ "$FAILED" -gt 0 ]; then
+              echo "GHCR prune: ${FAILED} deletion(s) failed; see WARNING lines above." >&2
+              exit 1
+            fi
           '''
         }
       }

--- a/infra/deploy/SETUP.md
+++ b/infra/deploy/SETUP.md
@@ -287,12 +287,14 @@ After the first GitHub Actions workflow push succeeds, four packages appear unde
 the `mizu5555` account: `mealorder-backend`, `mealorder-frontend`, `mealorder-db`,
 `mealorder-gateway`.
 
-For each package:
+`mizu5555` is a **user** account (not an org), so the packages are personal.
+For each package (`https://github.com/users/mizu5555/packages` → open package → **Package settings**):
 
-1. Go to `https://github.com/orgs/mizu5555/packages` (or the user's packages page).
-2. Open the package → **Package settings**.
-3. Under **Manage Actions access**, confirm the `mizu5555/Corporate-Meal-Ordering-System` repo has **Write** access (needed so Actions can push).
-4. Confirm the `github-token` PAT account has **Read** (pull) and **delete** (cleanup) capability for the package.
+1. **Manage Actions access** — confirm `mizu5555/Corporate-Meal-Ordering-System` has **Write** (so Actions can push).
+2. **Visibility** — the repo is public and the images bake no runtime secrets (`.env` is dockerignored), so set the 4 packages **Public**. Public GHCR storage/transfer is free and unlimited, which removes any quota pressure.
+3. **Delete permission for cleanup** — the `Prune GHCR images` stage in `Jenkinsfile.cleanup` deletes versions via the GitHub API. Deleting a version of a *user-owned* package requires the token to have `delete:packages` **and admin on the package**. Since the Jenkins `github-token` belongs to a contributor (not `mizu5555`), the owner must grant that account **Admin** under **Manage access** on each package — otherwise the delete returns `404 Package not found` and the cleanup stage fails (by design, so it is visible). Alternatively back `github-token` with `mizu5555`'s own PAT.
+
+**Retention policy** (`Jenkinsfile.cleanup`, hourly): per package keep newest 3 `pr-*`, newest 5 `sha-*`, all `v*` (releases); delete untagged. Tune `KEEP_PR` / `KEEP_SHA` in the Jenkinsfile.
 
 ### 11.5 Branch protection — update required status check name
 


### PR DESCRIPTION
## Summary

Replaces the closed-PR `pr-*` prune with a bounded **retention policy** in `Jenkinsfile.cleanup` (hourly), per package (`mealorder-{backend,frontend,db,gateway}`):

- `pr-*` → keep newest **3**
- `sha-*` → keep newest **5**
- `v*` (releases) → keep all (untouched)
- untagged → delete (orphaned manifests; safe while images are single-arch)

`KEEP_PR` / `KEEP_SHA` are variables at the top of the stage.

## Why

`sha-*` images (one per merge to `main`) accumulated with no pruning, and overwritten tags left untagged manifests — both consume GHCR storage. This bounds growth.

## Also: surface delete failures

The previous prune swallowed errors (`2>/dev/null` / `|| true`), which hid a real `404` (the Jenkins token can read but not delete `mizu5555`-owned packages). The stage now logs a `WARNING` per failed delete and **exits non-zero** so a broken permission/scope is visible instead of a silently-successful no-op.

## Operational note (see `infra/deploy/SETUP.md` §11.4)

- Set the 4 packages **Public** — repo is already public and images bake no secrets; public GHCR storage is free/unlimited, removing quota pressure.
- For deletes to work, the `github-token` account needs `delete:packages` **and Admin on each package** (user-owned packages); otherwise the delete returns `404` and this stage fails by design.

## Test plan

- [x] jq retention filters verified locally (keep N newest by `created_at`, untagged selected, `v*` untouched)
- [x] after merge + package-admin grant: cleanup run deletes only the intended versions and is green
- [x] without the grant: cleanup goes red with clear `WARNING` lines (no silent no-op)

Refs #71