### PR TITLE
feat(pickup): add digital pickup feat: add digital pickup labels and pickup confirmationlabels

### DIFF
--- a/backend/db/migrations/008_pickup_labels.sql
+++ b/backend/db/migrations/008_pickup_labels.sql
@@ -1,0 +1,19 @@
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS pickup_code VARCHAR(24),
+  ADD COLUMN IF NOT EXISTS pickup_confirmed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS pickup_confirmed_by_user_id BIGINT REFERENCES users(id);
+
+UPDATE orders
+SET pickup_code = CONCAT(
+  COALESCE(TO_CHAR(meal_date, 'MMDD'), 'P'),
+  '-',
+  LPAD(id::TEXT, 4, '0')
+)
+WHERE pickup_code IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_orders_pickup_code
+  ON orders (pickup_code)
+  WHERE pickup_code IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_orders_pickup_flow
+  ON orders (vendor_id, meal_date, status, pickup_code);

--- a/backend/repositories/employee_selection_repository.py
+++ b/backend/repositories/employee_selection_repository.py
@@ -24,6 +24,9 @@ class _OrderRecord:
     facility_id: int | None
     meal_date: date | None
     status: OrderStatus
+    pickup_code: str
+    pickup_confirmed_at: datetime | None
+    pickup_confirmed_by_user_id: int | None
     created_at: datetime
     updated_at: datetime
     cancelled_at: datetime | None
@@ -85,13 +88,17 @@ class EmployeeSelectionRepository:
         facility_id: int | None = None,
     ) -> EmployeeOrder:
         now = datetime.now(timezone.utc)
+        order_id = next(self._order_id_seq)
         order = _OrderRecord(
-            id=next(self._order_id_seq),
+            id=order_id,
             employee_id=employee_id,
             vendor_id=vendor_id,
             facility_id=facility_id,
             meal_date=meal_date,
             status="pending",
+            pickup_code=_make_pickup_code(order_id, meal_date),
+            pickup_confirmed_at=None,
+            pickup_confirmed_by_user_id=None,
             created_at=now,
             updated_at=now,
             cancelled_at=None,
@@ -137,6 +144,9 @@ class EmployeeSelectionRepository:
             facility_id=order.facility_id,
             meal_date=order.meal_date,
             status="cancelled",
+            pickup_code=order.pickup_code,
+            pickup_confirmed_at=order.pickup_confirmed_at,
+            pickup_confirmed_by_user_id=order.pickup_confirmed_by_user_id,
             created_at=order.created_at,
             updated_at=now,
             cancelled_at=now,
@@ -164,6 +174,9 @@ class EmployeeSelectionRepository:
             facility_id=facility_id,
             meal_date=meal_date,
             status=order.status,
+            pickup_code=order.pickup_code,
+            pickup_confirmed_at=order.pickup_confirmed_at,
+            pickup_confirmed_by_user_id=order.pickup_confirmed_by_user_id,
             created_at=order.created_at,
             updated_at=now,
             cancelled_at=order.cancelled_at,
@@ -240,6 +253,9 @@ class EmployeeSelectionRepository:
             return None
         now = datetime.now(timezone.utc)
         cancelled_at = now if new_status == "cancelled" else order.cancelled_at
+        pickup_confirmed_at = order.pickup_confirmed_at
+        if new_status == "delivered" and pickup_confirmed_at is None:
+            pickup_confirmed_at = now
         self._orders[order_id] = _OrderRecord(
             id=order.id,
             employee_id=order.employee_id,
@@ -247,9 +263,41 @@ class EmployeeSelectionRepository:
             facility_id=order.facility_id,
             meal_date=order.meal_date,
             status=new_status,
+            pickup_code=order.pickup_code,
+            pickup_confirmed_at=pickup_confirmed_at,
+            pickup_confirmed_by_user_id=order.pickup_confirmed_by_user_id,
             created_at=order.created_at,
             updated_at=now,
             cancelled_at=cancelled_at,
+        )
+        return self._order_to_schema(self._orders[order_id])
+
+    def confirm_pickup(
+        self,
+        *,
+        vendor_id: int,
+        order_id: int,
+        confirmer_user_id: int | None = None,
+    ) -> EmployeeOrder | None:
+        order = self._orders.get(order_id)
+        if order is None or order.vendor_id != vendor_id:
+            return None
+        now = datetime.now(timezone.utc)
+        self._orders[order_id] = _OrderRecord(
+            id=order.id,
+            employee_id=order.employee_id,
+            vendor_id=order.vendor_id,
+            facility_id=order.facility_id,
+            meal_date=order.meal_date,
+            status="delivered",
+            pickup_code=order.pickup_code,
+            pickup_confirmed_at=order.pickup_confirmed_at or now,
+            pickup_confirmed_by_user_id=order.pickup_confirmed_by_user_id
+            if order.pickup_confirmed_by_user_id is not None
+            else confirmer_user_id,
+            created_at=order.created_at,
+            updated_at=now,
+            cancelled_at=order.cancelled_at,
         )
         return self._order_to_schema(self._orders[order_id])
 
@@ -295,6 +343,9 @@ class EmployeeSelectionRepository:
             status=order.status,
             items=schema_items,
             total_price_cents=sum(item.total_price_cents for item in schema_items),
+            pickup_code=order.pickup_code,
+            pickup_confirmed_at=order.pickup_confirmed_at,
+            pickup_confirmed_by_user_id=order.pickup_confirmed_by_user_id,
             created_at=order.created_at,
             updated_at=order.updated_at,
             cancelled_at=order.cancelled_at,
@@ -305,3 +356,9 @@ class EmployeeSelectionRepository:
         items = [r for r in self._items.values() if r.order_id == order_id]
         items.sort(key=lambda r: r.id)
         return [_selection_to_schema(order, item) for item in items]
+
+
+def _make_pickup_code(order_id: int, meal_date: date | None) -> str:
+    if meal_date is None:
+        return f"P-{order_id:04d}"
+    return f"{meal_date:%m%d}-{order_id:04d}"

--- a/backend/repositories/postgres_employee_selection_repository.py
+++ b/backend/repositories/postgres_employee_selection_repository.py
@@ -185,10 +185,22 @@ class PostgresEmployeeSelectionRepository:
             total_price_cents = sum(s.quantity * s.unit_price_cents for s in items)
             order_row = conn.execute(
                 """
-                INSERT INTO orders (employee_id, vendor_id, facility_id, meal_date, total_price_cents)
-                VALUES (%s, %s, %s, %s, %s)
-                RETURNING id, employee_id, vendor_id, facility_id, meal_date, status,
-                          total_price_cents, created_at, updated_at, cancelled_at
+                WITH inserted AS (
+                    INSERT INTO orders (employee_id, vendor_id, facility_id, meal_date, total_price_cents)
+                    VALUES (%s, %s, %s, %s, %s)
+                    RETURNING id
+                )
+                UPDATE orders AS o
+                SET pickup_code = CONCAT(
+                    COALESCE(TO_CHAR(o.meal_date, 'MMDD'), 'P'),
+                    '-',
+                    LPAD(o.id::TEXT, 4, '0')
+                )
+                FROM inserted
+                WHERE o.id = inserted.id
+                RETURNING o.id, o.employee_id, o.vendor_id, o.facility_id, o.meal_date, o.status,
+                          o.total_price_cents, o.pickup_code, o.pickup_confirmed_at,
+                          o.pickup_confirmed_by_user_id, o.created_at, o.updated_at, o.cancelled_at
                 """,
                 (employee_id, vendor_id, facility_id, meal_date, total_price_cents),
             ).fetchone()
@@ -252,7 +264,8 @@ class PostgresEmployeeSelectionRepository:
             order_rows = conn.execute(
                 f"""
                 SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
-                       total_price_cents, created_at, updated_at, cancelled_at
+                       total_price_cents, pickup_code, pickup_confirmed_at,
+                       pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
                 FROM orders
                 WHERE {" AND ".join(where)}
                 ORDER BY id
@@ -266,7 +279,8 @@ class PostgresEmployeeSelectionRepository:
             row = conn.execute(
                 """
                 SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
-                       total_price_cents, created_at, updated_at, cancelled_at
+                       total_price_cents, pickup_code, pickup_confirmed_at,
+                       pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
                 FROM orders
                 WHERE vendor_id = %s AND id = %s
                 """,
@@ -283,12 +297,43 @@ class PostgresEmployeeSelectionRepository:
                 UPDATE orders
                 SET status = %s,
                     updated_at = NOW(),
-                    cancelled_at = CASE WHEN %s = 'cancelled' THEN NOW() ELSE cancelled_at END
+                    cancelled_at = CASE WHEN %s = 'cancelled' THEN NOW() ELSE cancelled_at END,
+                    pickup_confirmed_at = CASE
+                        WHEN %s = 'delivered' AND pickup_confirmed_at IS NULL THEN NOW()
+                        ELSE pickup_confirmed_at
+                    END
                 WHERE vendor_id = %s AND id = %s
                 RETURNING id, employee_id, vendor_id, facility_id, meal_date, status,
-                          total_price_cents, created_at, updated_at, cancelled_at
+                          total_price_cents, pickup_code, pickup_confirmed_at,
+                          pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
                 """,
-                (new_status, new_status, vendor_id, order_id),
+                (new_status, new_status, new_status, vendor_id, order_id),
+            ).fetchone()
+            if row is None:
+                return None
+            return self._hydrate_order(conn, row)
+
+    def confirm_pickup(
+        self,
+        *,
+        vendor_id: int,
+        order_id: int,
+        confirmer_user_id: int | None = None,
+    ) -> EmployeeOrder | None:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                UPDATE orders
+                SET status = 'delivered',
+                    pickup_confirmed_at = COALESCE(pickup_confirmed_at, NOW()),
+                    pickup_confirmed_by_user_id = COALESCE(pickup_confirmed_by_user_id, %s),
+                    updated_at = NOW()
+                WHERE vendor_id = %s AND id = %s
+                RETURNING id, employee_id, vendor_id, facility_id, meal_date, status,
+                          total_price_cents, pickup_code, pickup_confirmed_at,
+                          pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
+                """,
+                (confirmer_user_id, vendor_id, order_id),
             ).fetchone()
             if row is None:
                 return None
@@ -315,7 +360,8 @@ class PostgresEmployeeSelectionRepository:
             order_rows = conn.execute(
                 """
                 SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
-                       total_price_cents, created_at, updated_at, cancelled_at
+                       total_price_cents, pickup_code, pickup_confirmed_at,
+                       pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
                 FROM orders
                 WHERE employee_id = %s
                 ORDER BY id
@@ -329,7 +375,8 @@ class PostgresEmployeeSelectionRepository:
             row = conn.execute(
                 """
                 SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
-                       total_price_cents, created_at, updated_at, cancelled_at
+                       total_price_cents, pickup_code, pickup_confirmed_at,
+                       pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
                 FROM orders
                 WHERE employee_id = %s AND id = %s
                 """,
@@ -347,7 +394,8 @@ class PostgresEmployeeSelectionRepository:
                 SET status = 'cancelled', updated_at = NOW(), cancelled_at = NOW()
                 WHERE employee_id = %s AND id = %s AND status = 'pending'
                 RETURNING id, employee_id, vendor_id, facility_id, meal_date, status,
-                          total_price_cents, created_at, updated_at, cancelled_at
+                          total_price_cents, pickup_code, pickup_confirmed_at,
+                          pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
                 """,
                 (employee_id, order_id),
             ).fetchone()
@@ -355,7 +403,8 @@ class PostgresEmployeeSelectionRepository:
                 row = conn.execute(
                     """
                     SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
-                           total_price_cents, created_at, updated_at, cancelled_at
+                           total_price_cents, pickup_code, pickup_confirmed_at,
+                           pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
                     FROM orders
                     WHERE employee_id = %s AND id = %s
                     """,
@@ -378,7 +427,8 @@ class PostgresEmployeeSelectionRepository:
             order_row = conn.execute(
                 """
                 SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
-                       total_price_cents, created_at, updated_at, cancelled_at
+                       total_price_cents, pickup_code, pickup_confirmed_at,
+                       pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
                 FROM orders
                 WHERE employee_id = %s AND id = %s
                 FOR UPDATE
@@ -457,7 +507,8 @@ class PostgresEmployeeSelectionRepository:
                     updated_at = NOW()
                 WHERE employee_id = %s AND id = %s
                 RETURNING id, employee_id, vendor_id, facility_id, meal_date, status,
-                          total_price_cents, created_at, updated_at, cancelled_at
+                          total_price_cents, pickup_code, pickup_confirmed_at,
+                          pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
                 """,
                 (meal_date, facility_id, total_price_cents, employee_id, order_id),
             ).fetchone()

--- a/backend/repositories/postgres_employee_selection_repository.py
+++ b/backend/repositories/postgres_employee_selection_repository.py
@@ -185,22 +185,38 @@ class PostgresEmployeeSelectionRepository:
             total_price_cents = sum(s.quantity * s.unit_price_cents for s in items)
             order_row = conn.execute(
                 """
-                WITH inserted AS (
-                    INSERT INTO orders (employee_id, vendor_id, facility_id, meal_date, total_price_cents)
-                    VALUES (%s, %s, %s, %s, %s)
-                    RETURNING id
+                WITH next_order AS (
+                    SELECT nextval(pg_get_serial_sequence('orders', 'id')) AS id
+                ),
+                order_input AS (
+                    SELECT
+                        %s::BIGINT AS employee_id,
+                        %s::BIGINT AS vendor_id,
+                        %s::BIGINT AS facility_id,
+                        %s::DATE AS meal_date,
+                        %s::INT AS total_price_cents
                 )
-                UPDATE orders AS o
-                SET pickup_code = CONCAT(
-                    COALESCE(TO_CHAR(o.meal_date, 'MMDD'), 'P'),
-                    '-',
-                    LPAD(o.id::TEXT, 4, '0')
+                INSERT INTO orders (
+                    id, employee_id, vendor_id, facility_id,
+                    meal_date, total_price_cents, pickup_code
                 )
-                FROM inserted
-                WHERE o.id = inserted.id
-                RETURNING o.id, o.employee_id, o.vendor_id, o.facility_id, o.meal_date, o.status,
-                          o.total_price_cents, o.pickup_code, o.pickup_confirmed_at,
-                          o.pickup_confirmed_by_user_id, o.created_at, o.updated_at, o.cancelled_at
+                SELECT
+                    next_order.id,
+                    order_input.employee_id,
+                    order_input.vendor_id,
+                    order_input.facility_id,
+                    order_input.meal_date,
+                    order_input.total_price_cents,
+                    CONCAT(
+                        COALESCE(TO_CHAR(order_input.meal_date, 'MMDD'), 'P'),
+                        '-',
+                        LPAD(next_order.id::TEXT, 4, '0')
+                    )
+                FROM next_order
+                CROSS JOIN order_input
+                RETURNING id, employee_id, vendor_id, facility_id, meal_date, status,
+                          total_price_cents, pickup_code, pickup_confirmed_at,
+                          pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
                 """,
                 (employee_id, vendor_id, facility_id, meal_date, total_price_cents),
             ).fetchone()

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -22,6 +22,7 @@ from backend.schemas.employee import (
     EmployeeVendor,
     MealSelection,
     MealSelectionCreate,
+    PickupLabel,
     RandomMealDraw,
     RandomMealDrawRequest,
 )
@@ -154,6 +155,15 @@ def get_my_order(
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
 ) -> EmployeeOrder:
     return service.get_my_order(employee_id, order_id)
+
+
+@router.get("/me/orders/{order_id}/pickup-label", response_model=PickupLabel)
+def get_my_pickup_label(
+    order_id: int,
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+) -> PickupLabel:
+    return service.get_my_pickup_label(employee_id, order_id)
 
 
 @router.put("/me/orders/{order_id}", response_model=EmployeeOrder)

--- a/backend/routes/vendor_orders.py
+++ b/backend/routes/vendor_orders.py
@@ -1,16 +1,18 @@
 """/vendor/me/orders — 商家訂單查詢與狀態更新。"""
 from __future__ import annotations
 
+from datetime import date
 from typing import Annotated
 
-from fastapi import APIRouter, BackgroundTasks, Depends, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, Query
 
+from backend.core.errors import CodedHTTPException
 from backend.core.vendor_identity import get_vendor_profile_repository, require_approved_vendor
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
 from backend.routes.employee_ordering import get_employee_selection_repository
 from backend.routes.notifications import get_notification_service
-from backend.schemas.employee import EmployeeOrder, VendorOrderStatusUpdate
+from backend.schemas.employee import EmployeeOrder, OrderStatus, PickupLabel, VendorOrderStatusUpdate
 from backend.services.notification_service import NotificationService
 from backend.services.vendor_order_service import VendorOrderService
 
@@ -24,6 +26,19 @@ def get_vendor_order_service(
     return VendorOrderService(selection_repo, vendor_repo)
 
 
+def optional_header_user_id(x_user_id: Annotated[str | None, Header()] = None) -> int | None:
+    if x_user_id is None:
+        return None
+    try:
+        return int(x_user_id)
+    except ValueError as exc:
+        raise CodedHTTPException(
+            status_code=400,
+            code="validation_error",
+            detail="x-user-id must be integer",
+        ) from exc
+
+
 @router.get("", response_model=list[EmployeeOrder])
 def list_vendor_orders(
     vendor_id: Annotated[int, Depends(require_approved_vendor)],
@@ -33,6 +48,31 @@ def list_vendor_orders(
     return service.list_orders(vendor_id, facility_id=facility_id)
 
 
+@router.get("/labels", response_model=list[PickupLabel])
+def list_vendor_pickup_labels(
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
+    facility_id: Annotated[int | None, Query()] = None,
+    meal_date: Annotated[date | None, Query()] = None,
+    status_filter: Annotated[OrderStatus | None, Query(alias="status")] = None,
+) -> list[PickupLabel]:
+    return service.list_pickup_labels(
+        vendor_id,
+        facility_id=facility_id,
+        meal_date=meal_date,
+        status=status_filter,
+    )
+
+
+@router.get("/{order_id}/label", response_model=PickupLabel)
+def get_vendor_pickup_label(
+    order_id: int,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
+) -> PickupLabel:
+    return service.get_pickup_label(vendor_id, order_id)
+
+
 @router.get("/{order_id}", response_model=EmployeeOrder)
 def get_vendor_order(
     order_id: int,
@@ -40,6 +80,20 @@ def get_vendor_order(
     service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
 ) -> EmployeeOrder:
     return service.get_order(vendor_id, order_id)
+
+
+@router.post("/{order_id}/pickup-confirm", response_model=EmployeeOrder)
+def confirm_vendor_order_pickup(
+    order_id: int,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    confirmer_user_id: Annotated[int | None, Depends(optional_header_user_id)],
+    service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
+) -> EmployeeOrder:
+    return service.confirm_pickup(
+        vendor_id,
+        order_id,
+        confirmer_user_id=confirmer_user_id,
+    )
 
 
 @router.patch("/{order_id}/status", response_model=EmployeeOrder)

--- a/backend/schemas/employee.py
+++ b/backend/schemas/employee.py
@@ -96,9 +96,33 @@ class EmployeeOrder(BaseModel):
     status: OrderStatus
     items: list[EmployeeOrderItem]
     total_price_cents: int
+    pickup_code: str | None = None
+    pickup_confirmed_at: datetime | None = None
+    pickup_confirmed_by_user_id: int | None = None
     created_at: datetime
     updated_at: datetime
     cancelled_at: datetime | None = None
+
+
+class PickupLabelItem(BaseModel):
+    item_name: str
+    quantity: int
+
+
+class PickupLabel(BaseModel):
+    order_id: int
+    pickup_code: str | None = None
+    employee_id: int
+    vendor_id: int
+    vendor_name: str
+    meal_date: date | None = None
+    status: OrderStatus
+    facility_names: list[str] = Field(default_factory=list)
+    items: list[PickupLabelItem]
+    total_quantity: int
+    total_price_cents: int
+    pickup_confirmed_at: datetime | None = None
+    pickup_confirmed_by_user_id: int | None = None
 
 
 class RandomMealDrawRequest(BaseModel):

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -18,6 +18,8 @@ from backend.schemas.employee import (
     EmployeeVendor,
     MealSelection,
     MealSelectionCreate,
+    PickupLabel,
+    PickupLabelItem,
     RandomMealDraw,
     RandomMealDrawRequest,
 )
@@ -208,6 +210,9 @@ class EmployeeOrderingService:
             raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
         return order
 
+    def get_my_pickup_label(self, employee_id: int, order_id: int) -> PickupLabel:
+        return self._order_to_pickup_label(self.get_my_order(employee_id, order_id))
+
     def cancel_my_order(self, employee_id: int, order_id: int) -> EmployeeOrder:
         order = self.get_my_order(employee_id, order_id)
         if order.status != "pending":
@@ -387,6 +392,30 @@ class EmployeeOrderingService:
             available=item.available,
             daily_quota=item.daily_quota,
             photo_path=item.photo_path,
+        )
+
+    def _order_to_pickup_label(self, order: EmployeeOrder) -> PickupLabel:
+        vendor = self.vendor_repository.get(order.vendor_id)
+        employee_facilities = self.vendor_repository.list_employee_facilities(order.employee_id)
+        facilities = employee_facilities or self.vendor_repository.list_facilities(order.vendor_id)
+        items = [
+            PickupLabelItem(item_name=item.item_name, quantity=item.quantity)
+            for item in order.items
+        ]
+        return PickupLabel(
+            order_id=order.id,
+            pickup_code=order.pickup_code,
+            employee_id=order.employee_id,
+            vendor_id=order.vendor_id,
+            vendor_name=vendor.name if vendor else f"Vendor #{order.vendor_id}",
+            meal_date=order.meal_date,
+            status=order.status,
+            facility_names=[facility.name for facility in facilities],
+            items=items,
+            total_quantity=sum(item.quantity for item in order.items),
+            total_price_cents=order.total_price_cents,
+            pickup_confirmed_at=order.pickup_confirmed_at,
+            pickup_confirmed_by_user_id=order.pickup_confirmed_by_user_id,
         )
 
     def _build_order_items(

--- a/backend/services/vendor_order_service.py
+++ b/backend/services/vendor_order_service.py
@@ -1,10 +1,12 @@
 """Vendor order management: list, detail, and status transition."""
 from __future__ import annotations
 
+from datetime import date
+
 from backend.core.errors import CodedHTTPException
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
-from backend.schemas.employee import EmployeeOrder
+from backend.schemas.employee import EmployeeOrder, OrderStatus, PickupLabel, PickupLabelItem
 
 ALLOWED_TRANSITIONS: dict[str, set[str]] = {
     "pending": {"confirmed", "cancelled"},
@@ -27,11 +29,52 @@ class VendorOrderService:
         self._assert_facility_access(vendor_id, facility_id)
         return self._repo.list_orders_by_vendor(vendor_id=vendor_id, facility_id=facility_id)
 
+    def list_pickup_labels(
+        self,
+        vendor_id: int,
+        *,
+        facility_id: int | None = None,
+        meal_date: date | None = None,
+        status: OrderStatus | None = None,
+    ) -> list[PickupLabel]:
+        orders = self.list_orders(vendor_id, facility_id=facility_id)
+        if meal_date is not None:
+            orders = [order for order in orders if order.meal_date == meal_date]
+        if status is not None:
+            orders = [order for order in orders if order.status == status]
+        return [self._order_to_label(order) for order in orders]
+
     def get_order(self, vendor_id: int, order_id: int) -> EmployeeOrder:
         order = self._repo.get_order_for_vendor(vendor_id=vendor_id, order_id=order_id)
         if order is None:
             raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
         return order
+
+    def get_pickup_label(self, vendor_id: int, order_id: int) -> PickupLabel:
+        return self._order_to_label(self.get_order(vendor_id, order_id))
+
+    def confirm_pickup(
+        self,
+        vendor_id: int,
+        order_id: int,
+        *,
+        confirmer_user_id: int | None = None,
+    ) -> EmployeeOrder:
+        order = self.get_order(vendor_id, order_id)
+        if order.status != "ready":
+            raise CodedHTTPException(
+                status_code=409,
+                code="order_not_ready_for_pickup",
+                detail="only ready orders can be confirmed for pickup",
+            )
+        updated = self._repo.confirm_pickup(
+            vendor_id=vendor_id,
+            order_id=order_id,
+            confirmer_user_id=confirmer_user_id,
+        )
+        if updated is None:
+            raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
+        return updated
 
     def update_status(self, vendor_id: int, order_id: int, new_status: str) -> EmployeeOrder:
         order = self.get_order(vendor_id, order_id)
@@ -59,3 +102,34 @@ class VendorOrderService:
                 code="forbidden",
                 detail="vendor does not serve the selected facility",
             )
+
+    def _order_to_label(self, order: EmployeeOrder) -> PickupLabel:
+        vendor = self._vendor_repo.get(order.vendor_id)
+        employee_facilities = self._vendor_repo.list_employee_facilities(order.employee_id)
+        if order.facility_id is None:
+            facilities = employee_facilities or self._vendor_repo.list_facilities(order.vendor_id)
+        else:
+            facilities = [
+                facility
+                for facility in (employee_facilities or self._vendor_repo.list_facilities(order.vendor_id))
+                if facility.id == order.facility_id
+            ]
+        items = [
+            PickupLabelItem(item_name=item.item_name, quantity=item.quantity)
+            for item in order.items
+        ]
+        return PickupLabel(
+            order_id=order.id,
+            pickup_code=order.pickup_code,
+            employee_id=order.employee_id,
+            vendor_id=order.vendor_id,
+            vendor_name=vendor.name if vendor else f"Vendor #{order.vendor_id}",
+            meal_date=order.meal_date,
+            status=order.status,
+            facility_names=[facility.name for facility in facilities],
+            items=items,
+            total_quantity=sum(item.quantity for item in order.items),
+            total_price_cents=order.total_price_cents,
+            pickup_confirmed_at=order.pickup_confirmed_at,
+            pickup_confirmed_by_user_id=order.pickup_confirmed_by_user_id,
+        )

--- a/backend/tests/test_pickup_labels.py
+++ b/backend/tests/test_pickup_labels.py
@@ -1,0 +1,178 @@
+"""Digital pickup labels and pickup confirmation flow."""
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.employee_selection_repository import (
+    EmployeeSelectionRepository,
+    OrderItemSnapshot,
+)
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.routes.employee_ordering import get_employee_selection_repository
+
+
+def _seed_vendor_repo() -> VendorProfileRepository:
+    repo = VendorProfileRepository()
+    repo.seed(VendorRecord(id=1, name="Alice Bento", status="approved", address="No. 1"))
+    repo.seed(VendorRecord(id=2, name="Bob Noodles", status="approved", address="No. 2"))
+    repo.assign_facility(1, facility_id=10, code="F12A", name="Fab 12A")
+    repo.assign_employee_facility(100, facility_id=10, code="F12A", name="Fab 12A")
+    return repo
+
+
+def _client(
+    vendor_repo: VendorProfileRepository,
+    selection_repo: EmployeeSelectionRepository,
+) -> TestClient:
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
+    app.dependency_overrides[get_employee_selection_repository] = lambda: selection_repo
+    return TestClient(app)
+
+
+def _vh(vendor_id: int = 1, user_id: int | None = None) -> dict[str, str]:
+    headers = {"x-user-role": "vendor_manager", "x-vendor-id": str(vendor_id)}
+    if user_id is not None:
+        headers["x-user-id"] = str(user_id)
+    return headers
+
+
+def _eh(user_id: int = 100) -> dict[str, str]:
+    return {"x-user-role": "employee", "x-user-id": str(user_id)}
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+def test_order_creation_assigns_pickup_code() -> None:
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(
+        employee_id=100,
+        vendor_id=1,
+        meal_date=date(2026, 5, 28),
+        items=[OrderItemSnapshot(item_id=1, item_name="Rice Bowl", quantity=2, unit_price_cents=120)],
+    )
+
+    assert order.pickup_code == "0528-0001"
+    assert order.pickup_confirmed_at is None
+
+
+def test_vendor_can_view_digital_pickup_label() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(
+        employee_id=100,
+        vendor_id=1,
+        meal_date=date(2026, 5, 28),
+        items=[OrderItemSnapshot(item_id=1, item_name="Rice Bowl", quantity=2, unit_price_cents=120)],
+    )
+
+    resp = _client(vendor_repo, selection_repo).get(
+        f"/vendor/me/orders/{order.id}/label",
+        headers=_vh(1),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["pickup_code"] == "0528-0001"
+    assert body["vendor_name"] == "Alice Bento"
+    assert body["facility_names"] == ["Fab 12A"]
+    assert body["items"] == [{"item_name": "Rice Bowl", "quantity": 2}]
+    assert body["total_quantity"] == 2
+
+
+def test_vendor_label_list_filters_by_date_and_status() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    ready = selection_repo.create_order(
+        employee_id=100,
+        vendor_id=1,
+        meal_date=date(2026, 5, 28),
+        items=[],
+    )
+    other_date = selection_repo.create_order(
+        employee_id=100,
+        vendor_id=1,
+        meal_date=date(2026, 5, 29),
+        items=[],
+    )
+    selection_repo.update_order_status(vendor_id=1, order_id=ready.id, new_status="ready")
+    selection_repo.update_order_status(vendor_id=1, order_id=other_date.id, new_status="ready")
+
+    resp = _client(vendor_repo, selection_repo).get(
+        "/vendor/me/orders/labels?meal_date=2026-05-28&status=ready",
+        headers=_vh(1),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [label["order_id"] for label in body] == [ready.id]
+
+
+def test_employee_can_view_only_own_pickup_label() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(
+        employee_id=100,
+        vendor_id=1,
+        meal_date=date(2026, 5, 28),
+        items=[],
+    )
+    client = _client(vendor_repo, selection_repo)
+
+    own = client.get(f"/employee/me/orders/{order.id}/pickup-label", headers=_eh(100))
+    other = client.get(f"/employee/me/orders/{order.id}/pickup-label", headers=_eh(200))
+
+    assert own.status_code == 200
+    assert own.json()["pickup_code"] == "0528-0001"
+    assert other.status_code == 404
+
+
+def test_pickup_confirm_requires_ready_order() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).post(
+        f"/vendor/me/orders/{order.id}/pickup-confirm",
+        headers=_vh(1),
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "order_not_ready_for_pickup"
+
+
+def test_vendor_can_confirm_ready_pickup() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=None)
+    selection_repo.update_order_status(vendor_id=1, order_id=order.id, new_status="ready")
+
+    resp = _client(vendor_repo, selection_repo).post(
+        f"/vendor/me/orders/{order.id}/pickup-confirm",
+        headers=_vh(1, user_id=77),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "delivered"
+    assert body["pickup_confirmed_at"] is not None
+    assert body["pickup_confirmed_by_user_id"] == 77
+
+
+def test_vendor_cannot_view_other_vendors_label() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    order = selection_repo.create_order(employee_id=100, vendor_id=2, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).get(
+        f"/vendor/me/orders/{order.id}/label",
+        headers=_vh(1),
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "not_found"

--- a/frontend/src/api/vendor.js
+++ b/frontend/src/api/vendor.js
@@ -37,6 +37,12 @@ export function updateOrderStatus(orderId, status) {
   });
 }
 
+export function confirmPickup(orderId) {
+  return apiFetch(`/vendor/me/orders/${orderId}/pickup-confirm`, {
+    method: "POST",
+  });
+}
+
 export function createMenuItem(data) {
   return apiFetch("/vendor/me/menu", {
     method: "POST",

--- a/frontend/src/pages/employee/OrdersPage.jsx
+++ b/frontend/src/pages/employee/OrdersPage.jsx
@@ -137,12 +137,22 @@ export default function OrdersPage() {
                     <p style={{ color: "var(--muted)", fontSize: 13, margin: "4px 0 0" }}>
                       {order.meal_date ? `用餐日 ${order.meal_date}` : formatDate(order.created_at)}
                     </p>
+                    {order.pickup_code && (
+                      <p style={{ margin: "4px 0 0", fontSize: 13, fontWeight: 700 }}>
+                        取餐碼 {order.pickup_code}
+                      </p>
+                    )}
                   </div>
                   <div style={{ textAlign: "right" }}>
                     <p style={{ fontWeight: 800, margin: 0 }}>{formatPrice(total)}</p>
                     <p style={{ color: "var(--muted)", fontSize: 13, margin: "4px 0 0" }}>
                       {STATUS_LABELS[order.status] ?? order.status}
                     </p>
+                    {order.status === "ready" && (
+                      <span className="badge badge-available" style={{ marginTop: 6 }}>
+                        可領餐
+                      </span>
+                    )}
                   </div>
                 </div>
 

--- a/frontend/src/pages/vendor/VendorOrderDetailPage.jsx
+++ b/frontend/src/pages/vendor/VendorOrderDetailPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { getMyOrder, updateOrderStatus } from "../../api/vendor";
+import { confirmPickup, getMyOrder, updateOrderStatus } from "../../api/vendor";
 import { formatPrice } from "../../utils/format";
 
 const STATUS_LABEL = {
@@ -28,7 +28,6 @@ const NEXT_ACTIONS = {
   ],
   confirmed: [{ status: "preparing", label: "開始備餐", variant: "primary" }],
   preparing: [{ status: "ready", label: "備餐完成", variant: "primary" }],
-  ready: [{ status: "delivered", label: "標記已送達", variant: "primary" }],
 };
 
 const ACTION_STYLE = {
@@ -95,11 +94,25 @@ export default function VendorOrderDetailPage() {
     }
   }
 
+  async function handleConfirmPickup() {
+    setSubmitting(true);
+    setActionError(null);
+    try {
+      const updated = await confirmPickup(orderId);
+      setOrder(updated);
+    } catch (err) {
+      setActionError(err.message ?? "領餐確認失敗");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   if (loading) return <p className="loading-state">載入訂單中...</p>;
   if (error) return <p className="error-state">{error}</p>;
   if (!order) return null;
 
   const actions = NEXT_ACTIONS[order.status] ?? [];
+  const totalQuantity = order.items.reduce((sum, item) => sum + item.quantity, 0);
 
   return (
     <div>
@@ -195,6 +208,7 @@ export default function VendorOrderDetailPage() {
           <div className="panel">
             <p className="eyebrow" style={{ marginBottom: 14 }}>訂單資訊</p>
             <InfoRow label="訂單編號" value={`#${order.id}`} />
+            <InfoRow label="取餐碼" value={order.pickup_code ?? "-"} />
             <InfoRow label="員工" value={`員工 #${order.employee_id}`} />
             {order.meal_date && <InfoRow label="用餐日期" value={order.meal_date} />}
             <InfoRow
@@ -215,8 +229,38 @@ export default function VendorOrderDetailPage() {
             </div>
           </div>
 
+          <div className="panel">
+            <p className="eyebrow" style={{ marginBottom: 14 }}>數位配送標籤</p>
+            <div
+              style={{
+                border: "1px solid var(--line)",
+                borderRadius: "var(--radius-md)",
+                padding: 16,
+                background: "var(--surface-strong)",
+              }}
+            >
+              <p style={{ margin: "0 0 4px", color: "var(--muted)", fontSize: 12, fontWeight: 700 }}>
+                PICKUP CODE
+              </p>
+              <p style={{ margin: 0, fontSize: 28, fontWeight: 800 }}>
+                {order.pickup_code ?? "-"}
+              </p>
+              <div style={{ display: "grid", gap: 8, marginTop: 16 }}>
+                <InfoRow label="用餐日期" value={order.meal_date ?? "今日"} />
+                <InfoRow label="總份數" value={`${totalQuantity} 份`} />
+                <InfoRow label="員工" value={`#${order.employee_id}`} />
+              </div>
+            </div>
+
+            {order.pickup_confirmed_at && (
+              <p className="success-state" style={{ marginTop: 12 }}>
+                已於 {new Date(order.pickup_confirmed_at).toLocaleString("zh-TW")} 完成領餐確認。
+              </p>
+            )}
+          </div>
+
           {/* 操作按鈕 */}
-          {actions.length > 0 && (
+          {(actions.length > 0 || order.status === "ready") && (
             <div className="panel">
               <p className="eyebrow" style={{ marginBottom: 14 }}>操作</p>
 
@@ -247,6 +291,25 @@ export default function VendorOrderDetailPage() {
                     {action.label}
                   </button>
                 ))}
+                {order.status === "ready" && (
+                  <button
+                    type="button"
+                    disabled={submitting}
+                    onClick={handleConfirmPickup}
+                    style={{
+                      padding: "10px 0",
+                      borderRadius: "var(--radius-md)",
+                      fontWeight: 700,
+                      fontSize: 14,
+                      cursor: submitting ? "not-allowed" : "pointer",
+                      opacity: submitting ? 0.7 : 1,
+                      transition: "opacity 140ms ease",
+                      ...ACTION_STYLE.confirm,
+                    }}
+                  >
+                    {submitting ? "確認中..." : "確認員工已領餐"}
+                  </button>
+                )}
               </div>
             </div>
           )}

--- a/frontend/src/pages/vendor/VendorOrdersPage.jsx
+++ b/frontend/src/pages/vendor/VendorOrdersPage.jsx
@@ -105,7 +105,7 @@ export default function VendorOrdersPage() {
             <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "56px 120px 1fr 110px 100px 36px",
+                gridTemplateColumns: "56px 120px 110px 1fr 110px 100px 36px",
                 padding: "10px 20px",
                 borderBottom: "1px solid var(--line)",
                 color: "var(--muted)",
@@ -117,6 +117,7 @@ export default function VendorOrdersPage() {
             >
               <span>#</span>
               <span>來源</span>
+              <span>取餐碼</span>
               <span>品項</span>
               <span style={{ textAlign: "right" }}>合計</span>
               <span style={{ textAlign: "right" }}>狀態</span>
@@ -130,7 +131,7 @@ export default function VendorOrdersPage() {
                 onClick={() => navigate(`/vendor/orders/${order.id}`)}
                 style={{
                   display: "grid",
-                  gridTemplateColumns: "56px 120px 1fr 110px 100px 36px",
+                  gridTemplateColumns: "56px 120px 110px 1fr 110px 100px 36px",
                   alignItems: "center",
                   width: "100%",
                   padding: "14px 20px",
@@ -147,6 +148,9 @@ export default function VendorOrdersPage() {
                 <p style={{ margin: 0, fontSize: 12, color: "var(--muted)" }}>#{order.id}</p>
                 <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>
                   員工 #{order.employee_id}
+                </p>
+                <p style={{ margin: 0, fontWeight: 700, fontSize: 13 }}>
+                  {order.pickup_code ?? "-"}
                 </p>
                 <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>
                   {itemsSummary(order.items)}


### PR DESCRIPTION
## Summary
- Add digital pickup labels with pickup codes for orders
- Add vendor APIs for pickup label list, single pickup label, and pickup confirmation
- Add employee API for viewing their own pickup label
- Support facility-based filtering for vendor pickup labels
- Display pickup codes and pickup status in the frontend

## Tests
- `python -m compileall -q backend`
- `python -m pytest backend/tests/test_postgres_quota.py backend/tests/test_pickup_labels.py backend/tests/test_vendor_orders.py -q -p no:cacheprovider`
- `python -m pytest backend/tests --ignore=backend/tests/integration -q -p no:cacheprovider --basetemp .tmp/pytest`
- `npm run build`

Closes #78
