### PR TITLE
fix(security): resolve SonarCloud gate findings in backend image and auth (#83)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 COPY requirements.txt .
-RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+RUN pip install --no-cache-dir --only-binary=:all: --prefix=/install -r requirements.txt
 
 FROM python:3.12-slim
 WORKDIR /app

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -7,7 +7,10 @@ from backend.schemas.auth import LoginRequest, RegisterRequest, TokenResponse
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
-_DUMMY_HASH = "$2b$12$lHiK1mHe6SpHhZxArGe4GekOeUH9iRv6lXc25aM5kCu0HaJhni2uq"
+# Constant-time placeholder so verify_password always runs even when the account
+# does not exist, keeping login latency uniform (mitigates username enumeration).
+# Computed at import so no bcrypt hash literal lives in the source.
+_DUMMY_HASH = hash_password("timing-attack-placeholder")
 
 
 def _fetch_user(email: str) -> dict | None:


### PR DESCRIPTION
## Summary

Resolves 2 of the 3 SonarCloud Quality Gate findings from #83 (the ones with a code fix). The third is accepted in SonarCloud (see below).

- **`backend/Dockerfile` (docker:S8541, MAJOR)** — add `--only-binary=:all:` to the `pip install` so pip installs prebuilt wheels only and never executes setup scripts from source distributions during the build.
- **`backend/routes/auth.py` (secrets:S8215, BLOCKER — false positive)** — `_DUMMY_HASH` is the constant-time placeholder that keeps login latency uniform whether or not an account exists (username-enumeration mitigation). It is not a credential. Computing it at import removes the hardcoded bcrypt literal that triggered the rule; **behavior is unchanged**.

### Not in this PR
- **docker:S8544 (dependency version locking, MAJOR)** is being **Accepted** in SonarCloud rather than code-fixed: direct dependencies are already pinned with `==`, and hash-locking the full transitive tree (`--require-hashes`) is disproportionate for this project and would burden every future dependency change. Tracked in #83.

## Verification

- `docker build -f backend/Dockerfile .` succeeds with `--only-binary=:all:` (all dependencies have wheels for the target platform).
- `backend.routes.auth` imports cleanly; `_DUMMY_HASH` is a valid 60-char bcrypt hash computed at runtime.
- `pytest backend/tests/test_auth.py` — 9 passed.

## After merge
Once `main` is re-analysed, S8541 and S8215 drop off automatically. With S8544 marked Accept, the `main` Security Rating returns to A and the Quality Gate passes.

Refs #83