### PR TITLE
fix(vendor): show uploaded menu photo immediately (#66)

### DIFF
--- a/frontend/src/pages/vendor/VendorMenuFormPage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuFormPage.jsx
@@ -104,7 +104,7 @@ export default function VendorMenuFormPage() {
 
   // Live item — reflects photo_path changes without re-mounting
   const currentItem = isEdit ? getItem(Number(itemId)) : null;
-  const currentPhotoUrl = photoUrl(currentItem?.photo_path);
+  const currentPhotoUrl = photoUrl(currentItem?.photo_path, currentItem?._photo_v);
   const photoBusy = photoState !== "idle";
 
   return (

--- a/frontend/src/pages/vendor/VendorMenuListPage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuListPage.jsx
@@ -10,7 +10,7 @@ function MenuItemPhoto({ item, onUpload, onDelete }) {
   const inputRef = useRef(null);
   const [state, setState] = useState("idle"); // "idle" | "uploading" | "deleting"
   const [hover, setHover] = useState(false);
-  const url = photoUrl(item.photo_path);
+  const url = photoUrl(item.photo_path, item._photo_v);
   const busy = state !== "idle";
 
   async function handleFileChange(e) {

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -10,8 +10,9 @@ export function quotaLabel(dailyQuota) {
   return `剩餘 ${dailyQuota} 份`;
 }
 
-export function photoUrl(photoPath) {
+export function photoUrl(photoPath, version) {
   if (!photoPath) return null;
   const base = import.meta.env.BASE_URL.replace(/\/$/, "");
-  return `${base}/uploads/${photoPath}`;
+  const url = `${base}/uploads/${photoPath}`;
+  return version ? `${url}?v=${version}` : url;
 }

--- a/frontend/src/vendor/VendorMenuContext.jsx
+++ b/frontend/src/vendor/VendorMenuContext.jsx
@@ -43,7 +43,9 @@ export function VendorMenuProvider({ children }) {
   async function uploadPhoto(id, file) {
     const result = await uploadMenuItemPhoto(id, file);
     setItems((prev) =>
-      prev.map((item) => (item.id === id ? { ...item, photo_path: result.photo_path } : item)),
+      prev.map((item) =>
+        item.id === id ? { ...item, photo_path: result.photo_path, _photo_v: Date.now() } : item,
+      ),
     );
     return result;
   }

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -51,8 +51,13 @@
 
 	handle_path /uploads/* {
 		root * /srv/uploads
+		# Only cache responses that actually serve a file. Without the file
+		# matcher the header would also apply to 404s, which the browser caches
+		# for an hour — so a photo requested before upload stays "missing" even
+		# after it exists (#66).
+		@exists file
+		header @exists Cache-Control "public, max-age=3600"
 		file_server
-		header Cache-Control "public, max-age=3600"
 	}
 
 	# /metrics is explicitly blocked on the public listeners. Backend metrics


### PR DESCRIPTION
## Summary

Closes #66 — after uploading a menu-item photo it rendered as alt text (broken image) until a hard refresh. Two compounding causes, both fixed:

### Gateway — stop caching 404s (root cause)
`infra/caddy/Caddyfile` applied `Cache-Control: public, max-age=3600` to **every** `/uploads/*` response, including the 404 a browser gets when it requests a photo before it exists. That 404 was cached for an hour, so the image stayed "missing" even after upload.

Fix: only set the header when the file actually exists, via Caddy's `file` matcher:
```caddy
@exists file
header @exists Cache-Control "public, max-age=3600"
```
(The issue suggested `@found status 2xx`, but `status` is not a valid request matcher for `header`; the `file` matcher is the correct idiom.)

### Frontend — cache-busting on replace
`photoUrl()` now takes an optional version token; `uploadPhoto` stamps the item with `_photo_v = Date.now()` so replacing a photo produces a new URL and the browser re-fetches.

## Verification

- **Gateway** (tested against `caddy:2-alpine` with the real Caddyfile):
  - existing file → `200` + `Cache-Control: public, max-age=3600`
  - missing file → `404` with **no** `Cache-Control` (not cached)
- **Frontend**: `npm run build` succeeds; `npm test` 8/8 pass.

## Note on ownership
The frontend files (`frontend/src/...`) are normally the frontend team's area — please review those bits. The gateway change is in the network/gateway scope.

## Files
- `infra/caddy/Caddyfile`
- `frontend/src/utils/format.js`
- `frontend/src/vendor/VendorMenuContext.jsx`
- `frontend/src/pages/vendor/VendorMenuListPage.jsx`
- `frontend/src/pages/vendor/VendorMenuFormPage.jsx`