### PR TITLE
feat(audit): complete audit log for sensitive operations (#56)

### DIFF
--- a/backend/core/audit.py
+++ b/backend/core/audit.py
@@ -1,0 +1,15 @@
+"""Audit log repository singletons + selection factory."""
+from __future__ import annotations
+
+from backend.core.config import settings
+from backend.repositories.audit_log_repository import AuditLogRepository
+from backend.repositories.postgres_audit_log_repository import PostgresAuditLogRepository
+
+_IN_MEMORY = AuditLogRepository()
+_POSTGRES = PostgresAuditLogRepository()
+
+
+def get_audit_log_repository():
+    if settings.database_url:
+        return _POSTGRES
+    return _IN_MEMORY

--- a/backend/db/migrations/010_audit_actor_role.sql
+++ b/backend/db/migrations/010_audit_actor_role.sql
@@ -1,0 +1,2 @@
+-- Issue #56: record the actor's role on each audit entry.
+ALTER TABLE audit_logs ADD COLUMN IF NOT EXISTS actor_role VARCHAR(50);

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from backend.db.migrate import run_migrations
 from backend.routes import (
     admin_users,
     admin_vendors,
+    audit_logs,
     auth,
     committee_reviews,
     employee_ordering,
@@ -66,6 +67,7 @@ def create_app() -> FastAPI:
     app.include_router(vendor_orders.router)
     app.include_router(employee_ordering.router)
     app.include_router(notifications.router)
+    app.include_router(audit_logs.router)
 
     Instrumentator(should_instrument_requests_inprogress=True).instrument(app).expose(app)
     return app

--- a/backend/repositories/audit_log_repository.py
+++ b/backend/repositories/audit_log_repository.py
@@ -1,13 +1,57 @@
-class AuditLogRepository:
-    def record_vendor_review(self, application_id: int, decision: str) -> None:
-        # Database implementation will be added when persistence work starts.
-        return None
+"""In-memory audit log persistence for tests and local no-DB mode."""
+from __future__ import annotations
 
-    def record_committee_review(
-        self,
-        review_id: int,
-        decision: str,
-        reason: str | None = None,
-    ) -> None:
-        # Database implementation will be added when persistence work starts.
-        return None
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from itertools import count
+
+from backend.schemas.audit import AuditLogEntry
+
+
+@dataclass
+class _AuditRecord:
+    id: int
+    actor_user_id: int | None
+    actor_role: str | None
+    action: str
+    target_type: str
+    target_id: int | None
+    metadata: dict
+    created_at: datetime
+
+
+class AuditLogRepository:
+    def __init__(self) -> None:
+        self._rows: list[_AuditRecord] = []
+        self._id_seq = count(1)
+
+    def record(self, *, actor_user_id: int | None, actor_role: str | None,
+               action: str, target_type: str, target_id: int | None = None,
+               metadata: dict | None = None) -> None:
+        self._rows.append(_AuditRecord(
+            id=next(self._id_seq), actor_user_id=actor_user_id, actor_role=actor_role,
+            action=action, target_type=target_type, target_id=target_id,
+            metadata=dict(metadata or {}), created_at=datetime.now(timezone.utc),
+        ))
+
+    def list(self, *, limit: int = 50, offset: int = 0, action: str | None = None,
+             actor_user_id: int | None = None, target_type: str | None = None,
+             target_id: int | None = None) -> list[AuditLogEntry]:
+        rows = [
+            r for r in self._rows
+            if (action is None or r.action == action)
+            and (actor_user_id is None or r.actor_user_id == actor_user_id)
+            and (target_type is None or r.target_type == target_type)
+            and (target_id is None or r.target_id == target_id)
+        ]
+        rows.sort(key=lambda r: (r.created_at, r.id), reverse=True)
+        rows = rows[offset:offset + limit]
+        return [self._to_schema(r) for r in rows]
+
+    @staticmethod
+    def _to_schema(r: _AuditRecord) -> AuditLogEntry:
+        return AuditLogEntry(
+            id=r.id, actor_user_id=r.actor_user_id, actor_role=r.actor_role,
+            action=r.action, target_type=r.target_type, target_id=r.target_id,
+            metadata=dict(r.metadata), created_at=r.created_at,
+        )

--- a/backend/repositories/postgres_audit_log_repository.py
+++ b/backend/repositories/postgres_audit_log_repository.py
@@ -1,0 +1,48 @@
+"""PostgreSQL audit log persistence."""
+from __future__ import annotations
+
+from psycopg.types.json import Jsonb
+
+from backend.db.connection import get_connection
+from backend.schemas.audit import AuditLogEntry
+
+_COLUMNS = "id, actor_user_id, actor_role, action, target_type, target_id, metadata, created_at"
+
+
+class PostgresAuditLogRepository:
+    def record(self, *, actor_user_id: int | None, actor_role: str | None,
+               action: str, target_type: str, target_id: int | None = None,
+               metadata: dict | None = None) -> None:
+        with get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO audit_logs
+                    (actor_user_id, actor_role, action, target_type, target_id, metadata)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                (actor_user_id, actor_role, action, target_type, target_id, Jsonb(metadata or {})),
+            )
+            conn.commit()
+
+    def list(self, *, limit: int = 50, offset: int = 0, action: str | None = None,
+             actor_user_id: int | None = None, target_type: str | None = None,
+             target_id: int | None = None) -> list[AuditLogEntry]:
+        conditions = ["1=1"]
+        params: list = []
+        if action is not None:
+            conditions.append("action = %s"); params.append(action)
+        if actor_user_id is not None:
+            conditions.append("actor_user_id = %s"); params.append(actor_user_id)
+        if target_type is not None:
+            conditions.append("target_type = %s"); params.append(target_type)
+        if target_id is not None:
+            conditions.append("target_id = %s"); params.append(target_id)
+        where = " AND ".join(conditions)
+        params.extend([limit, offset])
+        with get_connection() as conn:
+            rows = conn.execute(
+                f"SELECT {_COLUMNS} FROM audit_logs WHERE {where} "
+                "ORDER BY created_at DESC, id DESC LIMIT %s OFFSET %s",
+                params,
+            ).fetchall()
+        return [AuditLogEntry(**dict(r)) for r in rows]

--- a/backend/routes/admin_users.py
+++ b/backend/routes/admin_users.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, status
 
+from backend.core.audit import get_audit_log_repository
 from backend.core.errors import CodedHTTPException
 from backend.core.rbac import get_current_user_id, require_roles
 from backend.db.connection import get_connection
@@ -54,6 +55,7 @@ def disable_user(
     user_id: int,
     _role: Annotated[str, Depends(require_roles("admin"))],
     actor_id: Annotated[int | None, Depends(get_current_user_id)],
+    repo: Annotated[object, Depends(get_audit_log_repository)],
 ) -> dict:
     if actor_id == user_id:
         raise CodedHTTPException(
@@ -67,6 +69,8 @@ def disable_user(
             raise CodedHTTPException(status_code=404, code="user_not_found", detail="User not found")
         conn.execute("UPDATE users SET is_active = FALSE, updated_at = NOW() WHERE id = %s", (user_id,))
         conn.commit()
+    repo.record(actor_user_id=actor_id, actor_role="admin",
+                action="user.disable", target_type="user", target_id=user_id)
     return {"user_id": user_id, "is_active": False}
 
 
@@ -74,6 +78,8 @@ def disable_user(
 def enable_user(
     user_id: int,
     _role: Annotated[str, Depends(require_roles("admin"))],
+    actor_id: Annotated[int | None, Depends(get_current_user_id)],
+    repo: Annotated[object, Depends(get_audit_log_repository)],
 ) -> dict:
     with get_connection() as conn:
         row = conn.execute("SELECT id FROM users WHERE id = %s", (user_id,)).fetchone()
@@ -81,6 +87,8 @@ def enable_user(
             raise CodedHTTPException(status_code=404, code="user_not_found", detail="User not found")
         conn.execute("UPDATE users SET is_active = TRUE, updated_at = NOW() WHERE id = %s", (user_id,))
         conn.commit()
+    repo.record(actor_user_id=actor_id, actor_role="admin",
+                action="user.enable", target_type="user", target_id=user_id)
     return {"user_id": user_id, "is_active": True}
 
 
@@ -89,6 +97,7 @@ def delete_user(
     user_id: int,
     _role: Annotated[str, Depends(require_roles("admin"))],
     actor_id: Annotated[int | None, Depends(get_current_user_id)],
+    repo: Annotated[object, Depends(get_audit_log_repository)],
 ) -> None:
     if actor_id == user_id:
         raise CodedHTTPException(
@@ -102,3 +111,5 @@ def delete_user(
             raise CodedHTTPException(status_code=404, code="user_not_found", detail="User not found")
         conn.execute("DELETE FROM users WHERE id = %s", (user_id,))
         conn.commit()
+    repo.record(actor_user_id=actor_id, actor_role="admin",
+                action="user.delete", target_type="user", target_id=user_id)

--- a/backend/routes/admin_vendors.py
+++ b/backend/routes/admin_vendors.py
@@ -2,7 +2,9 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, status
 
+from backend.core.audit import get_audit_log_repository
 from backend.core.rbac import get_current_user_id, require_roles
+from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.vendor_repository import VendorRepository
 from backend.schemas.vendor import (
     VendorApplicationDetail,
@@ -10,6 +12,7 @@ from backend.schemas.vendor import (
     VendorReviewRequest,
     VendorReviewResponse,
 )
+from backend.services.vendor_review_service import VendorReviewService
 
 router = APIRouter(prefix="/admin/vendors", tags=["admin-vendors"])
 
@@ -18,6 +21,16 @@ _repo = VendorRepository()
 
 def get_vendor_repository() -> VendorRepository:
     return _repo
+
+
+def get_vendor_review_service(
+    repo: Annotated[VendorRepository, Depends(get_vendor_repository)],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
+) -> VendorReviewService:
+    return VendorReviewService(
+        vendor_repository=repo,
+        audit_log_repository=audit_repo,
+    )
 
 
 @router.get("/applications", response_model=list[VendorApplicationSummary])
@@ -53,19 +66,15 @@ def review_vendor_application(
     reviewer_id: Annotated[int | None, Depends(get_current_user_id)],
     _role: Annotated[str, Depends(require_roles("admin"))],
     repo: Annotated[VendorRepository, Depends(get_vendor_repository)],
+    service: Annotated[VendorReviewService, Depends(get_vendor_review_service)],
 ) -> VendorReviewResponse:
     from backend.core.errors import CodedHTTPException
     app = repo.get_application(application_id)
     if app is None:
         raise CodedHTTPException(status_code=404, code="not_found", detail="application not found")
-    repo.mark_application_reviewed(
+    return service.review_application(
         application_id,
-        decision=payload.decision,
-        reviewer_user_id=reviewer_id,
-        reason=payload.reason,
-    )
-    return VendorReviewResponse(
-        application_id=application_id,
-        decision=payload.decision,
-        status="review_recorded",
+        payload,
+        actor_user_id=reviewer_id,
+        actor_role="admin",
     )

--- a/backend/routes/audit_logs.py
+++ b/backend/routes/audit_logs.py
@@ -1,0 +1,24 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+
+from backend.core.audit import get_audit_log_repository
+from backend.core.rbac import require_roles
+from backend.schemas.audit import AuditLogEntry
+
+router = APIRouter(prefix="/admin/audit-logs", tags=["admin-audit"])
+
+
+@router.get("", response_model=list[AuditLogEntry])
+def list_audit_logs(
+    _role: Annotated[str, Depends(require_roles("admin"))],
+    repo: Annotated[object, Depends(get_audit_log_repository)],
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    action: str | None = Query(default=None),
+    actor_user_id: int | None = Query(default=None),
+    target_type: str | None = Query(default=None),
+    target_id: int | None = Query(default=None),
+) -> list[AuditLogEntry]:
+    return repo.list(limit=limit, offset=offset, action=action, actor_user_id=actor_user_id,
+                     target_type=target_type, target_id=target_id)

--- a/backend/routes/committee_reviews.py
+++ b/backend/routes/committee_reviews.py
@@ -2,7 +2,9 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 
-from backend.core.rbac import require_roles
+from backend.core.audit import get_audit_log_repository
+from backend.core.rbac import get_current_user_id, require_roles
+from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.committee_review_repository import CommitteeReviewRepository
 from backend.schemas.committee import CommitteeReviewItem, CommitteeReviewRequest, CommitteeReviewResponse
 from backend.services.committee_review_service import CommitteeReviewService
@@ -21,8 +23,15 @@ def get_committee_review_service(
         CommitteeReviewRepository,
         Depends(get_committee_review_repository),
     ],
+    audit_repository: Annotated[
+        AuditLogRepository,
+        Depends(get_audit_log_repository),
+    ],
 ) -> CommitteeReviewService:
-    return CommitteeReviewService(committee_review_repository=repository)
+    return CommitteeReviewService(
+        committee_review_repository=repository,
+        audit_log_repository=audit_repository,
+    )
 
 
 @router.get("/pending", response_model=list[CommitteeReviewItem])
@@ -42,6 +51,12 @@ def decide_committee_review(
     review_id: int,
     payload: CommitteeReviewRequest,
     _role: Annotated[str, Depends(require_roles("committee_reviewer"))],
+    actor_id: Annotated[int | None, Depends(get_current_user_id)],
     service: Annotated[CommitteeReviewService, Depends(get_committee_review_service)],
 ) -> CommitteeReviewResponse:
-    return service.record_decision(review_id, payload)
+    return service.record_decision(
+        review_id,
+        payload,
+        actor_user_id=actor_id,
+        actor_role="committee_reviewer",
+    )

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -5,9 +5,11 @@ from typing import Annotated
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Query, Response, status
 
+from backend.core.audit import get_audit_log_repository
 from backend.core.config import settings
 from backend.core.employee_identity import require_employee
 from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.postgres_employee_selection_repository import PostgresEmployeeSelectionRepository
@@ -46,8 +48,9 @@ def get_employee_ordering_service(
     vendor_repo: Annotated[VendorProfileRepository, Depends(get_vendor_profile_repository)],
     item_repo: Annotated[MenuItemRepository, Depends(get_menu_item_repository)],
     selection_repo: Annotated[EmployeeSelectionRepository, Depends(get_employee_selection_repository)],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
 ) -> EmployeeOrderingService:
-    return EmployeeOrderingService(vendor_repo, item_repo, selection_repo)
+    return EmployeeOrderingService(vendor_repo, item_repo, selection_repo, audit_repo)
 
 
 @router.get("/vendors", response_model=list[EmployeeVendor])
@@ -127,7 +130,7 @@ def create_order(
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
     notification_service: Annotated[NotificationService, Depends(get_notification_service)],
 ) -> EmployeeOrder:
-    order = service.create_order(employee_id, vendor_id, payload)
+    order = service.create_order(employee_id, vendor_id, payload, actor_user_id=employee_id)
     background_tasks.add_task(notification_service.create_order_placed, order)
     return order
 

--- a/backend/routes/vendor_orders.py
+++ b/backend/routes/vendor_orders.py
@@ -6,8 +6,10 @@ from typing import Annotated
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, Query
 
+from backend.core.audit import get_audit_log_repository
 from backend.core.errors import CodedHTTPException
 from backend.core.vendor_identity import get_vendor_profile_repository, require_approved_vendor
+from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
 from backend.routes.employee_ordering import get_employee_selection_repository
@@ -22,8 +24,9 @@ router = APIRouter(prefix="/vendor/me/orders", tags=["vendor-self"])
 def get_vendor_order_service(
     selection_repo: Annotated[EmployeeSelectionRepository, Depends(get_employee_selection_repository)],
     vendor_repo: Annotated[VendorProfileRepository, Depends(get_vendor_profile_repository)],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
 ) -> VendorOrderService:
-    return VendorOrderService(selection_repo, vendor_repo)
+    return VendorOrderService(selection_repo, vendor_repo, audit_repo)
 
 
 def optional_header_user_id(x_user_id: Annotated[str | None, Header()] = None) -> int | None:
@@ -102,9 +105,10 @@ def update_vendor_order_status(
     payload: VendorOrderStatusUpdate,
     background_tasks: BackgroundTasks,
     vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    actor_user_id: Annotated[int | None, Depends(optional_header_user_id)],
     service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
     notification_service: Annotated[NotificationService, Depends(get_notification_service)],
 ) -> EmployeeOrder:
-    order = service.update_status(vendor_id, order_id, payload.status)
+    order = service.update_status(vendor_id, order_id, payload.status, actor_user_id=actor_user_id)
     background_tasks.add_task(notification_service.create_order_status_updated, order)
     return order

--- a/backend/schemas/audit.py
+++ b/backend/schemas/audit.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class AuditLogEntry(BaseModel):
+    id: int
+    actor_user_id: int | None = None
+    actor_role: str | None = None
+    action: str
+    target_type: str
+    target_id: int | None = None
+    metadata: dict = Field(default_factory=dict)
+    created_at: datetime

--- a/backend/services/committee_review_service.py
+++ b/backend/services/committee_review_service.py
@@ -45,10 +45,13 @@ class CommitteeReviewService:
             payload.decision,
             payload.reason,
         )
-        self.audit_log_repository.record_committee_review(
-            review_id,
-            payload.decision,
-            payload.reason,
+        self.audit_log_repository.record(
+            actor_user_id=None,
+            actor_role=None,
+            action="committee.review",
+            target_type="committee_review",
+            target_id=review_id,
+            metadata={"decision": payload.decision, "reason": payload.reason},
         )
 
         return CommitteeReviewResponse(

--- a/backend/services/committee_review_service.py
+++ b/backend/services/committee_review_service.py
@@ -25,6 +25,9 @@ class CommitteeReviewService:
         self,
         review_id: int,
         payload: CommitteeReviewRequest,
+        *,
+        actor_user_id: int | None = None,
+        actor_role: str | None = None,
     ) -> CommitteeReviewResponse:
         review = self.committee_review_repository.get(review_id)
         if review is None:
@@ -46,8 +49,8 @@ class CommitteeReviewService:
             payload.reason,
         )
         self.audit_log_repository.record(
-            actor_user_id=None,
-            actor_role=None,
+            actor_user_id=actor_user_id,
+            actor_role=actor_role,
             action="committee.review",
             target_type="committee_review",
             target_id=review_id,

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -6,6 +6,7 @@ from datetime import date, timedelta
 
 from backend.core.errors import CodedHTTPException
 from backend.core.order_failure_codes import ITEM_UNAVAILABLE, QUOTA_EXHAUSTED
+from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository, OrderItemSnapshot
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
@@ -34,10 +35,12 @@ class EmployeeOrderingService:
         vendor_repository: VendorProfileRepository,
         menu_item_repository: MenuItemRepository,
         selection_repository: EmployeeSelectionRepository,
+        audit_log_repository: AuditLogRepository | None = None,
     ) -> None:
         self.vendor_repository = vendor_repository
         self.menu_item_repository = menu_item_repository
         self.selection_repository = selection_repository
+        self.audit_log_repository = audit_log_repository or AuditLogRepository()
 
     def list_vendors(
         self,
@@ -100,6 +103,7 @@ class EmployeeOrderingService:
                     )
                 ],
             ),
+            actor_user_id=employee_id,
         )
         item = order.items[0]
         return MealSelection(
@@ -125,19 +129,30 @@ class EmployeeOrderingService:
         employee_id: int,
         vendor_id: int,
         payload: EmployeeOrderCreate,
+        *,
+        actor_user_id: int | None = None,
     ) -> EmployeeOrder:
         vendor = self._vendor_to_schema(self._get_approved_vendor(vendor_id))
         facility_id = self._resolve_order_facility(employee_id, vendor, payload.facility_id)
         meal_date = payload.meal_date or date.today()
         self._ensure_meal_date_in_window(meal_date)
         snapshots = self._build_order_items(vendor_id, payload, meal_date=meal_date)
-        return self.selection_repository.create_order(
+        order = self.selection_repository.create_order(
             employee_id=employee_id,
             vendor_id=vendor_id,
             items=snapshots,
             meal_date=meal_date,
             facility_id=facility_id,
         )
+        self.audit_log_repository.record(
+            actor_user_id=actor_user_id,
+            actor_role="employee",
+            action="order.create",
+            target_type="order",
+            target_id=order.id,
+            metadata={"vendor_id": order.vendor_id, "total_cents": order.total_price_cents},
+        )
+        return order
 
     def draw_random_meal(
         self,

--- a/backend/services/vendor_order_service.py
+++ b/backend/services/vendor_order_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import date
 
 from backend.core.errors import CodedHTTPException
+from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
 from backend.schemas.employee import EmployeeOrder, OrderStatus, PickupLabel, PickupLabelItem
@@ -21,9 +22,11 @@ class VendorOrderService:
         self,
         selection_repo: EmployeeSelectionRepository,
         vendor_repo: VendorProfileRepository,
+        audit_log_repository: AuditLogRepository | None = None,
     ) -> None:
         self._repo = selection_repo
         self._vendor_repo = vendor_repo
+        self._audit = audit_log_repository or AuditLogRepository()
 
     def list_orders(self, vendor_id: int, facility_id: int | None = None) -> list[EmployeeOrder]:
         self._assert_facility_access(vendor_id, facility_id)
@@ -76,8 +79,16 @@ class VendorOrderService:
             raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
         return updated
 
-    def update_status(self, vendor_id: int, order_id: int, new_status: str) -> EmployeeOrder:
+    def update_status(
+        self,
+        vendor_id: int,
+        order_id: int,
+        new_status: str,
+        *,
+        actor_user_id: int | None = None,
+    ) -> EmployeeOrder:
         order = self.get_order(vendor_id, order_id)
+        old_status = order.status
         allowed = ALLOWED_TRANSITIONS.get(order.status, set())
         if new_status not in allowed:
             raise CodedHTTPException(
@@ -90,6 +101,14 @@ class VendorOrderService:
         )
         if updated is None:
             raise CodedHTTPException(status_code=404, code="not_found", detail="order not found")
+        self._audit.record(
+            actor_user_id=actor_user_id,
+            actor_role="vendor_manager",
+            action="order.status_update",
+            target_type="order",
+            target_id=order_id,
+            metadata={"from": old_status, "to": new_status},
+        )
         return updated
 
     def _assert_facility_access(self, vendor_id: int, facility_id: int | None) -> None:

--- a/backend/services/vendor_review_service.py
+++ b/backend/services/vendor_review_service.py
@@ -16,11 +16,19 @@ class VendorReviewService:
         self,
         application_id: int,
         payload: VendorReviewRequest,
+        *,
+        actor_user_id: int | None = None,
+        actor_role: str | None = None,
     ) -> VendorReviewResponse:
-        self.vendor_repository.mark_application_reviewed(application_id, payload.decision)
+        self.vendor_repository.mark_application_reviewed(
+            application_id,
+            decision=payload.decision,
+            reviewer_user_id=actor_user_id,
+            reason=payload.reason,
+        )
         self.audit_log_repository.record(
-            actor_user_id=None,
-            actor_role=None,
+            actor_user_id=actor_user_id,
+            actor_role=actor_role,
             action="vendor.review",
             target_type="vendor_application",
             target_id=application_id,

--- a/backend/services/vendor_review_service.py
+++ b/backend/services/vendor_review_service.py
@@ -18,7 +18,14 @@ class VendorReviewService:
         payload: VendorReviewRequest,
     ) -> VendorReviewResponse:
         self.vendor_repository.mark_application_reviewed(application_id, payload.decision)
-        self.audit_log_repository.record_vendor_review(application_id, payload.decision)
+        self.audit_log_repository.record(
+            actor_user_id=None,
+            actor_role=None,
+            action="vendor.review",
+            target_type="vendor_application",
+            target_id=application_id,
+            metadata={"decision": payload.decision},
+        )
 
         return VendorReviewResponse(
             application_id=application_id,

--- a/backend/tests/integration/test_audit_log_repository_db.py
+++ b/backend/tests/integration/test_audit_log_repository_db.py
@@ -6,6 +6,19 @@ from backend.repositories.postgres_audit_log_repository import PostgresAuditLogR
 pytestmark = pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="requires DATABASE_URL")
 
 
+@pytest.fixture(scope="module", autouse=True)
+def _migrated_db():
+    """Apply migrations so audit_logs (incl. the actor_role column) exists.
+
+    CI only psql-applies 001; the remaining migrations — including 010 which
+    adds actor_role — are applied here via run_migrations(), matching the
+    pattern in test_atomic_quota.py.
+    """
+    from backend.db.migrate import run_migrations
+
+    run_migrations()
+
+
 def test_record_and_list_roundtrip():
     repo = PostgresAuditLogRepository()
     repo.record(actor_user_id=1, actor_role="admin", action="vendor.review",

--- a/backend/tests/integration/test_audit_log_repository_db.py
+++ b/backend/tests/integration/test_audit_log_repository_db.py
@@ -30,21 +30,3 @@ def test_record_and_list_roundtrip():
     assert e.actor_role == "admin"
     assert e.target_id == 999
     assert e.metadata == {"decision": "approved"}
-
-
-def test_record_with_nonexistent_actor_raises_fk_violation():
-    """Regression for #56: the Postgres audit write enforces
-    audit_logs.actor_user_id -> users(id). A synthetic actor id violates the FK.
-
-    This is exactly the failure that surfaced when the full test suite ran
-    against a real database: fake-domain unit tests create orders for synthetic
-    employee ids, so their audit writes must go to the in-memory repo (the unit
-    tests override get_audit_log_repository). Locking this behavior here makes
-    the constraint — and the reason for that override — explicit.
-    """
-    import psycopg
-
-    repo = PostgresAuditLogRepository()
-    with pytest.raises(psycopg.errors.ForeignKeyViolation):
-        repo.record(actor_user_id=99_999_999, actor_role="employee",
-                    action="order.create", target_type="order", target_id=1)

--- a/backend/tests/integration/test_audit_log_repository_db.py
+++ b/backend/tests/integration/test_audit_log_repository_db.py
@@ -30,3 +30,21 @@ def test_record_and_list_roundtrip():
     assert e.actor_role == "admin"
     assert e.target_id == 999
     assert e.metadata == {"decision": "approved"}
+
+
+def test_record_with_nonexistent_actor_raises_fk_violation():
+    """Regression for #56: the Postgres audit write enforces
+    audit_logs.actor_user_id -> users(id). A synthetic actor id violates the FK.
+
+    This is exactly the failure that surfaced when the full test suite ran
+    against a real database: fake-domain unit tests create orders for synthetic
+    employee ids, so their audit writes must go to the in-memory repo (the unit
+    tests override get_audit_log_repository). Locking this behavior here makes
+    the constraint — and the reason for that override — explicit.
+    """
+    import psycopg
+
+    repo = PostgresAuditLogRepository()
+    with pytest.raises(psycopg.errors.ForeignKeyViolation):
+        repo.record(actor_user_id=99_999_999, actor_role="employee",
+                    action="order.create", target_type="order", target_id=1)

--- a/backend/tests/integration/test_audit_log_repository_db.py
+++ b/backend/tests/integration/test_audit_log_repository_db.py
@@ -1,0 +1,19 @@
+import os
+import pytest
+
+from backend.repositories.postgres_audit_log_repository import PostgresAuditLogRepository
+
+pytestmark = pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="requires DATABASE_URL")
+
+
+def test_record_and_list_roundtrip():
+    repo = PostgresAuditLogRepository()
+    repo.record(actor_user_id=1, actor_role="admin", action="vendor.review",
+                target_type="vendor_application", target_id=999, metadata={"decision": "approved"})
+    entries = repo.list(action="vendor.review", target_id=999)
+    assert len(entries) >= 1
+    e = entries[0]
+    assert e.action == "vendor.review"
+    assert e.actor_role == "admin"
+    assert e.target_id == 999
+    assert e.metadata == {"decision": "approved"}

--- a/backend/tests/test_admin_users.py
+++ b/backend/tests/test_admin_users.py
@@ -5,8 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.core.audit import get_audit_log_repository
 from backend.core.security import create_access_token, hash_password
 from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
 
 client = TestClient(app)
 
@@ -171,6 +173,70 @@ def test_delete_self_returns_403() -> None:
 
     assert resp.status_code == 403
     assert resp.json()["code"] == "cannot_delete_self"
+
+
+# ---------------------------------------------------------------------------
+# Audit trail (issue #56)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def audit_repo():
+    """Substitute an in-memory audit repo for the duration of a test."""
+    repo = AuditLogRepository()
+    app.dependency_overrides[get_audit_log_repository] = lambda: repo
+    yield repo
+    app.dependency_overrides.pop(get_audit_log_repository, None)
+
+
+def test_disable_user_records_audit_entry(audit_repo) -> None:
+    with patch("backend.routes.admin_users.get_connection", return_value=_action_conn(exists=True)):
+        resp = client.patch("/admin/users/2/disable", headers=_ADMIN_HEADERS)
+
+    assert resp.status_code == 200
+    entries = audit_repo.list(action="user.disable")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.target_type == "user"
+    assert entry.target_id == 2
+    assert entry.actor_role == "admin"
+    assert entry.actor_user_id == 1
+
+
+def test_enable_user_records_audit_entry(audit_repo) -> None:
+    with patch("backend.routes.admin_users.get_connection", return_value=_action_conn(exists=True)):
+        resp = client.patch("/admin/users/2/enable", headers=_ADMIN_HEADERS)
+
+    assert resp.status_code == 200
+    entries = audit_repo.list(action="user.enable")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.target_type == "user"
+    assert entry.target_id == 2
+    assert entry.actor_role == "admin"
+    assert entry.actor_user_id == 1
+
+
+def test_delete_user_records_audit_entry(audit_repo) -> None:
+    with patch("backend.routes.admin_users.get_connection", return_value=_action_conn(exists=True)):
+        resp = client.delete("/admin/users/2", headers=_ADMIN_HEADERS)
+
+    assert resp.status_code == 204
+    entries = audit_repo.list(action="user.delete")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.target_type == "user"
+    assert entry.target_id == 2
+    assert entry.actor_role == "admin"
+    assert entry.actor_user_id == 1
+
+
+def test_failed_disable_does_not_record_audit(audit_repo) -> None:
+    """404 (user not found) must not produce an audit entry."""
+    with patch("backend.routes.admin_users.get_connection", return_value=_action_conn(exists=False)):
+        resp = client.patch("/admin/users/999/disable", headers=_ADMIN_HEADERS)
+
+    assert resp.status_code == 404
+    assert audit_repo.list(action="user.disable") == []
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_admin_vendors.py
+++ b/backend/tests/test_admin_vendors.py
@@ -1,9 +1,46 @@
+from datetime import datetime, timezone
+
 from fastapi.testclient import TestClient
 
+from backend.core.audit import get_audit_log_repository
+from backend.core.rbac import get_current_user_id
 from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
+from backend.routes.admin_vendors import get_vendor_repository
+from backend.schemas.vendor import VendorApplicationDetail
 
 
 client = TestClient(app)
+
+
+class _FakeVendorRepository:
+    """Minimal stand-in so the admin-review route never touches Postgres."""
+
+    def __init__(self) -> None:
+        self.reviewed: list[tuple] = []
+
+    def get_application(self, application_id: int) -> VendorApplicationDetail | None:
+        return VendorApplicationDetail(
+            application_id=application_id,
+            vendor_id=100,
+            vendor_name="Alice Bento",
+            status="pending",
+            submitted_at=datetime.now(timezone.utc),
+        )
+
+    def mark_application_reviewed(
+        self,
+        application_id: int,
+        *,
+        decision: str,
+        reviewer_user_id: int | None = None,
+        reason: str | None = None,
+    ) -> None:
+        self.reviewed.append((application_id, decision, reviewer_user_id, reason))
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
 
 
 def test_non_admin_vendor_review_returns_403() -> None:
@@ -14,3 +51,29 @@ def test_non_admin_vendor_review_returns_403() -> None:
     )
 
     assert response.status_code == 403
+
+
+def test_vendor_review_records_audit_entry_with_actor() -> None:
+    audit_repo = AuditLogRepository()
+    vendor_repo = _FakeVendorRepository()
+    app.dependency_overrides[get_vendor_repository] = lambda: vendor_repo
+    app.dependency_overrides[get_audit_log_repository] = lambda: audit_repo
+    app.dependency_overrides[get_current_user_id] = lambda: 42
+
+    response = client.post(
+        "/admin/vendors/applications/1/review",
+        json={"decision": "approved", "reason": "basic check"},
+        headers={"x-user-role": "admin", "x-user-id": "42"},
+    )
+
+    assert response.status_code == 202
+
+    entries = audit_repo.list(action="vendor.review")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.action == "vendor.review"
+    assert entry.target_type == "vendor_application"
+    assert entry.target_id == 1
+    assert entry.actor_user_id == 42
+    assert entry.actor_role == "admin"
+    assert entry.metadata["decision"] == "approved"

--- a/backend/tests/test_audit_log_repository.py
+++ b/backend/tests/test_audit_log_repository.py
@@ -1,0 +1,50 @@
+from backend.repositories.audit_log_repository import AuditLogRepository
+
+
+def _record(repo, **over):
+    base = dict(actor_user_id=1, actor_role="admin", action="vendor.review",
+               target_type="vendor_application", target_id=7, metadata={"decision": "approved"})
+    base.update(over)
+    repo.record(**base)
+
+
+def test_record_then_list_returns_entry():
+    repo = AuditLogRepository()
+    _record(repo)
+    entries = repo.list()
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.actor_user_id == 1
+    assert e.actor_role == "admin"
+    assert e.action == "vendor.review"
+    assert e.target_type == "vendor_application"
+    assert e.target_id == 7
+    assert e.metadata == {"decision": "approved"}
+    assert e.id == 1
+
+
+def test_list_orders_newest_first():
+    repo = AuditLogRepository()
+    _record(repo, action="a1")
+    _record(repo, action="a2")
+    actions = [e.action for e in repo.list()]
+    assert actions == ["a2", "a1"]
+
+
+def test_list_filters_and_pagination():
+    repo = AuditLogRepository()
+    _record(repo, action="order.create", target_type="order", target_id=1, actor_user_id=5)
+    _record(repo, action="vendor.review", target_type="vendor_application", target_id=2, actor_user_id=1)
+    _record(repo, action="order.create", target_type="order", target_id=3, actor_user_id=5)
+    assert [e.target_id for e in repo.list(action="order.create")] == [3, 1]
+    assert [e.target_id for e in repo.list(actor_user_id=1)] == [2]
+    assert [e.target_id for e in repo.list(target_type="order", target_id=1)] == [1]
+    assert len(repo.list(limit=1)) == 1
+    assert repo.list(limit=1, offset=1)[0].action == "vendor.review"
+
+
+def test_record_defaults_metadata_to_empty_dict():
+    repo = AuditLogRepository()
+    repo.record(actor_user_id=1, actor_role="admin", action="user.delete",
+                target_type="user", target_id=9)
+    assert repo.list()[0].metadata == {}

--- a/backend/tests/test_audit_logs_route.py
+++ b/backend/tests/test_audit_logs_route.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+
+from backend.core.audit import get_audit_log_repository
+from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
+
+client = TestClient(app)
+
+
+def _override(repo):
+    app.dependency_overrides[get_audit_log_repository] = lambda: repo
+
+
+def teardown_function():
+    app.dependency_overrides.clear()
+
+
+def test_requires_admin():
+    _override(AuditLogRepository())
+    r = client.get("/admin/audit-logs", headers={"x-user-role": "employee"})
+    assert r.status_code == 403
+
+
+def test_returns_entries_newest_first():
+    repo = AuditLogRepository()
+    repo.record(actor_user_id=1, actor_role="admin", action="a1", target_type="t", target_id=1)
+    repo.record(actor_user_id=1, actor_role="admin", action="a2", target_type="t", target_id=2)
+    _override(repo)
+    r = client.get("/admin/audit-logs", headers={"x-user-role": "admin"})
+    assert r.status_code == 200
+    assert [e["action"] for e in r.json()] == ["a2", "a1"]
+
+
+def test_filter_by_action_and_pagination():
+    repo = AuditLogRepository()
+    repo.record(actor_user_id=1, actor_role="admin", action="order.create", target_type="order", target_id=1)
+    repo.record(actor_user_id=1, actor_role="admin", action="vendor.review", target_type="vendor_application", target_id=2)
+    _override(repo)
+    r = client.get("/admin/audit-logs?action=order.create", headers={"x-user-role": "admin"})
+    assert [e["target_id"] for e in r.json()] == [1]
+    r2 = client.get("/admin/audit-logs?limit=1", headers={"x-user-role": "admin"})
+    assert len(r2.json()) == 1

--- a/backend/tests/test_committee_reviews.py
+++ b/backend/tests/test_committee_reviews.py
@@ -1,6 +1,9 @@
 from fastapi.testclient import TestClient
 
+from backend.core.audit import get_audit_log_repository
+from backend.core.rbac import get_current_user_id
 from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.committee_review_repository import CommitteeReviewRecord, CommitteeReviewRepository
 from backend.routes.committee_reviews import get_committee_review_repository
 
@@ -73,6 +76,31 @@ def test_committee_reviewer_can_record_decision() -> None:
     assert response.status_code == 202
     assert response.json()["status"] == "approved"
     assert repo.get(1).status == "approved"
+
+
+def test_committee_decision_records_audit_entry_with_actor() -> None:
+    _setup_repo()
+    audit_repo = AuditLogRepository()
+    app.dependency_overrides[get_audit_log_repository] = lambda: audit_repo
+    app.dependency_overrides[get_current_user_id] = lambda: 77
+
+    response = client.post(
+        "/committee/reviews/1/decision",
+        json={"decision": "approved", "reason": "looks good"},
+        headers={"x-user-role": "committee_reviewer", "x-user-id": "77"},
+    )
+
+    assert response.status_code == 202
+
+    entries = audit_repo.list(action="committee.review")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.action == "committee.review"
+    assert entry.target_type == "committee_review"
+    assert entry.target_id == 1
+    assert entry.actor_user_id == 77
+    assert entry.actor_role == "committee_reviewer"
+    assert entry.metadata == {"decision": "approved", "reason": "looks good"}
 
 
 def test_unknown_committee_review_returns_404() -> None:

--- a/backend/tests/test_employee_facility_filter.py
+++ b/backend/tests/test_employee_facility_filter.py
@@ -14,8 +14,10 @@ from datetime import date, timedelta
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.core.audit import get_audit_log_repository
 from backend.core.vendor_identity import get_vendor_profile_repository
 from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
@@ -65,6 +67,7 @@ def _setup() -> tuple[TestClient, VendorProfileRepository, MenuItemRepository, E
     app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
     app.dependency_overrides[get_menu_item_repository] = lambda: item_repo
     app.dependency_overrides[get_employee_selection_repository] = lambda: selection_repo
+    app.dependency_overrides[get_audit_log_repository] = lambda: AuditLogRepository()
     return TestClient(app), vendor_repo, item_repo, selection_repo
 
 

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -5,11 +5,14 @@ from fastapi.testclient import TestClient
 
 from backend.core.vendor_identity import get_vendor_profile_repository
 from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository, OrderItemSnapshot
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
 from backend.routes.employee_ordering import get_employee_selection_repository
 from backend.routes.vendor_menu import get_menu_item_repository
+from backend.schemas.employee import EmployeeOrderCreate, EmployeeOrderItemCreate
+from backend.services.employee_ordering_service import EmployeeOrderingService
 
 
 def _setup() -> tuple[TestClient, MenuItemRepository, EmployeeSelectionRepository]:
@@ -546,6 +549,33 @@ def test_employee_endpoints_require_employee_role() -> None:
 
     assert resp.status_code == 403
     assert resp.json()["code"] == "forbidden"
+
+
+def test_create_order_records_audit_entry() -> None:
+    vendor_repo = VendorProfileRepository()
+    vendor_repo.seed(VendorRecord(id=1, name="Alice Bento", status="approved", address="No. 1"))
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+    audit_repo = AuditLogRepository()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=5)
+
+    service = EmployeeOrderingService(vendor_repo, item_repo, selection_repo, audit_repo)
+    order = service.create_order(
+        100,
+        1,
+        EmployeeOrderCreate(items=[EmployeeOrderItemCreate(item_id=item.id, quantity=2)]),
+        actor_user_id=100,
+    )
+
+    entries = audit_repo.list(action="order.create")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.target_type == "order"
+    assert entry.target_id == order.id
+    assert entry.actor_user_id == 100
+    assert entry.actor_role == "employee"
+    assert entry.metadata["vendor_id"] == 1
+    assert entry.metadata["total_cents"] == 240
 
 
 def test_select_meal_requires_employee_id() -> None:

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -3,6 +3,7 @@ from datetime import date, timedelta
 
 from fastapi.testclient import TestClient
 
+from backend.core.audit import get_audit_log_repository
 from backend.core.vendor_identity import get_vendor_profile_repository
 from backend.main import app
 from backend.repositories.audit_log_repository import AuditLogRepository
@@ -39,6 +40,7 @@ def _setup() -> tuple[TestClient, MenuItemRepository, EmployeeSelectionRepositor
     app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
     app.dependency_overrides[get_menu_item_repository] = lambda: item_repo
     app.dependency_overrides[get_employee_selection_repository] = lambda: selection_repo
+    app.dependency_overrides[get_audit_log_repository] = lambda: AuditLogRepository()
     return TestClient(app), item_repo, selection_repo
 
 

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,8 +1,10 @@
 """In-app notifications for employee order events."""
 from fastapi.testclient import TestClient
 
+from backend.core.audit import get_audit_log_repository
 from backend.core.vendor_identity import get_vendor_profile_repository
 from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.notification_repository import NotificationRepository
@@ -26,6 +28,7 @@ def _setup() -> tuple[TestClient, MenuItemRepository, EmployeeSelectionRepositor
     app.dependency_overrides[get_menu_item_repository] = lambda: item_repo
     app.dependency_overrides[get_employee_selection_repository] = lambda: selection_repo
     app.dependency_overrides[get_notification_repository] = lambda: notification_repo
+    app.dependency_overrides[get_audit_log_repository] = lambda: AuditLogRepository()
     return TestClient(app), item_repo, selection_repo, notification_repo
 
 

--- a/backend/tests/test_vendor_orders.py
+++ b/backend/tests/test_vendor_orders.py
@@ -3,9 +3,11 @@ from fastapi.testclient import TestClient
 
 from backend.core.vendor_identity import get_vendor_profile_repository
 from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
 from backend.routes.employee_ordering import get_employee_selection_repository
+from backend.services.vendor_order_service import VendorOrderService
 
 
 def _seed_vendor_repo() -> VendorProfileRepository:
@@ -217,6 +219,25 @@ def test_patch_status_rejects_transition_from_terminal_state() -> None:
     )
     assert resp.status_code == 409
     assert resp.json()["code"] == "invalid_status_transition"
+
+
+def test_update_status_records_audit_entry() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    audit_repo = AuditLogRepository()
+    order = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+
+    service = VendorOrderService(selection_repo, vendor_repo, audit_repo)
+    service.update_status(1, order.id, "confirmed", actor_user_id=500)
+
+    entries = audit_repo.list(action="order.status_update")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.target_type == "order"
+    assert entry.target_id == order.id
+    assert entry.actor_user_id == 500
+    assert entry.actor_role == "vendor_manager"
+    assert entry.metadata == {"from": "pending", "to": "confirmed"}
 
 
 def test_patch_status_404_for_other_vendors_order() -> None:


### PR DESCRIPTION
## Summary

Closes #56. Replaces the no-op `AuditLogRepository` stub with a real audit trail and exposes an admin read endpoint.

- **Migration 010** — adds `actor_role` to `audit_logs` (table already had actor_user_id/action/target_type/target_id/metadata/created_at).
- **General repo interface** — `record(*, actor_user_id, actor_role, action, target_type, target_id=None, metadata=None)` + `list(*, limit, offset, action, actor_user_id, target_type, target_id)`. In-memory (`audit_log_repository.py`) + `PostgresAuditLogRepository`, selected by `core/audit.py` on `settings.database_url` (same pattern as the other repos).
- **`GET /admin/audit-logs`** — admin-only, paginated (`limit` default 50 / max 200, `offset`) + optional filters `action` / `actor_user_id` / `target_type` / `target_id`, newest first.
- **Audit writes wired into 6 operations:**
  | action | where |
  |--------|-------|
  | `vendor.review` | admin approve/reject vendor application |
  | `committee.review` | committee review decision |
  | `user.disable` / `user.enable` / `user.delete` | admin user-account ops |
  | `order.create` | employee creates order |
  | `order.status_update` | vendor updates order status (`{from,to}`) |

## Scope note

The acceptance item "admin changes user role" has **no role-change endpoint in the codebase**, so it is satisfied by auditing the admin user-account operations that do exist and are sensitive: disable / enable / delete.

## Design decisions

- Audit `record(...)` runs after the domain op and is **not** wrapped in try/except — a write that can't be recorded surfaces as an error rather than a silent gap.
- Audit and domain writes are not in one transaction (each repo opens its own connection) — accepted trade-off for this project.

## Verification

- Unit suite: **210 passed** (`pytest backend/tests --ignore=backend/tests/integration`).
- Integration (CI-style: psql-apply 001, then `pytest backend/tests/integration` with `DATABASE_URL`): **13 passed, 4 skipped** — includes the audit DB round-trip; the audit integration test runs `run_migrations()` so `actor_role` exists.
- Migration 010 verified to add the column on a fresh DB.

## Ownership note

This touches admin (`admin_vendors`, `admin_users`, `committee_reviews`) and ordering (`employee_ordering`, `vendor_orders`) route/service files — please have those owners review their areas. The audit infra (repos, factory, route, schema, migration) is the new shared piece.