### PR TITLE
fix(deploy): create appuser-owned /app/uploads so photo upload works (#87)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,12 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 COPY --from=builder /install /usr/local
 COPY backend ./backend
 RUN useradd --create-home --uid 1000 appuser \
+    && mkdir -p /app/uploads \
     && chown -R appuser:appuser /app
+# /app/uploads must exist and be owned by appuser in the image: when the named
+# `uploads` volume is first mounted here it inherits this ownership, so the
+# non-root process can write photos. Without it the fresh volume is root-owned
+# and uploads fail with PermissionError -> 500.
 USER appuser
 EXPOSE 8000
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary

Closes #87. Vendor menu photo upload (`PUT /vendor/me/menu/{id}/photo`) returned **500** in container deployments because the non-root backend (uid 1000, since #76) could not write to the `uploads` named volume.

## Root cause (reproduced)

`/app/uploads` did not exist in the image, so when the named volume first mounts there Docker initialises it as **root:root**. `PhotoStorage.store_menu_photo` then fails at `mkdir(/app/uploads/vendors/...)` with `PermissionError` → unhandled → 500. Menu reads are unaffected (no disk write).

```
$ docker run --rm -u 1000:1000 -v vol:/app/uploads alpine sh -c 'mkdir -p /app/uploads/vendors/1/menu'
mkdir: can't create directory '/app/uploads/vendors/': Permission denied
```

## Fix

Pre-create `/app/uploads` and chown it to `appuser` before `USER appuser`, so the fresh named volume inherits appuser ownership.

## Verification

Built the real backend image and ran it with a fresh `uploads` volume as appuser:
```
uid=1000(appuser) ...
drwxr-xr-x appuser appuser /app/uploads
mkdir + write /app/uploads/vendors/1/menu/5.jpg -> WRITE_OK
```

## Operational note (prod only)

Docker copies image-dir ownership only when initialising an empty volume. Staging/preview `down -v` each deploy → self-heal. **Prod preserves its volume**, so if a root-owned `uploads` volume already exists there, run once:
```
docker run --rm -v <prod_uploads_volume>:/v alpine chown -R 1000:1000 /v
```