### PR TITLE
fix(gateway): serve SPA for deep-link/refresh on app-route prefixes (#89)

### DIFF
--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -17,6 +17,22 @@
 	request_header -x-user-id
 	request_header -x-vendor-id
 
+	# SPA client routes (/employee/*, /vendor/*, /admin/*, /committee/*) share
+	# prefixes with the API. A full-page browser navigation (refresh / deep link /
+	# direct URL) must receive index.html so React Router can handle it; otherwise
+	# it falls through to the API below and the backend 404s (#89). Browser
+	# document requests send `Accept: text/html`; XHR/fetch from the app send
+	# `Accept: */*`, so only navigations are routed to the SPA here. Real backend
+	# surfaces (/health, /docs, /openapi.json, /uploads, /metrics) are excluded so
+	# they keep working even when opened in a browser tab.
+	@spa_nav {
+		header Accept *text/html*
+		not path /health /docs* /openapi.json /uploads/* /metrics
+	}
+	handle @spa_nav {
+		reverse_proxy frontend:80
+	}
+
 	handle /auth/* {
 		reverse_proxy api:8000
 	}


### PR DESCRIPTION
## Summary

Closes #89. Refreshing or directly opening any SPA route under `/employee/*`, `/vendor/*`, `/admin/*`, `/committee/*` returned the backend's `{"detail":"Not Found"}` (404) instead of the app.

Observed on staging: `GET /meal-staging/employee/menu -> 404`. Same for `/vendor/...`.

## Root cause

SPA client routes share prefixes with the API (`/employee/menu` SPA vs `/employee/vendors` API, etc.). The gateway sent **all** of those prefixes to the backend, so full-page browser navigations to SPA routes hit FastAPI (no such route → 404) and never reached `index.html`.

## Fix

Route document navigations (`Accept: text/html`) to the SPA; XHR/fetch (`Accept: */*`, which the app's `apiFetch` sends) still go to the API. Backend-only surfaces (`/health`, `/docs`, `/openapi.json`, `/uploads`, `/metrics`) are excluded.

```caddyfile
@spa_nav {
    header Accept *text/html*
    not path /health /docs* /openapi.json /uploads/* /metrics
}
handle @spa_nav { reverse_proxy frontend:80 }
```

## Verification

`caddy validate` passes. Matcher tested against a Caddy container with respond stand-ins:

| Request | Accept | Routed to |
|---------|--------|-----------|
| /vendor/menu, /employee/menu, /admin/vendors, / | text/html | **SPA** |
| /vendor/me/menu, /employee/vendors, /auth/login | */* | **API** |
| /docs, /health | text/html | **API** (excluded) |

## Note

This explains the secondary symptoms too: the frontend `withMockFallback` showed phantom mock menu items when the page/route was broken. With deep-links fixed, the real pages and their API calls work; the silent mock fallback in `frontend/src/api/vendor.js` is worth revisiting separately so real API failures surface instead of phantom data.