### PR TITLE
fix(frontend): redirect to login on 401; no jump-away while loading (#91)

### DIFF
--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,4 +1,4 @@
-import { readStoredSession } from "../auth/authStorage";
+import { clearStoredSession, readStoredSession } from "../auth/authStorage";
 
 function withBase(path) {
   if (/^https?:\/\//.test(path)) return path;
@@ -31,6 +31,19 @@ export async function apiFetch(path, options = {}) {
     const err = new Error(body.detail ?? res.statusText);
     err.status = res.status;
     err.code = body.code;
+    // A 401 on a protected endpoint means the session is missing or expired.
+    // Send the user back to login instead of surfacing a raw error / phantom
+    // data. /auth/* failures (e.g. wrong password) are shown by their own forms,
+    // and mock-demo sessions are left alone.
+    const isAuthEndpoint = path.startsWith("/auth/");
+    const isMockSession = session?.token?.startsWith("mock-token-");
+    if (res.status === 401 && !isAuthEndpoint && !isMockSession) {
+      clearStoredSession();
+      const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+      if (!window.location.pathname.endsWith("/login")) {
+        window.location.assign(`${base}/login`);
+      }
+    }
     throw err;
   }
 

--- a/frontend/src/pages/vendor/VendorMenuFormPage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuFormPage.jsx
@@ -24,11 +24,12 @@ function formToData(form) {
 export default function VendorMenuFormPage() {
   const { itemId } = useParams();
   const navigate = useNavigate();
-  const { getItem, addItem, updateItem, uploadPhoto, removePhoto } = useVendorMenu();
+  const { getItem, loading, addItem, updateItem, uploadPhoto, removePhoto } = useVendorMenu();
   const isEdit = Boolean(itemId);
 
   const [form, setForm] = useState(EMPTY_FORM);
   const [error, setError] = useState(null);
+  const [notFound, setNotFound] = useState(false);
 
   // Photo state — edit mode only
   const photoInputRef = useRef(null);
@@ -36,8 +37,12 @@ export default function VendorMenuFormPage() {
 
   useEffect(() => {
     if (!isEdit) return;
+    // Wait for the menu to finish loading before deciding the item is missing —
+    // otherwise a refresh / deep link redirects away before data arrives.
+    if (loading) return;
     const item = getItem(Number(itemId));
-    if (!item) { navigate("/vendor/menu"); return; }
+    if (!item) { setNotFound(true); return; }
+    setNotFound(false);
     setForm({
       name: item.name,
       description: item.description ?? "",
@@ -45,7 +50,7 @@ export default function VendorMenuFormPage() {
       available: item.available,
       daily_quota: item.daily_quota === null || item.daily_quota === undefined ? "" : String(item.daily_quota),
     });
-  }, [isEdit, itemId, navigate, getItem]);
+  }, [isEdit, itemId, loading, getItem]);
 
   function handleChange(e) {
     const { name, value, type, checked } = e.target;
@@ -106,6 +111,33 @@ export default function VendorMenuFormPage() {
   const currentItem = isEdit ? getItem(Number(itemId)) : null;
   const currentPhotoUrl = photoUrl(currentItem?.photo_path, currentItem?._photo_v);
   const photoBusy = photoState !== "idle";
+
+  if (isEdit && loading) {
+    return (
+      <div>
+        <div className="page-header">
+          <p className="eyebrow">Vendor · Menu</p>
+          <h2>編輯餐點</h2>
+        </div>
+        <p className="panel-copy">載入中…</p>
+      </div>
+    );
+  }
+
+  if (isEdit && notFound) {
+    return (
+      <div>
+        <div className="page-header">
+          <p className="eyebrow">Vendor · Menu</p>
+          <h2>編輯餐點</h2>
+        </div>
+        <p className="error-state" style={{ marginBottom: 16 }}>找不到此餐點，可能已被刪除。</p>
+        <button className="ghost-button" type="button" onClick={() => navigate("/vendor/menu")}>
+          返回菜單
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div>


### PR DESCRIPTION
## Summary

Closes #91. Auth-aware redirects so users never see a raw error/404/500 when their session is missing or expired, and the menu form stops bouncing away during load.

- **`apiFetch`**: a **401** from a protected endpoint clears the session and redirects to `/login`. Excludes `/auth/*` (login/register show their own errors) and mock-demo sessions. Other errors (404/500) are NOT auto-redirected — only auth failures are.
- **`VendorMenuFormPage`**: waits for `loading` before deciding an item is missing; shows "載入中…" while loading and an inline "找不到此餐點" + manual "返回菜單" button when genuinely absent — no automatic `navigate` on refresh/deep-link.

Context: the JWT expires after 8h (`jwt_access_token_expire_minutes=480`); after that, API calls 401 and now route the user to login. Complements the gateway deep-link fix (#90/#89) and the existing `ProtectedRoute` (which already redirects unauthenticated users once the SPA loads).

## Verification

- `npm run build` passes; `npm test` 8/8.

## Test plan
- [x] Let token expire (or clear it) → next API call → lands on /login
- [x] Refresh on `/vendor/menu/:id/edit` → loading → form (no premature redirect)
- [x] Missing item → inline message + manual back
- [x] Wrong password → error on login form, no redirect loop