### PR TITLE
fix(frontend): persist session synchronously on login (#93)

### DIFF
--- a/frontend/src/auth/AuthContext.jsx
+++ b/frontend/src/auth/AuthContext.jsx
@@ -37,7 +37,14 @@ export function AuthProvider({ children }) {
           email,
           vendorId: data.vendor_id ?? null,
         };
-        setSession({ user, token: data.access_token });
+        // Persist synchronously so the very next API call (fired by the page we
+        // redirect to) reads the token from storage. Relying only on the
+        // [session] effect races: child mount effects run before the provider's
+        // effect, so those first post-login calls would go out unauthenticated
+        // → 403, and the menu would fall back to mock data.
+        const nextSession = { user, token: data.access_token };
+        writeStoredSession(nextSession);
+        setSession(nextSession);
         return user;
       },
 
@@ -53,14 +60,18 @@ export function AuthProvider({ children }) {
           email,
           vendorId: data.vendor_id ?? null,
         };
-        setSession({ user, token: data.access_token });
+        const nextSession = { user, token: data.access_token };
+        writeStoredSession(nextSession);
+        setSession(nextSession);
         return user;
       },
 
       loginAsRole(role) {
         const user = findMockUserByRole(role);
         if (!user) return false;
-        setSession({ user, token: `mock-token-${role}` });
+        const nextSession = { user, token: `mock-token-${role}` };
+        writeStoredSession(nextSession);
+        setSession(nextSession);
         return true;
       },
 


### PR DESCRIPTION
## Summary

Closes #93. After vendor login, `/vendor/me/menu` and `/vendor/me/facilities` returned **403** and the menu showed mock/default items until a page refresh.

## Root cause

`apiFetch` reads the token from `localStorage`. `AuthContext.login` set the session with `setSession`, but persisted it only via a `useEffect([session])`. React runs child mount effects before the parent provider effect, so the redirected page's data calls fired **before** `writeStoredSession` → unauthenticated → 403 → `withMockFallback` showed mock data. Refresh worked because the session was already stored.

Confirmed not a DB issue: a fresh fully-migrated DB returns `vendor_id` for the seeded vendor; the symptom only appears right after login and clears on refresh.

## Fix

Persist synchronously in `login` / `register` / `loginAsRole` (`writeStoredSession(nextSession)` before `setSession`). The `[session]` effect still handles later changes and logout.

## Verification

- `npm run build` passes; `npm test` 8/8.

## Test plan
- [x] Vendor login → menu + facilities load (200) with no refresh, real data (no mock, no 403)
- [x] Refresh still works; logout still clears session