### PR TITLE
style(frontend): keep selected filter pill readable on hover (#98)

### DIFF
--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -484,6 +484,12 @@ p {
   color: #fff7eb;
 }
 
+/* Keep the selected pill's text light on hover — otherwise .filter-pill:hover
+   turns it brand-orange on the orange background and it becomes unreadable. */
+.filter-pill-active:hover {
+  color: #fff7eb;
+}
+
 /* Menu item grid */
 .menu-grid {
   display: grid;


### PR DESCRIPTION
## Summary
Closes #98. Hovering the selected filter pill turned its text orange on the orange active background. Added `.filter-pill-active:hover { color:#fff7eb }` so the selected pill keeps light text on hover.

## Verification
- npm run build passes.