### PR TITLE
feat(frontend): admin audit log page (#100)

### DIFF
--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -25,6 +25,14 @@ export function getVendorApplications(status = null) {
   return apiFetch(`/admin/vendors/applications${qs}`);
 }
 
+export function getAuditLogs({ limit = 50, offset = 0, action } = {}) {
+  const params = new URLSearchParams();
+  params.set("limit", String(limit));
+  params.set("offset", String(offset));
+  if (action) params.set("action", action);
+  return apiFetch(`/admin/audit-logs?${params.toString()}`);
+}
+
 export function getVendorApplication(applicationId) {
   return apiFetch(`/admin/vendors/applications/${applicationId}`);
 }

--- a/frontend/src/pages/admin/AdminAuditPage.jsx
+++ b/frontend/src/pages/admin/AdminAuditPage.jsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from "react";
+import { getAuditLogs } from "../../api/admin";
+
+const PAGE_SIZE = 50;
+
+const ACTION_FILTERS = [
+  { label: "全部", value: "" },
+  { label: "廠商審核", value: "vendor.review" },
+  { label: "委員審核", value: "committee.review" },
+  { label: "建立訂單", value: "order.create" },
+  { label: "訂單狀態", value: "order.status_update" },
+  { label: "停用用戶", value: "user.disable" },
+  { label: "啟用用戶", value: "user.enable" },
+  { label: "刪除用戶", value: "user.delete" },
+];
+
+const ACTION_LABEL = ACTION_FILTERS.reduce((acc, f) => {
+  if (f.value) acc[f.value] = f.label;
+  return acc;
+}, {});
+
+function formatTime(iso) {
+  return new Date(iso).toLocaleString("zh-TW");
+}
+
+export default function AdminAuditPage() {
+  const [actionFilter, setActionFilter] = useState("");
+  const [page, setPage] = useState(0);
+  const [entries, setEntries] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    getAuditLogs({ limit: PAGE_SIZE, offset: page * PAGE_SIZE, action: actionFilter || undefined })
+      .then(setEntries)
+      .catch((err) => setError(err.message ?? "無法載入稽核紀錄"))
+      .finally(() => setLoading(false));
+  }, [actionFilter, page]);
+
+  function changeFilter(value) {
+    setPage(0);
+    setActionFilter(value);
+  }
+
+  return (
+    <div>
+      <div className="page-header">
+        <p className="eyebrow">Admin · Audit Log</p>
+        <h2>操作稽核紀錄</h2>
+      </div>
+
+      <div className="filter-bar" style={{ marginBottom: 20 }}>
+        {ACTION_FILTERS.map((f) => (
+          <button
+            key={f.value}
+            type="button"
+            className={`filter-pill${actionFilter === f.value ? " filter-pill-active" : ""}`}
+            onClick={() => changeFilter(f.value)}
+          >
+            {f.label}
+          </button>
+        ))}
+      </div>
+
+      {loading && <p className="loading-state">載入中...</p>}
+      {error && <p className="error-state">{error}</p>}
+
+      {!loading && !error && entries.length === 0 && (
+        <p className="empty-state">目前沒有稽核紀錄。</p>
+      )}
+
+      {!loading && !error && entries.length > 0 && (
+        <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "180px 140px 160px 160px 1fr",
+              padding: "10px 20px",
+              borderBottom: "1px solid var(--line)",
+              color: "var(--muted)",
+              fontSize: 12,
+              fontWeight: 600,
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+            }}
+          >
+            <span>時間</span>
+            <span>操作者</span>
+            <span>動作</span>
+            <span>目標</span>
+            <span>細節</span>
+          </div>
+
+          {entries.map((e, idx) => (
+            <div
+              key={e.id}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "180px 140px 160px 160px 1fr",
+                alignItems: "center",
+                padding: "12px 20px",
+                borderBottom: idx < entries.length - 1 ? "1px solid var(--line)" : "none",
+                fontSize: 13,
+              }}
+            >
+              <span style={{ color: "var(--muted)" }}>{formatTime(e.created_at)}</span>
+              <span>
+                #{e.actor_user_id ?? "—"}
+                {e.actor_role ? ` (${e.actor_role})` : ""}
+              </span>
+              <span>{ACTION_LABEL[e.action] ?? e.action}</span>
+              <span style={{ color: "var(--muted)" }}>
+                {e.target_type}
+                {e.target_id != null ? ` #${e.target_id}` : ""}
+              </span>
+              <span style={{ color: "var(--muted)", fontFamily: "monospace", fontSize: 12, wordBreak: "break-all" }}>
+                {Object.keys(e.metadata ?? {}).length ? JSON.stringify(e.metadata) : "—"}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!error && (page > 0 || entries.length === PAGE_SIZE) && (
+        <div style={{ display: "flex", gap: 12, justifyContent: "center", marginTop: 20 }}>
+          <button
+            type="button"
+            className="filter-pill"
+            disabled={page === 0 || loading}
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+          >
+            上一頁
+          </button>
+          <span style={{ alignSelf: "center", fontSize: 13, color: "var(--muted)" }}>第 {page + 1} 頁</span>
+          <button
+            type="button"
+            className="filter-pill"
+            disabled={entries.length < PAGE_SIZE || loading}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            下一頁
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -2,6 +2,7 @@ import { Navigate, Outlet, Route, Routes } from "react-router-dom";
 import { useAuth } from "../auth/AuthContext";
 import AppShell from "../layout/AppShell";
 import { roleHomePath } from "../layout/navigation";
+import AdminAuditPage from "../pages/admin/AdminAuditPage";
 import AdminHomePage from "../pages/admin/AdminHomePage";
 import AdminPermissionsPage from "../pages/admin/AdminPermissionsPage";
 import AdminVendorReviewDetailPage from "../pages/admin/AdminVendorReviewDetailPage";
@@ -96,15 +97,7 @@ export function AppRouter() {
             <Route element={<AdminVendorReviewListPage />} path="/admin/vendors" />
             <Route element={<AdminVendorReviewDetailPage />} path="/admin/vendors/:applicationId" />
             <Route element={<AdminPermissionsPage />} path="/admin/permissions" />
-            <Route
-              element={
-                <PlaceholderPage
-                  description="Audit log browsing depends on backend data and is intentionally deferred."
-                  title="Admin Audit"
-                />
-              }
-              path="/admin/audit"
-            />
+            <Route element={<AdminAuditPage />} path="/admin/audit" />
           </Route>
 
           <Route


### PR DESCRIPTION
## Summary

Closes #100. Replaces the `/admin/audit` placeholder with a real page that calls `GET /admin/audit-logs` (the endpoint from #56), so audited events are now visible to admins.

- `api/admin.js`: `getAuditLogs({ limit, offset, action })`.
- `AdminAuditPage`: table (time, actor #id + role, action, target type/id, metadata JSON) + action filter pills + prev/next pagination.
- Router: `/admin/audit` → `AdminAuditPage`.

## Decision

Menu CRUD is intentionally **not** audited. `audit_logs` is for sensitive admin/order operations; vendor self-service menu edits are routine and high-volume and would dilute the compliance signal. Audited events stay as #56's set (vendor.review, committee.review, user.disable/enable/delete, order.create, order.status_update).

## Verification
- `npm run build` passes; `npm test` 8/8.

## Test plan
- [x] As admin, open /admin/audit → entries load (create an order / review a vendor first to generate some)
- [x] Action filter narrows results; prev/next paginate