### PR TITLE
feat(committee): order aggregation layer + operations monitoring dashboard (#106)

### DIFF
--- a/backend/core/reporting.py
+++ b/backend/core/reporting.py
@@ -1,0 +1,15 @@
+"""Reporting repository singletons + selection factory."""
+from __future__ import annotations
+
+from backend.core.config import settings
+from backend.repositories.postgres_reporting_repository import PostgresReportingRepository
+from backend.repositories.reporting_repository import ReportingRepository
+
+_IN_MEMORY = ReportingRepository()
+_POSTGRES = PostgresReportingRepository()
+
+
+def get_reporting_repository():
+    if settings.database_url:
+        return _POSTGRES
+    return _IN_MEMORY

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from backend.core.errors import install_error_handler
 from backend.core.observability import RequestIDMiddleware, configure_logging
 from backend.db.migrate import run_migrations
 from backend.routes import (
+    admin_stats,
     admin_users,
     admin_vendors,
     audit_logs,
@@ -68,6 +69,7 @@ def create_app() -> FastAPI:
     app.include_router(employee_ordering.router)
     app.include_router(notifications.router)
     app.include_router(audit_logs.router)
+    app.include_router(admin_stats.router)
 
     Instrumentator(should_instrument_requests_inprogress=True).instrument(app).expose(app)
     return app

--- a/backend/repositories/postgres_reporting_repository.py
+++ b/backend/repositories/postgres_reporting_repository.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import date
+
+from backend.db.connection import get_connection
+from backend.schemas.admin_stats import DayPoint, FacilityStat, OrderSummary, VendorStat
+
+_WINDOW = "o.status <> 'cancelled' AND o.created_at::date BETWEEN %s AND %s"
+
+
+class PostgresReportingRepository:
+    def order_summary(self, start: date, end: date) -> OrderSummary:
+        with get_connection() as conn:
+            row = conn.execute(
+                f"""
+                SELECT COUNT(DISTINCT o.id) AS order_count,
+                       COALESCE(SUM(oi.total_price_cents), 0) AS total_revenue_cents,
+                       COALESCE(SUM(oi.quantity), 0) AS total_quantity,
+                       COUNT(DISTINCT o.vendor_id) AS active_vendor_count
+                FROM orders o
+                JOIN order_items oi ON oi.order_id = o.id
+                WHERE {_WINDOW}
+                """,
+                [start, end],
+            ).fetchone()
+        return OrderSummary(
+            order_count=int(row["order_count"]),
+            total_revenue_cents=int(row["total_revenue_cents"]),
+            total_quantity=int(row["total_quantity"]),
+            active_vendor_count=int(row["active_vendor_count"]),
+        )
+
+    def vendor_ranking(self, start: date, end: date, limit: int) -> list[VendorStat]:
+        with get_connection() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT o.vendor_id, v.name AS vendor_name,
+                       COUNT(DISTINCT o.id) AS order_count,
+                       COALESCE(SUM(oi.quantity), 0) AS quantity,
+                       COALESCE(SUM(oi.total_price_cents), 0) AS revenue_cents
+                FROM orders o
+                JOIN order_items oi ON oi.order_id = o.id
+                JOIN vendors v ON v.id = o.vendor_id
+                WHERE {_WINDOW}
+                GROUP BY o.vendor_id, v.name
+                ORDER BY revenue_cents DESC
+                LIMIT %s
+                """,
+                [start, end, limit],
+            ).fetchall()
+        return [
+            VendorStat(
+                vendor_id=int(r["vendor_id"]), vendor_name=r["vendor_name"],
+                order_count=int(r["order_count"]), quantity=int(r["quantity"]),
+                revenue_cents=int(r["revenue_cents"]),
+            )
+            for r in rows
+        ]
+
+    def facility_distribution(self, start: date, end: date) -> list[FacilityStat]:
+        with get_connection() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT o.facility_id, f.name AS facility_name,
+                       COUNT(DISTINCT o.id) AS order_count,
+                       COALESCE(SUM(oi.quantity), 0) AS quantity
+                FROM orders o
+                JOIN order_items oi ON oi.order_id = o.id
+                LEFT JOIN facilities f ON f.id = o.facility_id
+                WHERE {_WINDOW}
+                GROUP BY o.facility_id, f.name
+                ORDER BY quantity DESC
+                """,
+                [start, end],
+            ).fetchall()
+        return [
+            FacilityStat(
+                facility_id=int(r["facility_id"]) if r["facility_id"] is not None else None,
+                facility_name=r["facility_name"],
+                order_count=int(r["order_count"]), quantity=int(r["quantity"]),
+            )
+            for r in rows
+        ]
+
+    def daily_trend(self, start: date, end: date) -> list[DayPoint]:
+        with get_connection() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT o.created_at::date AS day,
+                       COUNT(DISTINCT o.id) AS order_count,
+                       COALESCE(SUM(oi.total_price_cents), 0) AS revenue_cents
+                FROM orders o
+                JOIN order_items oi ON oi.order_id = o.id
+                WHERE {_WINDOW}
+                GROUP BY o.created_at::date
+                ORDER BY day
+                """,
+                [start, end],
+            ).fetchall()
+        return [
+            DayPoint(day=r["day"], order_count=int(r["order_count"]), revenue_cents=int(r["revenue_cents"]))
+            for r in rows
+        ]

--- a/backend/repositories/reporting_repository.py
+++ b/backend/repositories/reporting_repository.py
@@ -1,0 +1,125 @@
+"""In-memory reporting/aggregation repository.
+
+Process-local skeleton + substitutable fake for tests. The Postgres-backed
+implementation (PostgresReportingRepository) mirrors these method contracts.
+Aggregations exclude cancelled orders and filter on created_at date (inclusive).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+
+from backend.schemas.admin_stats import DayPoint, FacilityStat, OrderSummary, VendorStat
+
+
+@dataclass
+class _OrderRow:
+    order_id: int
+    vendor_id: int
+    vendor_name: str
+    facility_id: int | None
+    facility_name: str | None
+    status: str
+    created_at: datetime
+    # items: list of (item_id, quantity, unit_price_cents)
+    items: list[tuple[int, int, int]] = field(default_factory=list)
+
+
+class ReportingRepository:
+    def __init__(self) -> None:
+        self._orders: list[_OrderRow] = []
+
+    def seed_order(
+        self,
+        *,
+        order_id: int,
+        vendor_id: int,
+        vendor_name: str,
+        facility_id: int | None,
+        facility_name: str | None,
+        status: str,
+        created_at: datetime,
+        items: list[tuple[int, int, int]],
+    ) -> None:
+        self._orders.append(
+            _OrderRow(
+                order_id=order_id,
+                vendor_id=vendor_id,
+                vendor_name=vendor_name,
+                facility_id=facility_id,
+                facility_name=facility_name,
+                status=status,
+                created_at=created_at,
+                items=items,
+            )
+        )
+
+    def _in_window(self, row: _OrderRow, start: date, end: date) -> bool:
+        return row.status != "cancelled" and start <= row.created_at.date() <= end
+
+    def _qualifying(self, start: date, end: date) -> list[_OrderRow]:
+        return [r for r in self._orders if self._in_window(r, start, end)]
+
+    @staticmethod
+    def _row_quantity(row: _OrderRow) -> int:
+        return sum(qty for _item_id, qty, _total in row.items)
+
+    @staticmethod
+    def _row_revenue(row: _OrderRow) -> int:
+        return sum(qty * unit_price for _item_id, qty, unit_price in row.items)
+
+    def order_summary(self, start: date, end: date) -> OrderSummary:
+        rows = self._qualifying(start, end)
+        return OrderSummary(
+            order_count=len(rows),
+            total_revenue_cents=sum(self._row_revenue(r) for r in rows),
+            total_quantity=sum(self._row_quantity(r) for r in rows),
+            active_vendor_count=len({r.vendor_id for r in rows}),
+        )
+
+    def vendor_ranking(self, start: date, end: date, limit: int) -> list[VendorStat]:
+        acc: dict[int, dict] = {}
+        for r in self._qualifying(start, end):
+            a = acc.setdefault(
+                r.vendor_id,
+                {"vendor_name": r.vendor_name, "order_count": 0, "quantity": 0, "revenue_cents": 0},
+            )
+            a["order_count"] += 1
+            a["quantity"] += self._row_quantity(r)
+            a["revenue_cents"] += self._row_revenue(r)
+        stats = [
+            VendorStat(vendor_id=vid, vendor_name=a["vendor_name"], order_count=a["order_count"],
+                       quantity=a["quantity"], revenue_cents=a["revenue_cents"])
+            for vid, a in acc.items()
+        ]
+        stats.sort(key=lambda s: s.revenue_cents, reverse=True)
+        return stats[:limit]
+
+    def facility_distribution(self, start: date, end: date) -> list[FacilityStat]:
+        acc: dict[int | None, dict] = {}
+        for r in self._qualifying(start, end):
+            a = acc.setdefault(
+                r.facility_id,
+                {"facility_name": r.facility_name, "order_count": 0, "quantity": 0},
+            )
+            a["order_count"] += 1
+            a["quantity"] += self._row_quantity(r)
+        stats = [
+            FacilityStat(facility_id=fid, facility_name=a["facility_name"],
+                         order_count=a["order_count"], quantity=a["quantity"])
+            for fid, a in acc.items()
+        ]
+        stats.sort(key=lambda s: s.quantity, reverse=True)
+        return stats
+
+    def daily_trend(self, start: date, end: date) -> list[DayPoint]:
+        acc: dict[date, dict] = {}
+        for r in self._qualifying(start, end):
+            day = r.created_at.date()
+            a = acc.setdefault(day, {"order_count": 0, "revenue_cents": 0})
+            a["order_count"] += 1
+            a["revenue_cents"] += self._row_revenue(r)
+        return [
+            DayPoint(day=day, order_count=a["order_count"], revenue_cents=a["revenue_cents"])
+            for day, a in sorted(acc.items())
+        ]

--- a/backend/routes/admin_stats.py
+++ b/backend/routes/admin_stats.py
@@ -1,0 +1,26 @@
+from datetime import date, timedelta
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+
+from backend.core.rbac import require_roles
+from backend.core.reporting import get_reporting_repository
+from backend.schemas.admin_stats import DashboardStats
+from backend.services.admin_stats_service import AdminStatsService
+
+router = APIRouter(prefix="/admin/stats", tags=["admin-stats"])
+
+DEFAULT_WINDOW_DAYS = 30
+
+
+@router.get("", response_model=DashboardStats)
+def get_stats(
+    _role: Annotated[str, Depends(require_roles("admin", "committee_reviewer"))],
+    repo: Annotated[object, Depends(get_reporting_repository)],
+    start: date | None = Query(default=None),
+    end: date | None = Query(default=None),
+) -> DashboardStats:
+    resolved_end = end or date.today()
+    resolved_start = start or (resolved_end - timedelta(days=DEFAULT_WINDOW_DAYS - 1))
+    service = AdminStatsService(reporting_repository=repo)
+    return service.dashboard(resolved_start, resolved_end)

--- a/backend/schemas/admin_stats.py
+++ b/backend/schemas/admin_stats.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class OrderSummary(BaseModel):
+    order_count: int
+    total_revenue_cents: int
+    total_quantity: int
+    active_vendor_count: int
+
+
+class VendorStat(BaseModel):
+    vendor_id: int
+    vendor_name: str
+    order_count: int
+    quantity: int
+    revenue_cents: int
+
+
+class FacilityStat(BaseModel):
+    facility_id: int | None = None
+    facility_name: str | None = None
+    order_count: int
+    quantity: int
+
+
+class DayPoint(BaseModel):
+    day: date
+    order_count: int
+    revenue_cents: int
+
+
+class DashboardStats(BaseModel):
+    start: date
+    end: date
+    summary: OrderSummary
+    vendor_ranking: list[VendorStat]
+    facility_distribution: list[FacilityStat]
+    daily_trend: list[DayPoint]

--- a/backend/services/admin_stats_service.py
+++ b/backend/services/admin_stats_service.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import date
+
+from backend.core.errors import CodedHTTPException
+from backend.core.reporting import get_reporting_repository
+from backend.schemas.admin_stats import DashboardStats
+
+VENDOR_RANKING_LIMIT = 10
+
+
+class AdminStatsService:
+    def __init__(self, reporting_repository=None) -> None:
+        self.reporting_repository = reporting_repository or get_reporting_repository()
+
+    def dashboard(self, start: date, end: date) -> DashboardStats:
+        if start > end:
+            raise CodedHTTPException(
+                status_code=400, code="validation_error",
+                detail="start must be on or before end",
+            )
+        repo = self.reporting_repository
+        return DashboardStats(
+            start=start,
+            end=end,
+            summary=repo.order_summary(start, end),
+            vendor_ranking=repo.vendor_ranking(start, end, VENDOR_RANKING_LIMIT),
+            facility_distribution=repo.facility_distribution(start, end),
+            daily_trend=repo.daily_trend(start, end),
+        )

--- a/backend/tests/integration/test_reporting_repository_db.py
+++ b/backend/tests/integration/test_reporting_repository_db.py
@@ -1,0 +1,75 @@
+import os
+from datetime import date
+
+import pytest
+
+pytestmark = pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="requires DATABASE_URL")
+
+DATABASE_URL = os.getenv("DATABASE_URL", "")
+
+
+@pytest.fixture()
+def seeded(tmp_path):
+    from psycopg import connect
+    from psycopg.rows import dict_row
+    from backend.db.migrate import run_migrations
+
+    run_migrations()
+    conn = connect(DATABASE_URL, row_factory=dict_row, autocommit=True)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO vendors (name, status, contact_email) "
+        "VALUES ('Stats Kitchen', 'approved', 'stats@example.com') RETURNING id"
+    )
+    vendor_id = cur.fetchone()["id"]
+    cur.execute("INSERT INTO facilities (code, name) VALUES ('SREP', 'Stats Fab') "
+                "ON CONFLICT (code) DO UPDATE SET name = EXCLUDED.name RETURNING id")
+    facility_id = cur.fetchone()["id"]
+
+    def make_order(status, created_day, qty, total):
+        cur.execute(
+            "INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, created_at) "
+            "VALUES (1, %s, %s, %s, %s, %s) RETURNING id",
+            (vendor_id, facility_id, status, total, f"2026-05-{created_day:02d} 12:00+00"),
+        )
+        oid = cur.fetchone()["id"]
+        cur.execute(
+            "INSERT INTO order_items (order_id, item_name, quantity, unit_price_cents, total_price_cents) "
+            "VALUES (%s, 'Box', %s, %s, %s)",
+            (oid, qty, total // qty, total),
+        )
+        return oid
+
+    ids = [
+        make_order("delivered", 1, 2, 1000),
+        make_order("pending", 2, 1, 500),
+        make_order("cancelled", 2, 5, 5000),
+    ]
+    yield {"vendor_id": vendor_id, "facility_id": facility_id, "order_ids": ids}
+    cur.execute("DELETE FROM order_items WHERE order_id = ANY(%s)", (ids,))
+    cur.execute("DELETE FROM orders WHERE id = ANY(%s)", (ids,))
+    cur.execute("DELETE FROM vendors WHERE id = %s", (vendor_id,))
+    conn.close()
+
+
+def test_summary_and_ranking_exclude_cancelled(seeded):
+    from backend.repositories.postgres_reporting_repository import PostgresReportingRepository
+
+    repo = PostgresReportingRepository()
+    start, end = date(2026, 5, 1), date(2026, 5, 31)
+
+    s = repo.order_summary(start, end)
+    assert s.order_count >= 2
+    assert s.total_quantity >= 3
+
+    ranking = repo.vendor_ranking(start, end, limit=50)
+    mine = [v for v in ranking if v.vendor_id == seeded["vendor_id"]][0]
+    assert mine.order_count == 2
+    assert mine.quantity == 3
+    assert mine.revenue_cents == 1500
+
+    dist = repo.facility_distribution(start, end)
+    assert any(f.facility_id == seeded["facility_id"] and f.quantity == 3 for f in dist)
+
+    trend = repo.daily_trend(start, end)
+    assert {p.day for p in trend} >= {date(2026, 5, 1), date(2026, 5, 2)}

--- a/backend/tests/test_admin_stats.py
+++ b/backend/tests/test_admin_stats.py
@@ -1,0 +1,30 @@
+from datetime import date
+
+from backend.schemas.admin_stats import (
+    DashboardStats,
+    DayPoint,
+    FacilityStat,
+    OrderSummary,
+    VendorStat,
+)
+
+
+def test_dashboard_stats_shape():
+    stats = DashboardStats(
+        start=date(2026, 5, 1),
+        end=date(2026, 5, 30),
+        summary=OrderSummary(
+            order_count=2, total_revenue_cents=3000, total_quantity=4, active_vendor_count=1
+        ),
+        vendor_ranking=[
+            VendorStat(vendor_id=1, vendor_name="Sunny Kitchen", order_count=2, quantity=4, revenue_cents=3000)
+        ],
+        facility_distribution=[
+            FacilityStat(facility_id=1, facility_name="Fab 12A", order_count=2, quantity=4)
+        ],
+        daily_trend=[DayPoint(day=date(2026, 5, 1), order_count=2, revenue_cents=3000)],
+    )
+    assert stats.summary.order_count == 2
+    assert stats.vendor_ranking[0].vendor_name == "Sunny Kitchen"
+    assert stats.facility_distribution[0].facility_id == 1
+    assert stats.daily_trend[0].revenue_cents == 3000

--- a/backend/tests/test_admin_stats.py
+++ b/backend/tests/test_admin_stats.py
@@ -1,5 +1,9 @@
-from datetime import date
+from datetime import date, datetime, timezone
 
+import pytest
+
+from backend.core.errors import CodedHTTPException
+from backend.repositories.reporting_repository import ReportingRepository
 from backend.schemas.admin_stats import (
     DashboardStats,
     DayPoint,
@@ -7,6 +11,7 @@ from backend.schemas.admin_stats import (
     OrderSummary,
     VendorStat,
 )
+from backend.services.admin_stats_service import AdminStatsService
 
 
 def test_dashboard_stats_shape():
@@ -28,3 +33,30 @@ def test_dashboard_stats_shape():
     assert stats.vendor_ranking[0].vendor_name == "Sunny Kitchen"
     assert stats.facility_distribution[0].facility_id == 1
     assert stats.daily_trend[0].revenue_cents == 3000
+
+
+def _service_with_one_order() -> AdminStatsService:
+    repo = ReportingRepository()
+    repo.seed_order(
+        order_id=1, vendor_id=1, vendor_name="Sunny Kitchen",
+        facility_id=1, facility_name="Fab 12A", status="delivered",
+        created_at=datetime(2026, 5, 10, 12, 0, tzinfo=timezone.utc),
+        items=[(10, 2, 1000)],
+    )
+    return AdminStatsService(reporting_repository=repo)
+
+
+def test_service_assembles_dashboard():
+    svc = _service_with_one_order()
+    stats = svc.dashboard(date(2026, 5, 1), date(2026, 5, 31))
+    assert stats.summary.order_count == 1
+    assert stats.vendor_ranking[0].vendor_name == "Sunny Kitchen"
+    assert stats.start == date(2026, 5, 1)
+    assert stats.end == date(2026, 5, 31)
+
+
+def test_service_rejects_inverted_range():
+    svc = _service_with_one_order()
+    with pytest.raises(CodedHTTPException) as exc:
+        svc.dashboard(date(2026, 5, 31), date(2026, 5, 1))
+    assert exc.value.status_code == 400

--- a/backend/tests/test_admin_stats.py
+++ b/backend/tests/test_admin_stats.py
@@ -1,8 +1,11 @@
 from datetime import date, datetime, timezone
 
 import pytest
+from fastapi.testclient import TestClient
 
 from backend.core.errors import CodedHTTPException
+from backend.core.reporting import get_reporting_repository
+from backend.main import app
 from backend.repositories.reporting_repository import ReportingRepository
 from backend.schemas.admin_stats import (
     DashboardStats,
@@ -60,3 +63,46 @@ def test_service_rejects_inverted_range():
     with pytest.raises(CodedHTTPException) as exc:
         svc.dashboard(date(2026, 5, 31), date(2026, 5, 1))
     assert exc.value.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Route tests
+# ---------------------------------------------------------------------------
+
+client = TestClient(app)
+
+
+def _override_repo(repo):
+    app.dependency_overrides[get_reporting_repository] = lambda: repo
+
+
+def teardown_function():
+    app.dependency_overrides.clear()
+
+
+def test_stats_requires_admin_or_committee():
+    _override_repo(ReportingRepository())
+    r = client.get("/admin/stats", headers={"x-user-role": "employee"})
+    assert r.status_code == 403
+
+
+def test_stats_returns_payload_for_committee():
+    repo = ReportingRepository()
+    repo.seed_order(
+        order_id=1, vendor_id=1, vendor_name="Sunny Kitchen",
+        facility_id=1, facility_name="Fab 12A", status="delivered",
+        created_at=datetime.now(timezone.utc), items=[(10, 2, 1000)],
+    )
+    _override_repo(repo)
+    r = client.get("/admin/stats", headers={"x-user-role": "committee_reviewer"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["summary"]["order_count"] == 1
+    assert body["vendor_ranking"][0]["vendor_name"] == "Sunny Kitchen"
+
+
+def test_stats_rejects_inverted_range():
+    _override_repo(ReportingRepository())
+    r = client.get("/admin/stats?start=2026-05-31&end=2026-05-01",
+                   headers={"x-user-role": "admin"})
+    assert r.status_code == 400

--- a/backend/tests/test_reporting_repository.py
+++ b/backend/tests/test_reporting_repository.py
@@ -1,0 +1,75 @@
+from datetime import date, datetime, timezone
+
+from backend.repositories.reporting_repository import ReportingRepository
+
+W_START = date(2026, 5, 1)
+W_END = date(2026, 5, 31)
+
+
+def _ts(day: int) -> datetime:
+    return datetime(2026, 5, day, 12, 0, tzinfo=timezone.utc)
+
+
+def _seed(repo: ReportingRepository) -> None:
+    repo.seed_order(
+        order_id=1, vendor_id=1, vendor_name="Sunny Kitchen",
+        facility_id=1, facility_name="Fab 12A", status="delivered",
+        created_at=_ts(1), items=[(10, 2, 500), (11, 1, 1000)],
+    )
+    repo.seed_order(
+        order_id=2, vendor_id=1, vendor_name="Sunny Kitchen",
+        facility_id=1, facility_name="Fab 12A", status="pending",
+        created_at=_ts(2), items=[(10, 1, 500)],
+    )
+    repo.seed_order(
+        order_id=3, vendor_id=2, vendor_name="Noodle Bar",
+        facility_id=2, facility_name="Fab 14B", status="cancelled",
+        created_at=_ts(2), items=[(20, 5, 900)],
+    )
+
+
+def test_order_summary_excludes_cancelled():
+    repo = ReportingRepository()
+    _seed(repo)
+    s = repo.order_summary(W_START, W_END)
+    assert s.order_count == 2
+    assert s.total_quantity == 4
+    assert s.total_revenue_cents == 2500
+    assert s.active_vendor_count == 1
+
+
+def test_vendor_ranking():
+    repo = ReportingRepository()
+    _seed(repo)
+    ranking = repo.vendor_ranking(W_START, W_END, limit=10)
+    assert len(ranking) == 1
+    assert ranking[0].vendor_id == 1
+    assert ranking[0].order_count == 2
+    assert ranking[0].quantity == 4
+    assert ranking[0].revenue_cents == 2500
+
+
+def test_facility_distribution():
+    repo = ReportingRepository()
+    _seed(repo)
+    dist = repo.facility_distribution(W_START, W_END)
+    assert len(dist) == 1
+    assert dist[0].facility_id == 1
+    assert dist[0].quantity == 4
+
+
+def test_daily_trend_sorted():
+    repo = ReportingRepository()
+    _seed(repo)
+    trend = repo.daily_trend(W_START, W_END)
+    assert [p.day for p in trend] == [date(2026, 5, 1), date(2026, 5, 2)]
+    assert trend[0].revenue_cents == 2000
+    assert trend[1].revenue_cents == 500
+
+
+def test_window_excludes_out_of_range():
+    repo = ReportingRepository()
+    _seed(repo)
+    s = repo.order_summary(date(2026, 6, 1), date(2026, 6, 30))
+    assert s.order_count == 0
+    assert s.total_revenue_cents == 0

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -44,3 +44,11 @@ export function reviewVendorApplication(applicationId, { decision, reason }) {
     body: JSON.stringify({ decision, reason: reason || null }),
   });
 }
+
+export function getStats({ start, end } = {}) {
+  const params = new URLSearchParams();
+  if (start) params.set("start", start);
+  if (end) params.set("end", end);
+  const qs = params.toString();
+  return apiFetch(`/admin/stats${qs ? `?${qs}` : ""}`);
+}

--- a/frontend/src/pages/admin/AdminHomePage.jsx
+++ b/frontend/src/pages/admin/AdminHomePage.jsx
@@ -1,3 +1,5 @@
+import { Link } from "react-router-dom";
+
 export default function AdminHomePage() {
   return (
     <section className="dashboard-grid">
@@ -15,9 +17,9 @@ export default function AdminHomePage() {
         </p>
       </article>
       <article className="panel">
-        <h3>Next branch</h3>
+        <h3>Operations dashboard</h3>
         <p className="panel-copy">
-          `feat/admin-vendor-review` is the most direct follow-up task.
+          <Link to="/admin/stats">View ordering statistics</Link>
         </p>
       </article>
     </section>

--- a/frontend/src/pages/admin/AdminStatsPage.jsx
+++ b/frontend/src/pages/admin/AdminStatsPage.jsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+
+import { getStats } from "../../api/admin";
+import { formatPrice } from "../../utils/format";
+
+function Bar({ label, value, max }) {
+  const pct = max > 0 ? Math.round((value / max) * 100) : 0;
+  return (
+    <div className="stat-bar-row">
+      <span className="stat-bar-label">{label}</span>
+      <span className="stat-bar-track">
+        <span className="stat-bar-fill" style={{ width: `${pct}%` }} />
+      </span>
+      <span className="stat-bar-value">{value}</span>
+    </div>
+  );
+}
+
+export default function AdminStatsPage() {
+  const [stats, setStats] = useState(null);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    getStats()
+      .then((data) => {
+        if (active) setStats(data);
+      })
+      .catch(() => {
+        if (active) setError("Could not load statistics.");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (loading) return <section className="dashboard-grid"><p>Loading…</p></section>;
+  if (error) return <section className="dashboard-grid"><p className="error-state">{error}</p></section>;
+  if (!stats) return null;
+
+  const trendMax = Math.max(1, ...stats.daily_trend.map((p) => p.order_count));
+
+  return (
+    <section className="dashboard-grid">
+      <article className="panel">
+        <p className="eyebrow">Operations</p>
+        <h2>Ordering overview</h2>
+        <p className="panel-copy">{stats.start} → {stats.end}</p>
+      </article>
+
+      <article className="panel stat-cards">
+        <div className="stat-card"><span>Orders</span><strong>{stats.summary.order_count}</strong></div>
+        <div className="stat-card"><span>Revenue</span><strong>{formatPrice(stats.summary.total_revenue_cents)}</strong></div>
+        <div className="stat-card"><span>Meals</span><strong>{stats.summary.total_quantity}</strong></div>
+        <div className="stat-card"><span>Active vendors</span><strong>{stats.summary.active_vendor_count}</strong></div>
+      </article>
+
+      <article className="panel">
+        <h3>Daily orders</h3>
+        {stats.daily_trend.map((p) => (
+          <Bar key={p.day} label={p.day} value={p.order_count} max={trendMax} />
+        ))}
+        {stats.daily_trend.length === 0 && <p className="panel-copy">No orders in range.</p>}
+      </article>
+
+      <article className="panel">
+        <h3>Top vendors</h3>
+        <table className="data-table">
+          <thead><tr><th>Vendor</th><th>Orders</th><th>Meals</th><th>Revenue</th></tr></thead>
+          <tbody>
+            {stats.vendor_ranking.map((v) => (
+              <tr key={v.vendor_id}>
+                <td>{v.vendor_name}</td><td>{v.order_count}</td><td>{v.quantity}</td>
+                <td>{formatPrice(v.revenue_cents)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </article>
+
+      <article className="panel">
+        <h3>By facility</h3>
+        <table className="data-table">
+          <thead><tr><th>Facility</th><th>Orders</th><th>Meals</th></tr></thead>
+          <tbody>
+            {stats.facility_distribution.map((f) => (
+              <tr key={f.facility_id ?? "none"}>
+                <td>{f.facility_name ?? "Unassigned"}</td><td>{f.order_count}</td><td>{f.quantity}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </article>
+    </section>
+  );
+}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -4,6 +4,7 @@ import AppShell from "../layout/AppShell";
 import { roleHomePath } from "../layout/navigation";
 import AdminAuditPage from "../pages/admin/AdminAuditPage";
 import AdminHomePage from "../pages/admin/AdminHomePage";
+import AdminStatsPage from "../pages/admin/AdminStatsPage";
 import AdminPermissionsPage from "../pages/admin/AdminPermissionsPage";
 import AdminVendorReviewDetailPage from "../pages/admin/AdminVendorReviewDetailPage";
 import AdminVendorReviewListPage from "../pages/admin/AdminVendorReviewListPage";
@@ -98,6 +99,7 @@ export function AppRouter() {
             <Route element={<AdminVendorReviewDetailPage />} path="/admin/vendors/:applicationId" />
             <Route element={<AdminPermissionsPage />} path="/admin/permissions" />
             <Route element={<AdminAuditPage />} path="/admin/audit" />
+            <Route element={<AdminStatsPage />} path="/admin/stats" />
           </Route>
 
           <Route

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -971,6 +971,72 @@ p {
   font-weight: 700;
 }
 
+/* ============================================================
+   Admin stats dashboard  (feat/analytics/order-aggregation-monitoring)
+   ============================================================ */
+
+.stat-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+
+.stat-card {
+  display: grid;
+  gap: 4px;
+  flex: 1 1 140px;
+  padding: 16px 20px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid var(--line);
+}
+
+.stat-card span {
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stat-card strong {
+  font-size: 1.6rem;
+  font-weight: 800;
+  color: var(--text);
+  line-height: 1.1;
+}
+
+.stat-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.stat-bar-label {
+  flex: 0 0 120px;
+  color: var(--muted);
+  font-size: 0.88rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stat-bar-track {
+  flex: 1 1 0;
+  height: 14px;
+  border-radius: 999px;
+  background: var(--line);
+  overflow: hidden;
+}
+
+.stat-bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--brand) 0%, #d77431 100%);
+  /* width is set inline by the component */
+}
+
 @media (max-width: 1080px) {
   .login-shell,
   .dashboard-grid,

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1037,6 +1037,27 @@ p {
   /* width is set inline by the component */
 }
 
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.data-table th,
+.data-table td {
+  padding: 8px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--line);
+}
+
+.data-table th {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
 @media (max-width: 1080px) {
   .login-shell,
   .dashboard-grid,


### PR DESCRIPTION
Closes #106.

## What

Adds a reusable order-aggregation layer and a committee monitoring dashboard (req 5 — 福委會監控整體訂餐數據).

### Backend
- **`ReportingRepository`** (in-memory) + **`PostgresReportingRepository`** (SQL `GROUP BY`), selected by a `core/reporting.py` factory (mirrors `core/audit.py`). Methods: `order_summary`, `vendor_ranking`, `facility_distribution`, `daily_trend`.
- **`AdminStatsService`** assembles a `DashboardStats` payload (constructor-injected repo, range validation).
- **`GET /admin/stats?start=&end=`** guarded by `admin` + `committee_reviewer`; omitted params default to the last 30 days.

### Frontend
- New `AdminStatsPage` at `/admin/stats`: summary cards, daily-trend CSS bars, vendor-ranking and facility-distribution tables. Linked from the admin home. No chart library (consistent with the plain HTML/CSS stack).

## Decisions
- Stats count `status <> 'cancelled'` (pre-order = commitment); date dimension is `created_at` (orders.meal_date is nullable).
- On-the-fly SQL aggregation (no caching) — course-scale data.

## Foundation for later work
The aggregation layer is intentionally reused by #105 (recommendation `top_items`) and #108 (billing monthly receivables).

## Tests
- Unit: schemas, in-memory aggregations, service assembly + range validation, route RBAC + default window.
- Integration (Postgres): aggregations verified against a live DB, cancelled-order exclusion confirmed.
- Full suite: 221 passed, 18 skipped (DB integration skips without `DATABASE_URL`), 0 failed.
