### PR TITLE
chore(ci): rename workflow to CI + make GHCR prune open-PR-aware (#111)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: CI
 
 on:
   pull_request:

--- a/Jenkinsfile.cleanup
+++ b/Jenkinsfile.cleanup
@@ -2,9 +2,10 @@ pipeline {
   agent any
   options { timeout(time: 10, unit: 'MINUTES'); timestamps() }
 
-  // Hourly defensive sweep. PR preview is disabled, so this should normally
-  // be a no-op; it exists to clean stray mealorder-pr-* projects if previews
-  // are ever re-enabled.
+  // Hourly maintenance: self-heal the shared preview router, sweep preview
+  // stacks whose PR has closed, and prune GHCR images. PR previews are active,
+  // so this is load-bearing — it keeps stray stacks and old images from piling
+  // up while never deleting anything still in use by an open PR.
   triggers {
     cron('H * * * *')
   }
@@ -39,7 +40,10 @@ pipeline {
 
     stage('Prune GHCR images') {
       // Retention per package (mealorder-{backend,frontend,db,gateway}):
-      //   - pr-*  : keep newest KEEP_PR
+      //   - pr-*  : keep every image whose PR is still OPEN; delete pr-<N>
+      //     only once PR #N is closed/merged (its preview stack is gone too).
+      //     Keying on recency instead broke open-PR previews (#111): an older
+      //     but still-open PR's images got pruned -> manifest unknown -> 502.
       //   - sha-* : keep newest KEEP_SHA
       //   - v*    : keep all (releases) — never touched
       //   - untagged: deleted (orphaned manifests from overwritten tags; safe
@@ -52,9 +56,15 @@ pipeline {
           sh '''
             set -euo pipefail
             OWNER=mizu5555
-            KEEP_PR=3
+            REPO=Corporate-Meal-Ordering-System
             KEEP_SHA=5
             FAILED=0
+
+            # PR numbers that are still OPEN — their preview images must never be
+            # pruned. If this API call errors, set -e aborts before any deletion
+            # (so a transient failure can't wipe every pr-* image).
+            OPEN_PRS=$(gh pr list -R "${OWNER}/${REPO}" --state open --limit 200 \
+                         --json number --jq 'map(.number|tostring)|join(" ")')
 
             ids_untagged() {
               echo "$1" | jq -r '.[] | select((.metadata.container.tags // []) | length == 0) | .id'
@@ -64,12 +74,26 @@ pipeline {
                 [ .[] | select((.metadata.container.tags // []) | any(startswith($pre))) ]
                 | sort_by(.created_at) | reverse | .[$keep:] | .[].id'
             }
+            ids_closed_pr() {  # $1=versions json  $2=space-separated open PR numbers
+              # A pr-* version is deletable only when ALL of its pr-<N> tags map to
+              # CLOSED PRs; if any tag is for an open PR the version is kept.
+              echo "$1" | jq -r --arg open "$2" '
+                ($open | split(" ") | map(select(length > 0))) as $openlist
+                | .[]
+                | select((.metadata.container.tags // []) | any(startswith("pr-")))
+                | select(
+                    (.metadata.container.tags // [])
+                    | map(select(startswith("pr-")) | ltrimstr("pr-"))
+                    | all(. as $n | ($openlist | index($n)) == null)
+                  )
+                | .id'
+            }
 
             for svc in backend frontend db gateway; do
               PKG="mealorder-${svc}"
               ALL=$(gh api --paginate "/users/${OWNER}/packages/container/${PKG}/versions")
               for VID in $(ids_untagged "$ALL") \
-                         $(ids_old_for_prefix "$ALL" "pr-"  "$KEEP_PR") \
+                         $(ids_closed_pr "$ALL" "$OPEN_PRS") \
                          $(ids_old_for_prefix "$ALL" "sha-" "$KEEP_SHA"); do
                 [ -z "$VID" ] && continue
                 if gh api -X DELETE "/users/${OWNER}/packages/container/${PKG}/versions/${VID}"; then


### PR DESCRIPTION
Closes #111.

Two CI/CD changes bundled (both touch the GitHub-Actions / Jenkins boundary):

### 1. Rename workflow `CI/CD` -> `CI`
`.github/workflows/test.yml` only does CI-side work (tests, SonarCloud, build/push GHCR) and *triggers* Jenkins. The actual deployment (CD) is Jenkins, so the name was misleading.

### 2. Fix GHCR prune deleting open-PR images (`Jenkinsfile.cleanup`)
The hourly prune kept only the newest `KEEP_PR=3` `pr-*` versions per package by recency, ignoring PR state — so an older but still-open PR's images were deleted, causing `docker compose pull` `manifest unknown` and a **502** preview (observed on pr-110: backend/frontend gone, db/gateway kept because their deletes lacked package-admin).

Now retention is **open-PR-aware**: a `pr-<N>` version is deleted only once PR #N is closed/merged (its preview stack is torn down anyway). Untagged and `sha-*` pruning unchanged. The stale "PR preview is disabled" header comment is refreshed.

> Note: the `github-token` used by the cleanup job still needs `delete:packages` + admin on the `mealorder-db` / `mealorder-gateway` packages, or those deletes keep failing (stage exits 1).
