### PR TITLE
feat(frontend): stats dashboard polish + login show-password toggle (#114, #115)

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -10,6 +10,7 @@ export default function LoginPage() {
 
   const [email, setEmail]       = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError]       = useState(null);
   const [loading, setLoading]   = useState(false);
 
@@ -83,15 +84,37 @@ export default function LoginPage() {
           </label>
           <label style={{ display: "grid", gap: 6 }}>
             <span style={{ fontWeight: 600, fontSize: 14 }}>Password</span>
-            <input
-              className="form-input"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              placeholder="••••••••"
-              autoComplete="current-password"
-            />
+            <span className="pw-field">
+              <input
+                className="form-input"
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                placeholder="••••••••"
+                autoComplete="current-password"
+              />
+              <button
+                type="button"
+                className="pw-toggle"
+                onClick={() => setShowPassword((s) => !s)}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                aria-pressed={showPassword}
+                title={showPassword ? "Hide password" : "Show password"}
+              >
+                {showPassword ? (
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+                    <line x1="1" y1="1" x2="23" y2="23" />
+                  </svg>
+                ) : (
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                    <circle cx="12" cy="12" r="3" />
+                  </svg>
+                )}
+              </button>
+            </span>
           </label>
           {error && <p className="error-state" style={{ margin: 0 }}>{error}</p>}
           <button className="primary-button" type="submit" disabled={loading}>

--- a/frontend/src/pages/admin/AdminStatsPage.jsx
+++ b/frontend/src/pages/admin/AdminStatsPage.jsx
@@ -9,8 +9,8 @@ const RANGES = [
   { days: 90, label: "近 90 天" },
 ];
 
-function isoDaysAgo(n) {
-  const d = new Date();
+function isoDaysBefore(base, n) {
+  const d = new Date(base);
   d.setDate(d.getDate() - n);
   return d.toISOString().slice(0, 10);
 }
@@ -92,7 +92,8 @@ export default function AdminStatsPage() {
     let active = true;
     setLoading(true);
     setError(null);
-    getStats({ start: isoDaysAgo(rangeDays - 1), end: isoDaysAgo(0) })
+    const today = new Date();
+    getStats({ start: isoDaysBefore(today, rangeDays - 1), end: isoDaysBefore(today, 0) })
       .then((data) => {
         if (active) setStats(data);
       })

--- a/frontend/src/pages/admin/AdminStatsPage.jsx
+++ b/frontend/src/pages/admin/AdminStatsPage.jsx
@@ -3,16 +3,82 @@ import { useEffect, useState } from "react";
 import { getStats } from "../../api/admin";
 import { formatPrice } from "../../utils/format";
 
-function Bar({ label, value, max }) {
-  const pct = max > 0 ? Math.round((value / max) * 100) : 0;
+const RANGES = [
+  { days: 7, label: "近 7 天" },
+  { days: 30, label: "近 30 天" },
+  { days: 90, label: "近 90 天" },
+];
+
+function isoDaysAgo(n) {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+function sharePct(part, total) {
+  if (!total) return "—";
+  return `${((part / total) * 100).toFixed(1)}%`;
+}
+
+function shortDay(iso) {
+  const [, m, d] = iso.split("-");
+  return `${Number(m)}/${Number(d)}`;
+}
+
+// Vertical column chart for the daily order trend. Pure inline SVG — no chart
+// library — so it stays within the plain HTML/CSS stack. Column height is
+// proportional to that day's order count relative to the busiest day.
+function ColumnChart({ data }) {
+  if (data.length === 0) return <p className="panel-copy">此區間無訂單資料。</p>;
+
+  const max = Math.max(1, ...data.map((p) => p.order_count));
+  const STEP = 34;
+  const BAR = 18;
+  const H = 200;
+  const PAD_TOP = 22;
+  const PAD_BOTTOM = 28;
+  const plotH = H - PAD_TOP - PAD_BOTTOM;
+  const W = Math.max(data.length * STEP, STEP);
+  const labelEvery = Math.ceil(data.length / 12);
+
   return (
-    <div className="stat-bar-row">
-      <span className="stat-bar-label">{label}</span>
-      <span className="stat-bar-track">
-        <span className="stat-bar-fill" style={{ width: `${pct}%` }} />
-      </span>
-      <span className="stat-bar-value">{value}</span>
-    </div>
+    <svg
+      className="col-chart"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-label="每日訂單數柱狀圖"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      <defs>
+        <linearGradient id="colFill" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" style={{ stopColor: "var(--accent)" }} />
+          <stop offset="100%" style={{ stopColor: "var(--brand)" }} />
+        </linearGradient>
+      </defs>
+      <line x1="0" y1={H - PAD_BOTTOM} x2={W} y2={H - PAD_BOTTOM} stroke="var(--line)" />
+      {data.map((p, i) => {
+        const h = (p.order_count / max) * plotH;
+        const x = i * STEP + (STEP - BAR) / 2;
+        const y = H - PAD_BOTTOM - h;
+        const cx = i * STEP + STEP / 2;
+        return (
+          <g key={p.day}>
+            <title>{`${p.day}：${p.order_count} 筆`}</title>
+            <rect x={x} y={y} width={BAR} height={Math.max(h, 2)} rx="4" fill="url(#colFill)" />
+            {data.length <= 14 && (
+              <text x={cx} y={y - 6} textAnchor="middle" className="col-chart-val">
+                {p.order_count}
+              </text>
+            )}
+            {i % labelEvery === 0 && (
+              <text x={cx} y={H - PAD_BOTTOM + 16} textAnchor="middle" className="col-chart-lab">
+                {shortDay(p.day)}
+              </text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
   );
 }
 
@@ -20,16 +86,18 @@ export default function AdminStatsPage() {
   const [stats, setStats] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [rangeDays, setRangeDays] = useState(30);
 
   useEffect(() => {
     let active = true;
     setLoading(true);
-    getStats()
+    setError(null);
+    getStats({ start: isoDaysAgo(rangeDays - 1), end: isoDaysAgo(0) })
       .then((data) => {
         if (active) setStats(data);
       })
       .catch(() => {
-        if (active) setError("Could not load statistics.");
+        if (active) setError("無法載入統計資料。");
       })
       .finally(() => {
         if (active) setLoading(false);
@@ -37,65 +105,138 @@ export default function AdminStatsPage() {
     return () => {
       active = false;
     };
-  }, []);
+  }, [rangeDays]);
 
-  if (loading) return <section className="dashboard-grid"><p>Loading…</p></section>;
-  if (error) return <section className="dashboard-grid"><p className="error-state">{error}</p></section>;
-  if (!stats) return null;
-
-  const trendMax = Math.max(1, ...stats.daily_trend.map((p) => p.order_count));
+  const totalRevenue = stats?.summary.total_revenue_cents ?? 0;
+  const totalMeals = stats?.summary.total_quantity ?? 0;
 
   return (
     <section className="dashboard-grid">
       <article className="panel">
-        <p className="eyebrow">Operations</p>
-        <h2>Ordering overview</h2>
-        <p className="panel-copy">{stats.start} → {stats.end}</p>
+        <p className="eyebrow">營運概況</p>
+        <h2>訂餐總覽</h2>
+        {stats && (
+          <p className="panel-copy">
+            {stats.start} → {stats.end}
+          </p>
+        )}
+        <div className="range-pills" role="group" aria-label="日期區間">
+          {RANGES.map((r) => (
+            <button
+              key={r.days}
+              type="button"
+              className={`range-pill${rangeDays === r.days ? " is-active" : ""}`}
+              onClick={() => setRangeDays(r.days)}
+              aria-pressed={rangeDays === r.days}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
       </article>
 
-      <article className="panel stat-cards">
-        <div className="stat-card"><span>Orders</span><strong>{stats.summary.order_count}</strong></div>
-        <div className="stat-card"><span>Revenue</span><strong>{formatPrice(stats.summary.total_revenue_cents)}</strong></div>
-        <div className="stat-card"><span>Meals</span><strong>{stats.summary.total_quantity}</strong></div>
-        <div className="stat-card"><span>Active vendors</span><strong>{stats.summary.active_vendor_count}</strong></div>
-      </article>
+      {loading && (
+        <article className="panel">
+          <p className="panel-copy">載入中…</p>
+        </article>
+      )}
+      {error && (
+        <article className="panel">
+          <p className="error-state">{error}</p>
+        </article>
+      )}
 
-      <article className="panel">
-        <h3>Daily orders</h3>
-        {stats.daily_trend.map((p) => (
-          <Bar key={p.day} label={p.day} value={p.order_count} max={trendMax} />
-        ))}
-        {stats.daily_trend.length === 0 && <p className="panel-copy">No orders in range.</p>}
-      </article>
+      {stats && !loading && !error && (
+        <>
+          <article className="panel stat-cards">
+            <div className="stat-card">
+              <span>訂單數</span>
+              <strong>{stats.summary.order_count}</strong>
+            </div>
+            <div className="stat-card">
+              <span>營收</span>
+              <strong>{formatPrice(totalRevenue)}</strong>
+            </div>
+            <div className="stat-card">
+              <span>餐點數</span>
+              <strong>{totalMeals}</strong>
+            </div>
+            <div className="stat-card">
+              <span>活躍商家</span>
+              <strong>{stats.summary.active_vendor_count}</strong>
+            </div>
+          </article>
 
-      <article className="panel">
-        <h3>Top vendors</h3>
-        <table className="data-table">
-          <thead><tr><th>Vendor</th><th>Orders</th><th>Meals</th><th>Revenue</th></tr></thead>
-          <tbody>
-            {stats.vendor_ranking.map((v) => (
-              <tr key={v.vendor_id}>
-                <td>{v.vendor_name}</td><td>{v.order_count}</td><td>{v.quantity}</td>
-                <td>{formatPrice(v.revenue_cents)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </article>
+          <article className="panel">
+            <h3>每日訂單</h3>
+            <ColumnChart data={stats.daily_trend} />
+          </article>
 
-      <article className="panel">
-        <h3>By facility</h3>
-        <table className="data-table">
-          <thead><tr><th>Facility</th><th>Orders</th><th>Meals</th></tr></thead>
-          <tbody>
-            {stats.facility_distribution.map((f) => (
-              <tr key={f.facility_id ?? "none"}>
-                <td>{f.facility_name ?? "Unassigned"}</td><td>{f.order_count}</td><td>{f.quantity}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </article>
+          <article className="panel">
+            <h3>商家排行</h3>
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>商家</th>
+                  <th>訂單</th>
+                  <th>餐點</th>
+                  <th>營收</th>
+                  <th>佔比</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stats.vendor_ranking.map((v) => (
+                  <tr key={v.vendor_id}>
+                    <td>{v.vendor_name}</td>
+                    <td>{v.order_count}</td>
+                    <td>{v.quantity}</td>
+                    <td>{formatPrice(v.revenue_cents)}</td>
+                    <td>{sharePct(v.revenue_cents, totalRevenue)}</td>
+                  </tr>
+                ))}
+                {stats.vendor_ranking.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="table-empty">
+                      此區間無資料
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </article>
+
+          <article className="panel">
+            <h3>廠區分布</h3>
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>廠區</th>
+                  <th>訂單</th>
+                  <th>餐點</th>
+                  <th>佔比</th>
+                </tr>
+              </thead>
+              <tbody>
+                {stats.facility_distribution.map((f) => (
+                  <tr key={f.facility_id ?? "none"}>
+                    <td>{f.facility_name ?? "未指派"}</td>
+                    <td>{f.order_count}</td>
+                    <td>{f.quantity}</td>
+                    <td>{sharePct(f.quantity, totalMeals)}</td>
+                  </tr>
+                ))}
+                {stats.facility_distribution.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="table-empty">
+                      此區間無資料
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </article>
+        </>
+      )}
     </section>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1006,35 +1006,95 @@ p {
   line-height: 1.1;
 }
 
-.stat-bar-row {
+/* Date-range presets on the stats dashboard */
+.range-pills {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 8px;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
 }
 
-.stat-bar-label {
-  flex: 0 0 120px;
+.range-pill {
+  border: 1px solid var(--line);
+  background: var(--surface-strong);
   color: var(--muted);
-  font-size: 0.88rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 
-.stat-bar-track {
-  flex: 1 1 0;
-  height: 14px;
-  border-radius: 999px;
+.range-pill:hover {
+  border-color: var(--brand);
+  color: var(--brand);
+}
+
+.range-pill.is-active {
+  background: var(--brand);
+  border-color: var(--brand);
+  color: var(--surface-strong);
+}
+
+/* Daily-orders column chart (inline SVG) */
+.col-chart {
+  width: 100%;
+  height: auto;
+  max-height: 220px;
+  display: block;
+  margin-top: 6px;
+}
+
+.col-chart-val {
+  fill: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.col-chart-lab {
+  fill: var(--muted);
+  font-size: 10px;
+}
+
+.table-empty {
+  text-align: center;
+  color: var(--muted);
+  padding: 18px 12px;
+}
+
+/* Password field with a show/hide toggle */
+.pw-field {
+  position: relative;
+  display: block;
+}
+
+.pw-field .form-input {
+  width: 100%;
+  padding-right: 44px;
+}
+
+.pw-toggle {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  border-radius: 8px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.pw-toggle:hover {
+  color: var(--brand);
   background: var(--line);
-  overflow: hidden;
-}
-
-.stat-bar-fill {
-  height: 100%;
-  border-radius: 999px;
-  background: linear-gradient(90deg, var(--brand) 0%, #d77431 100%);
-  /* width is set inline by the component */
 }
 
 .data-table {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1037,6 +1037,16 @@ p {
   color: var(--surface-strong);
 }
 
+.range-pill.is-active:hover {
+  color: var(--surface-strong);
+}
+
+.range-pill:focus-visible,
+.pw-toggle:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
 /* Daily-orders column chart (inline SVG) */
 .col-chart {
   width: 100%;


### PR DESCRIPTION
Closes #114, closes #115.

Frontend UX batch (pure frontend, no backend changes).

### Dashboard polish — #114 (`AdminStatsPage`)
- **Daily orders → inline-SVG column chart** (no chart library). Replaces the horizontal CSS bars whose colored fill never rendered (the inline `.stat-bar-fill` had no `display`, so only the gray track showed). Column height ∝ that day's order count; native `<title>` shows `date：N 筆`.
- **Date-range selector** — 近 7 / 30 / 90 天 pills, wired to `GET /admin/stats?start=&end=` (backend already supported it; the page was hardcoded to 30 days).
- **Traditional-Chinese labels** — aligns with the other admin pages (was English).
- **Empty states** on the vendor-ranking and facility tables.
- **Share-% column** on both tables (vendor by revenue, facility by meals; divide-by-zero guarded).
- Removed the now-dead `.stat-bar-*` CSS.

### Login — #115 (`LoginPage`)
- **Show/hide password eye toggle** — switches input `type`, with `aria-label` + `aria-pressed`; inline SVG, no new dependency. (Login page stays English, so its aria-labels are English for consistency.)

### Notes
- Verified with `npm run build` (no test framework on the frontend).
- A code review pass approved the change; minor fixes folded in (focus-visible rings, active-pill hover readability, single date base to avoid midnight drift).
- Deferred styling ideas (backlog): SVG y-axis gridlines, custom hover tooltip, single-data-point centering, responsive column spacing, mobile table horizontal scroll.
