### PR TITLE
fix(ci): push images without provenance/sbom + verify pullable (refs #109)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,17 @@ jobs:
           tags: ghcr.io/mizu5555/mealorder-${{ matrix.name }}:${{ needs.meta.outputs.image_tag }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+          # Push a single self-contained image manifest per tag. With the default
+          # provenance/SBOM attestations the tag becomes an index referencing
+          # UNTAGGED child manifests; the hourly GHCR prune (Jenkinsfile.cleanup
+          # ids_untagged) then deletes those children, corrupting the tagged image
+          # into "manifest unknown" on pull (broke pr-110 / pr-117 previews).
+          provenance: false
+          sbom: false
+      - name: Verify pushed image is pullable
+        # Fail loudly if the tag did not land as a complete, pullable manifest,
+        # instead of a green build-push followed by a silent "manifest unknown".
+        run: docker buildx imagetools inspect "ghcr.io/mizu5555/mealorder-${{ matrix.name }}:${{ needs.meta.outputs.image_tag }}"
 
   promote:
     needs: integration


### PR DESCRIPTION
Refs #109 (does not close it — one of the ops-reliability items).

## Problem
`deploy-preview` kept going green while no preview came up (502, `manifest unknown` on backend/frontend, db/gateway fine) — repeatedly, on #110 and #117.

Root cause: `docker/build-push-action@v6` attaches **provenance/SBOM attestations by default**, so each pushed tag is a manifest **index** referencing **untagged** child manifests. The hourly GHCR prune (`Jenkinsfile.cleanup` `ids_untagged`) deletes untagged versions → it removes children the tagged index points at → the tag becomes unpullable (`manifest unknown`). Whether it breaks depends on which untagged child the prune hits, hence intermittent and image-specific.

## Fix
- `provenance: false` + `sbom: false` on build-push → each tag is a single self-contained manifest with no untagged children for the prune to delete.
- New **`Verify pushed image is pullable`** step (`docker buildx imagetools inspect`) → a push that didn't land as a complete manifest now **fails the job** instead of going silently green.

Confirmed the open-PR-aware prune itself is correct (it keeps open-PR tags, deletes closed-PR + genuinely-orphaned untagged).