### PR TITLE
feat(recommendation): sales-based 熱門推薦 (#105)

### DIFF
--- a/backend/repositories/postgres_reporting_repository.py
+++ b/backend/repositories/postgres_reporting_repository.py
@@ -135,7 +135,9 @@ class PostgresReportingRepository:
             for r in rows
         ]
 
-    def top_items(self, start, end, limit, vendor_ids=None):
+    def top_items(
+        self, start: date, end: date, limit: int, vendor_ids: list[int] | None = None
+    ) -> list[ItemSales]:
         where = ["o.status <> 'cancelled'", "o.created_at::date BETWEEN %s AND %s", "oi.item_id IS NOT NULL"]
         values = [start, end]
         if vendor_ids is not None:

--- a/backend/repositories/postgres_reporting_repository.py
+++ b/backend/repositories/postgres_reporting_repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date
 
 from backend.db.connection import get_connection
-from backend.schemas.admin_stats import DayPoint, FacilityStat, OrderSummary, VendorStat
+from backend.schemas.admin_stats import DayPoint, FacilityStat, ItemSales, OrderSummary, VendorStat
 from backend.schemas.billing import EmployeeTotal, VendorReceivable
 
 _WINDOW = "o.status <> 'cancelled' AND o.created_at::date BETWEEN %s AND %s"
@@ -132,6 +132,33 @@ class PostgresReportingRepository:
                 order_count=int(r["order_count"]), quantity=int(r["quantity"]),
                 amount_cents=int(r["amount_cents"]),
             )
+            for r in rows
+        ]
+
+    def top_items(self, start, end, limit, vendor_ids=None):
+        where = ["o.status <> 'cancelled'", "o.created_at::date BETWEEN %s AND %s", "oi.item_id IS NOT NULL"]
+        values = [start, end]
+        if vendor_ids is not None:
+            where.append("o.vendor_id = ANY(%s)")
+            values.append(list(vendor_ids))
+        values.append(limit)
+        with get_connection() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT oi.item_id, MIN(o.vendor_id) AS vendor_id,
+                       COALESCE(SUM(oi.quantity), 0) AS quantity_sold
+                FROM orders o
+                JOIN order_items oi ON oi.order_id = o.id
+                WHERE {" AND ".join(where)}
+                GROUP BY oi.item_id
+                ORDER BY quantity_sold DESC
+                LIMIT %s
+                """,
+                values,
+            ).fetchall()
+        return [
+            ItemSales(item_id=int(r["item_id"]), vendor_id=int(r["vendor_id"]),
+                      quantity_sold=int(r["quantity_sold"]))
             for r in rows
         ]
 

--- a/backend/repositories/reporting_repository.py
+++ b/backend/repositories/reporting_repository.py
@@ -173,7 +173,9 @@ class ReportingRepository:
         rows.sort(key=lambda r: r.amount_cents, reverse=True)
         return rows
 
-    def top_items(self, start, end, limit, vendor_ids=None):
+    def top_items(
+        self, start: date, end: date, limit: int, vendor_ids: list[int] | None = None
+    ) -> list[ItemSales]:
         allowed = set(vendor_ids) if vendor_ids is not None else None
         acc: dict[int, dict] = {}
         for r in self._qualifying(start, end):

--- a/backend/repositories/reporting_repository.py
+++ b/backend/repositories/reporting_repository.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date, datetime
 
-from backend.schemas.admin_stats import DayPoint, FacilityStat, OrderSummary, VendorStat
+from backend.schemas.admin_stats import DayPoint, FacilityStat, ItemSales, OrderSummary, VendorStat
 from backend.schemas.billing import EmployeeTotal, VendorReceivable
 
 
@@ -172,6 +172,22 @@ class ReportingRepository:
         ]
         rows.sort(key=lambda r: r.amount_cents, reverse=True)
         return rows
+
+    def top_items(self, start, end, limit, vendor_ids=None):
+        allowed = set(vendor_ids) if vendor_ids is not None else None
+        acc: dict[int, dict] = {}
+        for r in self._qualifying(start, end):
+            if allowed is not None and r.vendor_id not in allowed:
+                continue
+            for item_id, qty, _unit in r.items:
+                a = acc.setdefault(item_id, {"vendor_id": r.vendor_id, "quantity_sold": 0})
+                a["quantity_sold"] += qty
+        rows = [
+            ItemSales(item_id=iid, vendor_id=a["vendor_id"], quantity_sold=a["quantity_sold"])
+            for iid, a in acc.items()
+        ]
+        rows.sort(key=lambda r: r.quantity_sold, reverse=True)
+        return rows[:limit]
 
     def employee_monthly_totals(self, year: int, month: int) -> list[EmployeeTotal]:
         acc: dict[int, dict] = {}

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -1,6 +1,7 @@
 """Employee-facing vendor browsing, menu browsing, and meal selection APIs."""
 from __future__ import annotations
 
+from datetime import date
 from typing import Annotated
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Query, Response, status
@@ -27,6 +28,7 @@ from backend.schemas.employee import (
     PickupLabel,
     RandomMealDraw,
     RandomMealDrawRequest,
+    RecommendedItem,
 )
 from backend.schemas.vendor_self import Facility
 from backend.services.employee_ordering_service import EmployeeOrderingService
@@ -96,6 +98,17 @@ def list_my_facilities(
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
 ) -> list[Facility]:
     return service.list_employee_facilities(employee_id)
+
+
+@router.get("/recommendations", response_model=list[RecommendedItem])
+def list_recommendations(
+    employee_id: Annotated[int, Depends(require_employee)],
+    service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+    facility_id: int | None = None,
+    meal_date: date | None = None,
+    limit: Annotated[int, Query(ge=1, le=50)] = 8,
+) -> list[RecommendedItem]:
+    return service.recommend(employee_id=employee_id, facility_id=facility_id, meal_date=meal_date, limit=limit)
 
 
 @router.post("/random-meals/draw", response_model=RandomMealDraw)

--- a/backend/schemas/admin_stats.py
+++ b/backend/schemas/admin_stats.py
@@ -33,6 +33,12 @@ class DayPoint(BaseModel):
     revenue_cents: int
 
 
+class ItemSales(BaseModel):
+    item_id: int
+    vendor_id: int
+    quantity_sold: int
+
+
 class DashboardStats(BaseModel):
     start: date
     end: date

--- a/backend/schemas/employee.py
+++ b/backend/schemas/employee.py
@@ -136,3 +136,11 @@ class RandomMealDraw(BaseModel):
     vendor: EmployeeVendor
     item: EmployeeMenuItem
     remaining_quantity: int | None = None
+
+
+class RecommendedItem(BaseModel):
+    vendor: EmployeeVendor
+    item: EmployeeMenuItem
+    quantity_sold: int
+    remaining_quantity: int | None = None
+    from_sales: bool = True

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -5,6 +5,7 @@ import random
 from datetime import date, timedelta
 
 from backend.core.errors import CodedHTTPException
+from backend.core.reporting import get_reporting_repository
 from backend.core.order_failure_codes import ITEM_UNAVAILABLE, QUOTA_EXHAUSTED
 from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository, OrderItemSnapshot
@@ -23,6 +24,7 @@ from backend.schemas.employee import (
     PickupLabelItem,
     RandomMealDraw,
     RandomMealDrawRequest,
+    RecommendedItem,
 )
 from backend.schemas.vendor_self import Facility, MenuItem as VendorMenuItem
 
@@ -36,11 +38,13 @@ class EmployeeOrderingService:
         menu_item_repository: MenuItemRepository,
         selection_repository: EmployeeSelectionRepository,
         audit_log_repository: AuditLogRepository | None = None,
+        reporting_repository=None,
     ) -> None:
         self.vendor_repository = vendor_repository
         self.menu_item_repository = menu_item_repository
         self.selection_repository = selection_repository
         self.audit_log_repository = audit_log_repository or AuditLogRepository()
+        self.reporting_repository = reporting_repository or get_reporting_repository()
 
     def list_vendors(
         self,
@@ -215,6 +219,92 @@ class EmployeeOrderingService:
             item=self._menu_item_to_schema(item),
             remaining_quantity=remaining,
         )
+
+    def recommend(
+        self,
+        *,
+        employee_id: int | None = None,
+        facility_id: int | None = None,
+        meal_date: date | None = None,
+        limit: int = 8,
+    ) -> list[RecommendedItem]:
+        target_date = meal_date or date.today()
+
+        # Build visible approved vendor schemas (reuse same pattern as draw_random_meal)
+        all_approved = self.vendor_repository.list(status="approved")
+        if employee_id is not None:
+            visible = self._filter_vendors_by_facility(
+                [self._vendor_to_schema(v) for v in all_approved],
+                employee_id,
+                facility_id=facility_id,
+            )
+        else:
+            visible = [self._vendor_to_schema(v) for v in all_approved]
+
+        if not visible:
+            return []
+
+        visible_ids = [v.id for v in visible]
+        vendor_by_id = {v.id: v for v in visible}
+
+        used = self.selection_repository.item_quantities_for_date(
+            meal_date=target_date,
+            vendor_ids=visible_ids,
+        )
+
+        # Build item_by_id: {item_id: (vendor_id, raw_item)}
+        item_by_id: dict[int, tuple[int, object]] = {}
+        for vid in visible_ids:
+            for it in self.menu_item_repository.list(vendor_id=vid, available=True):
+                item_by_id[it.id] = (vid, it)
+
+        # Sales window: past 30 days up to today
+        end = date.today()
+        start = end - timedelta(days=29)
+        ranked = self.reporting_repository.top_items(
+            start, end, limit=limit * 3, vendor_ids=visible_ids
+        )
+
+        results: list[RecommendedItem] = []
+        for sale in ranked:
+            if len(results) >= limit:
+                break
+            entry = item_by_id.get(sale.item_id)
+            if entry is None:
+                continue
+            vid, it = entry
+            remaining = self._remaining_quantity(it, used.get(it.id, 0))
+            if remaining is not None and remaining <= 0:
+                continue
+            results.append(
+                RecommendedItem(
+                    vendor=vendor_by_id[vid],
+                    item=self._menu_item_to_schema(it),
+                    quantity_sold=sale.quantity_sold,
+                    remaining_quantity=remaining,
+                    from_sales=True,
+                )
+            )
+
+        # Fallback: if no sales data, return available items
+        if not results:
+            for it_id, (vid, it) in item_by_id.items():
+                if len(results) >= limit:
+                    break
+                remaining = self._remaining_quantity(it, used.get(it.id, 0))
+                if remaining is not None and remaining <= 0:
+                    continue
+                results.append(
+                    RecommendedItem(
+                        vendor=vendor_by_id[vid],
+                        item=self._menu_item_to_schema(it),
+                        quantity_sold=0,
+                        remaining_quantity=remaining,
+                        from_sales=False,
+                    )
+                )
+
+        return results
 
     def list_my_orders(self, employee_id: int) -> list[EmployeeOrder]:
         return self.selection_repository.list_orders(employee_id=employee_id)

--- a/backend/tests/integration/test_reporting_top_items_db.py
+++ b/backend/tests/integration/test_reporting_top_items_db.py
@@ -1,0 +1,52 @@
+import os
+from datetime import date
+
+import pytest
+
+pytestmark = pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="requires DATABASE_URL")
+DATABASE_URL = os.getenv("DATABASE_URL", "")
+
+
+@pytest.fixture()
+def seeded():
+    from psycopg import connect
+    from psycopg.rows import dict_row
+    from backend.db.migrate import run_migrations
+    run_migrations()
+    conn = connect(DATABASE_URL, row_factory=dict_row, autocommit=True)
+    cur = conn.cursor()
+    cur.execute("INSERT INTO vendors (name, status, contact_email) "
+                "VALUES ('Reco Kitchen','approved','reco@example.com') RETURNING id")
+    vid = cur.fetchone()["id"]
+
+    # Create two menu items so FK is satisfied
+    cur.execute("INSERT INTO menu_items (vendor_id, name, price_cents) VALUES (%s, 'Item A', 100) RETURNING id", (vid,))
+    item_a = cur.fetchone()["id"]
+    cur.execute("INSERT INTO menu_items (vendor_id, name, price_cents) VALUES (%s, 'Item B', 100) RETURNING id", (vid,))
+    item_b = cur.fetchone()["id"]
+
+    def order(status, day, item_id, qty):
+        cur.execute("INSERT INTO orders (employee_id, vendor_id, status, total_price_cents, created_at) "
+                    "VALUES (1,%s,%s,100,%s) RETURNING id", (vid, status, f"2026-05-{day:02d} 12:00+00"))
+        oid = cur.fetchone()["id"]
+        cur.execute("INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents) "
+                    "VALUES (%s,%s,'X',%s,100,100)", (oid, item_id, qty))
+        return oid
+
+    ids = [order("delivered", 3, item_a, 4), order("delivered", 4, item_a, 1), order("cancelled", 4, item_b, 9)]
+    yield {"vendor_id": vid, "order_ids": ids, "item_id": item_a, "item_b": item_b}
+    cur.execute("DELETE FROM order_items WHERE order_id = ANY(%s)", (ids,))
+    cur.execute("DELETE FROM orders WHERE id = ANY(%s)", (ids,))
+    cur.execute("DELETE FROM menu_items WHERE id = ANY(%s)", ([item_a, item_b],))
+    cur.execute("DELETE FROM vendors WHERE id = %s", (vid,))
+    conn.close()
+
+
+def test_top_items_db(seeded):
+    from backend.repositories.postgres_reporting_repository import PostgresReportingRepository
+    repo = PostgresReportingRepository()
+    rows = repo.top_items(date(2026, 5, 1), date(2026, 5, 31), limit=50, vendor_ids=[seeded["vendor_id"]])
+    mine = [r for r in rows if r.item_id == seeded["item_id"]][0]
+    assert mine.quantity_sold == 5
+    assert mine.vendor_id == seeded["vendor_id"]
+    assert all(r.item_id != seeded["item_b"] for r in rows)

--- a/backend/tests/test_recommendation.py
+++ b/backend/tests/test_recommendation.py
@@ -1,0 +1,184 @@
+"""Tests for EmployeeOrderingService.recommend() — sales-based meal recommendations."""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+from backend.repositories.audit_log_repository import AuditLogRepository
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.reporting_repository import ReportingRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.services.employee_ordering_service import EmployeeOrderingService
+
+
+def _make_service(
+    vendor_repo: VendorProfileRepository,
+    item_repo: MenuItemRepository,
+    selection_repo: EmployeeSelectionRepository,
+    reporting_repo: ReportingRepository,
+) -> EmployeeOrderingService:
+    return EmployeeOrderingService(
+        vendor_repo,
+        item_repo,
+        selection_repo,
+        AuditLogRepository(),
+        reporting_repository=reporting_repo,
+    )
+
+
+def _base_vendor_repo() -> VendorProfileRepository:
+    """Approved vendor #1, no facility restrictions (no employee_facility assignment)."""
+    repo = VendorProfileRepository()
+    repo.seed(
+        VendorRecord(
+            id=1,
+            name="Sunny Kitchen",
+            status="approved",
+            address="No. 10",
+            business_hours="11:00-14:00",
+            contact_phone="0912-000-001",
+            contact_email="sunny@example.com",
+        )
+    )
+    return repo
+
+
+def _seed_sale(
+    reporting_repo: ReportingRepository,
+    *,
+    order_id: int,
+    vendor_id: int,
+    items: list[tuple[int, int, int]],
+) -> None:
+    """Seed a non-cancelled order into ReportingRepository within the 30-day window."""
+    reporting_repo.seed_order(
+        order_id=order_id,
+        vendor_id=vendor_id,
+        vendor_name="Sunny Kitchen",
+        facility_id=None,
+        facility_name=None,
+        status="delivered",
+        created_at=datetime.combine(date.today() - timedelta(days=1), datetime.min.time()),
+        items=items,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: top-selling item ranks first
+# ---------------------------------------------------------------------------
+def test_top_selling_item_ranks_first() -> None:
+    vendor_repo = _base_vendor_repo()
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+    reporting_repo = ReportingRepository()
+
+    popular = item_repo.create(vendor_id=1, name="Popular Rice", price_cents=120, daily_quota=50)
+    less_popular = item_repo.create(vendor_id=1, name="Less Popular Noodle", price_cents=100, daily_quota=50)
+
+    # Seed sales: popular item sold 10, less popular sold 3
+    _seed_sale(reporting_repo, order_id=1, vendor_id=1, items=[(popular.id, 10, 120)])
+    _seed_sale(reporting_repo, order_id=2, vendor_id=1, items=[(less_popular.id, 3, 100)])
+
+    svc = _make_service(vendor_repo, item_repo, selection_repo, reporting_repo)
+    results = svc.recommend(limit=8)
+
+    assert len(results) >= 2
+    assert results[0].item.id == popular.id
+    assert results[0].quantity_sold == 10
+    assert results[0].from_sales is True
+    assert results[1].item.id == less_popular.id
+    assert results[1].quantity_sold == 3
+
+
+# ---------------------------------------------------------------------------
+# Test 2: unavailable item is excluded
+# ---------------------------------------------------------------------------
+def test_unavailable_item_excluded() -> None:
+    vendor_repo = _base_vendor_repo()
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+    reporting_repo = ReportingRepository()
+
+    good = item_repo.create(vendor_id=1, name="Good Item", price_cents=100, daily_quota=10)
+    hidden = item_repo.create(vendor_id=1, name="Hidden Item", price_cents=80, available=False)
+
+    # Seed sales for both — but hidden is unavailable so should be excluded
+    _seed_sale(reporting_repo, order_id=1, vendor_id=1, items=[(hidden.id, 20, 80)])
+    _seed_sale(reporting_repo, order_id=2, vendor_id=1, items=[(good.id, 5, 100)])
+
+    svc = _make_service(vendor_repo, item_repo, selection_repo, reporting_repo)
+    results = svc.recommend(limit=8)
+
+    returned_ids = [r.item.id for r in results]
+    assert hidden.id not in returned_ids
+    assert good.id in returned_ids
+
+
+# ---------------------------------------------------------------------------
+# Test 3: quota-exhausted item is excluded
+# ---------------------------------------------------------------------------
+def test_quota_exhausted_item_excluded() -> None:
+    vendor_repo = _base_vendor_repo()
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+    reporting_repo = ReportingRepository()
+
+    today = date.today()
+    quota_item = item_repo.create(vendor_id=1, name="Quota Item", price_cents=100, daily_quota=2)
+    other_item = item_repo.create(vendor_id=1, name="Other Item", price_cents=90, daily_quota=10)
+
+    # Exhaust quota for today
+    from backend.repositories.employee_selection_repository import OrderItemSnapshot
+    selection_repo.create_order(
+        employee_id=200,
+        vendor_id=1,
+        meal_date=today,
+        items=[OrderItemSnapshot(item_id=quota_item.id, item_name=quota_item.name, quantity=2, unit_price_cents=100)],
+    )
+
+    # Seed sales for both items
+    _seed_sale(reporting_repo, order_id=1, vendor_id=1, items=[(quota_item.id, 15, 100)])
+    _seed_sale(reporting_repo, order_id=2, vendor_id=1, items=[(other_item.id, 5, 90)])
+
+    svc = _make_service(vendor_repo, item_repo, selection_repo, reporting_repo)
+    results = svc.recommend(meal_date=today, limit=8)
+
+    returned_ids = [r.item.id for r in results]
+    assert quota_item.id not in returned_ids
+    assert other_item.id in returned_ids
+
+
+# ---------------------------------------------------------------------------
+# Test 4: no sales → fallback to available items (from_sales=False)
+# ---------------------------------------------------------------------------
+def test_fallback_when_no_sales_data() -> None:
+    vendor_repo = _base_vendor_repo()
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+    reporting_repo = ReportingRepository()  # empty — no sales seeded
+
+    item_repo.create(vendor_id=1, name="Soup", price_cents=60, daily_quota=5)
+    item_repo.create(vendor_id=1, name="Rice", price_cents=80, daily_quota=5)
+
+    svc = _make_service(vendor_repo, item_repo, selection_repo, reporting_repo)
+    results = svc.recommend(limit=8)
+
+    assert len(results) >= 1
+    for r in results:
+        assert r.from_sales is False
+        assert r.quantity_sold == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 5: empty vendor list returns []
+# ---------------------------------------------------------------------------
+def test_no_vendors_returns_empty() -> None:
+    vendor_repo = VendorProfileRepository()  # no vendors seeded
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+    reporting_repo = ReportingRepository()
+
+    svc = _make_service(vendor_repo, item_repo, selection_repo, reporting_repo)
+    results = svc.recommend(limit=8)
+
+    assert results == []

--- a/backend/tests/test_recommendation_route.py
+++ b/backend/tests/test_recommendation_route.py
@@ -1,0 +1,151 @@
+"""Route-level tests for GET /employee/recommendations."""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.reporting_repository import ReportingRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.routes.employee_ordering import get_employee_ordering_service
+from backend.services.employee_ordering_service import EmployeeOrderingService
+
+
+def _make_service_with_reporting(
+    reporting_repo: ReportingRepository,
+) -> EmployeeOrderingService:
+    vendor_repo = VendorProfileRepository()
+    vendor_repo.seed(
+        VendorRecord(
+            id=1,
+            name="Sunny Kitchen",
+            status="approved",
+            address="No. 10",
+            business_hours="11:00-14:00",
+            contact_phone="0912-000-001",
+            contact_email="sunny@example.com",
+        )
+    )
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+    return EmployeeOrderingService(
+        vendor_repo,
+        item_repo,
+        selection_repo,
+        AuditLogRepository(),
+        reporting_repository=reporting_repo,
+    ), item_repo
+
+
+def _seed_sale(
+    reporting_repo: ReportingRepository,
+    *,
+    order_id: int,
+    vendor_id: int,
+    items: list[tuple[int, int, int]],
+) -> None:
+    """Seed a delivered order into ReportingRepository within the 30-day window."""
+    reporting_repo.seed_order(
+        order_id=order_id,
+        vendor_id=vendor_id,
+        vendor_name="Sunny Kitchen",
+        facility_id=None,
+        facility_name=None,
+        status="delivered",
+        created_at=datetime.combine(date.today() - timedelta(days=1), datetime.min.time()),
+        items=items,
+    )
+
+
+def _h(user_id: int = 100) -> dict[str, str]:
+    """Employee auth headers."""
+    return {"x-user-role": "employee", "x-user-id": str(user_id)}
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: non-employee caller is blocked (403)
+# ---------------------------------------------------------------------------
+def test_recommendations_requires_employee_role() -> None:
+    reporting_repo = ReportingRepository()
+    svc, _ = _make_service_with_reporting(reporting_repo)
+    app.dependency_overrides[get_employee_ordering_service] = lambda: svc
+
+    client = TestClient(app)
+    resp = client.get("/employee/recommendations", headers={"x-user-role": "vendor_manager"})
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "forbidden"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: unauthenticated caller is blocked (400 — missing x-user-id)
+# ---------------------------------------------------------------------------
+def test_recommendations_requires_user_id_header() -> None:
+    reporting_repo = ReportingRepository()
+    svc, _ = _make_service_with_reporting(reporting_repo)
+    app.dependency_overrides[get_employee_ordering_service] = lambda: svc
+
+    client = TestClient(app)
+    # role is correct but no x-user-id → require_employee raises 400
+    resp = client.get("/employee/recommendations", headers={"x-user-role": "employee"})
+
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: employee gets 200 with a list, top-selling item first
+# ---------------------------------------------------------------------------
+def test_recommendations_returns_top_seller_first() -> None:
+    reporting_repo = ReportingRepository()
+    svc, item_repo = _make_service_with_reporting(reporting_repo)
+
+    popular = item_repo.create(vendor_id=1, name="Popular Rice", price_cents=120, daily_quota=50)
+    less_popular = item_repo.create(vendor_id=1, name="Less Popular Noodle", price_cents=100, daily_quota=50)
+
+    _seed_sale(reporting_repo, order_id=1, vendor_id=1, items=[(popular.id, 10, 120)])
+    _seed_sale(reporting_repo, order_id=2, vendor_id=1, items=[(less_popular.id, 3, 100)])
+
+    app.dependency_overrides[get_employee_ordering_service] = lambda: svc
+    client = TestClient(app)
+
+    resp = client.get("/employee/recommendations", headers=_h(100))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) >= 2
+    assert body[0]["item"]["id"] == popular.id
+    assert body[0]["quantity_sold"] == 10
+    assert body[1]["item"]["id"] == less_popular.id
+    assert body[1]["quantity_sold"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Test 4: each item in the response has the from_sales field
+# ---------------------------------------------------------------------------
+def test_recommendations_items_have_from_sales_field() -> None:
+    reporting_repo = ReportingRepository()
+    svc, item_repo = _make_service_with_reporting(reporting_repo)
+
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=10)
+    _seed_sale(reporting_repo, order_id=1, vendor_id=1, items=[(item.id, 5, 120)])
+
+    app.dependency_overrides[get_employee_ordering_service] = lambda: svc
+    client = TestClient(app)
+
+    resp = client.get("/employee/recommendations", headers=_h(100))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) >= 1
+    for rec in body:
+        assert "from_sales" in rec
+    assert body[0]["from_sales"] is True

--- a/backend/tests/test_reporting_top_items.py
+++ b/backend/tests/test_reporting_top_items.py
@@ -1,0 +1,37 @@
+from datetime import date, datetime, timezone
+
+from backend.repositories.reporting_repository import ReportingRepository
+
+W_START = date(2026, 5, 1)
+W_END = date(2026, 5, 31)
+
+
+def _ts(day):
+    return datetime(2026, 5, day, 12, 0, tzinfo=timezone.utc)
+
+
+def _seed(repo):
+    repo.seed_order(order_id=1, vendor_id=1, vendor_name="Sunny", facility_id=1,
+                    facility_name="F12A", status="delivered", created_at=_ts(1),
+                    items=[(10, 5, 500), (11, 1, 900)])
+    repo.seed_order(order_id=2, vendor_id=1, vendor_name="Sunny", facility_id=1,
+                    facility_name="F12A", status="pending", created_at=_ts(2),
+                    items=[(10, 2, 500)])
+    repo.seed_order(order_id=3, vendor_id=2, vendor_name="Noodle", facility_id=2,
+                    facility_name="F14B", status="cancelled", created_at=_ts(2),
+                    items=[(20, 9, 900)])
+
+
+def test_top_items_ranks_by_quantity_excludes_cancelled():
+    repo = ReportingRepository()
+    _seed(repo)
+    rows = repo.top_items(W_START, W_END, limit=10)
+    assert [(r.item_id, r.quantity_sold) for r in rows] == [(10, 7), (11, 1)]
+    assert rows[0].vendor_id == 1
+
+
+def test_top_items_vendor_filter_and_limit():
+    repo = ReportingRepository()
+    _seed(repo)
+    rows = repo.top_items(W_START, W_END, limit=1, vendor_ids=[1])
+    assert len(rows) == 1 and rows[0].item_id == 10

--- a/frontend/src/api/employee.js
+++ b/frontend/src/api/employee.js
@@ -120,6 +120,15 @@ function mockRandomMeal({ mealDate, vendorIds, facilityId }) {
   return candidates[Math.floor(Math.random() * candidates.length)];
 }
 
+export function getRecommendations({ facilityId, mealDate, limit } = {}) {
+  const params = new URLSearchParams();
+  if (facilityId != null) params.set("facility_id", facilityId);
+  if (mealDate) params.set("meal_date", mealDate);
+  if (limit) params.set("limit", limit);
+  const qs = params.toString();
+  return apiFetch(`/employee/recommendations${qs ? `?${qs}` : ""}`);
+}
+
 export function drawRandomMeal({ mealDate, vendorIds, facilityId }) {
   const payload = { meal_date: mealDate, ...facilityPayload(facilityId) };
   if (vendorIds != null) payload.vendor_ids = vendorIds;

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -50,6 +50,7 @@ export default function RandomMealPage() {
   const [recSubmitting, setRecSubmitting] = useState(null); // item id being submitted
   const [recSubmitted, setRecSubmitted] = useState(null);   // item id successfully submitted
   const [recSubmitError, setRecSubmitError] = useState(null);
+  const [limit, setLimit] = useState(10);
 
   const selectedCount = allVendors ? vendors.length : selectedVendorIds.length;
   const mealDateInRange = mealDate >= minMealDate && mealDate <= maxMealDate;
@@ -76,7 +77,7 @@ export default function RandomMealPage() {
     setRecError(null);
     setRecSubmitted(null);
     setRecSubmitError(null);
-    getRecommendations({ facilityId: selectedFacilityId, mealDate })
+    getRecommendations({ facilityId: selectedFacilityId, mealDate, limit })
       .then((data) => {
         if (!cancelled) setRecommendations(data);
       })
@@ -90,7 +91,7 @@ export default function RandomMealPage() {
         if (!cancelled) setRecLoading(false);
       });
     return () => { cancelled = true; };
-  }, [tab, mealDate, selectedFacilityId]);
+  }, [tab, mealDate, selectedFacilityId, limit]);
 
   function toggleVendor(vendorId) {
     setSelectedVendorIds((current) =>
@@ -246,7 +247,7 @@ export default function RandomMealPage() {
         </div>
 
         {/* Tab content panel */}
-        <div className="panel random-meal-result" style={{ flexDirection: "column", alignItems: "stretch" }}>
+        <div className="panel random-meal-result">
           {/* Tab buttons */}
           <div className="range-pills" style={{ marginBottom: "16px" }}>
             <button
@@ -267,41 +268,43 @@ export default function RandomMealPage() {
 
           {/* 熱門推薦 tab */}
           {tab === "recommend" && (
-            <div>
+            <div className="recommend-panel">
+              {/* 顯示數量 selector */}
+              <div className="recommend-limit-row">
+                <span className="field-label">顯示數量</span>
+                <div className="range-pills" style={{ margin: 0 }}>
+                  {[10, 20].map((n) => (
+                    <button
+                      key={n}
+                      type="button"
+                      className={`range-pill${limit === n ? " is-active" : ""}`}
+                      onClick={() => setLimit(n)}
+                    >
+                      前 {n}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
               {recLoading && <p className="loading-state compact-state">載入推薦中…</p>}
               {recError && <p className="error-state">{recError}</p>}
-              {!recLoading && !recError && recommendations.length === 0 && (
-                <p className="panel-copy" style={{ textAlign: "center", marginTop: "24px" }}>
-                  目前沒有可推薦的餐點
-                </p>
-              )}
               {recSubmitError && <p className="error-state">{recSubmitError}</p>}
+              {!recLoading && !recError && recommendations.length === 0 && (
+                <p className="recommend-empty">目前沒有可推薦的餐點</p>
+              )}
               {!recLoading && !recError && recommendations.length > 0 && (
-                <ol style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                <div className="recommend-grid">
                   {recommendations.map((rec, index) => (
-                    <li
+                    <div
                       key={`${rec.vendor.id}-${rec.item.id}`}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "12px",
-                        padding: "12px 0",
-                        borderBottom: "1px solid var(--line)",
-                      }}
+                      className="recommend-card"
                     >
-                      <span
-                        style={{
-                          minWidth: "28px",
-                          fontWeight: 700,
-                          fontSize: "1.1rem",
-                          color: index < 3 ? "var(--brand)" : "var(--muted)",
-                        }}
-                      >
+                      <div className="recommend-card-rank" data-top={index < 3 || undefined}>
                         {index + 1}
-                      </span>
-                      <div style={{ flex: 1, minWidth: 0 }}>
+                      </div>
+                      <div className="recommend-card-body">
                         <p className="eyebrow" style={{ marginBottom: "2px" }}>{rec.vendor.name}</p>
-                        <p style={{ fontWeight: 600, margin: "0 0 4px" }}>{rec.item.name}</p>
+                        <p className="recommend-card-name">{rec.item.name}</p>
                         <div className="item-badges">
                           <span className="badge badge-quota">
                             {formatPrice(rec.item.price_cents)}
@@ -316,38 +319,39 @@ export default function RandomMealPage() {
                           </span>
                         </div>
                       </div>
-                      {recSubmitted === rec.item.id ? (
-                        <div style={{ textAlign: "center" }}>
-                          <p className="eyebrow" style={{ color: "var(--brand)", marginBottom: "4px" }}>已訂購</p>
+                      <div className="recommend-card-action">
+                        {recSubmitted === rec.item.id ? (
+                          <>
+                            <p className="eyebrow" style={{ color: "var(--brand)", marginBottom: "6px" }}>已訂購</p>
+                            <button
+                              className="ghost-button"
+                              type="button"
+                              onClick={() => navigate("/employee/orders")}
+                            >
+                              查看訂單
+                            </button>
+                          </>
+                        ) : (
                           <button
-                            className="ghost-button"
+                            className="primary-button"
                             type="button"
-                            onClick={() => navigate("/employee/orders")}
+                            onClick={() => handleRecOrder(rec)}
+                            disabled={recSubmitting === rec.item.id}
                           >
-                            查看訂單
+                            {recSubmitting === rec.item.id ? "訂購中…" : "訂購"}
                           </button>
-                        </div>
-                      ) : (
-                        <button
-                          className="primary-button"
-                          type="button"
-                          style={{ whiteSpace: "nowrap", flexShrink: 0 }}
-                          onClick={() => handleRecOrder(rec)}
-                          disabled={recSubmitting === rec.item.id}
-                        >
-                          {recSubmitting === rec.item.id ? "訂購中…" : "訂購"}
-                        </button>
-                      )}
-                    </li>
+                        )}
+                      </div>
+                    </div>
                   ))}
-                </ol>
+                </div>
               )}
             </div>
           )}
 
           {/* 隨機抽餐 tab */}
           {tab === "random" && (
-            <div>
+            <div className="random-draw-panel">
               {!draw && !drawError && (
                 <div className="random-placeholder">
                   <p className="eyebrow">Ready</p>

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { drawRandomMeal, submitSelection } from "../../api/employee";
+import { drawRandomMeal, getRecommendations, submitSelection } from "../../api/employee";
 import { useFacility } from "../../facility/FacilityContext";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { useVendors } from "../../hooks/useVendors";
@@ -32,6 +32,9 @@ export default function RandomMealPage() {
   const minMealDate = addDaysIso(0);
   const maxMealDate = addDaysIso(6);
   const [mealDate, setMealDate] = useState(minMealDate);
+  const [tab, setTab] = useState("recommend");
+
+  // --- 隨機抽餐 state ---
   const [allVendors, setAllVendors] = useState(true);
   const [selectedVendorIds, setSelectedVendorIds] = useState([]);
   const [draw, setDraw] = useState(null);
@@ -39,6 +42,14 @@ export default function RandomMealPage() {
   const [drawing, setDrawing] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+
+  // --- 熱門推薦 state ---
+  const [recommendations, setRecommendations] = useState([]);
+  const [recLoading, setRecLoading] = useState(false);
+  const [recError, setRecError] = useState(null);
+  const [recSubmitting, setRecSubmitting] = useState(null); // item id being submitted
+  const [recSubmitted, setRecSubmitted] = useState(null);   // item id successfully submitted
+  const [recSubmitError, setRecSubmitError] = useState(null);
 
   const selectedCount = allVendors ? vendors.length : selectedVendorIds.length;
   const mealDateInRange = mealDate >= minMealDate && mealDate <= maxMealDate;
@@ -53,7 +64,33 @@ export default function RandomMealPage() {
     setSelectedVendorIds([]);
     setDraw(null);
     setSubmitted(false);
+    setRecSubmitted(null);
+    setRecSubmitError(null);
   }, [selectedFacilityId]);
+
+  // Fetch recommendations whenever the tab, mealDate, or facilityId changes
+  useEffect(() => {
+    if (tab !== "recommend") return;
+    let cancelled = false;
+    setRecLoading(true);
+    setRecError(null);
+    setRecSubmitted(null);
+    setRecSubmitError(null);
+    getRecommendations({ facilityId: selectedFacilityId, mealDate })
+      .then((data) => {
+        if (!cancelled) setRecommendations(data);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setRecError("無法載入推薦餐點，請稍後再試。");
+          setRecommendations([]);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setRecLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [tab, mealDate, selectedFacilityId]);
 
   function toggleVendor(vendorId) {
     setSelectedVendorIds((current) =>
@@ -103,18 +140,44 @@ export default function RandomMealPage() {
     }
   }
 
+  async function handleRecOrder(rec) {
+    setRecSubmitting(rec.item.id);
+    setRecSubmitError(null);
+    try {
+      await submitSelection(rec.vendor.id, {
+        itemId: rec.item.id,
+        quantity: 1,
+        mealDate,
+        facilityId: selectedFacilityId,
+      });
+      setRecSubmitted(rec.item.id);
+    } catch (err) {
+      setRecSubmitError(
+        err?.message ?? "訂購失敗，請稍後再試。"
+      );
+    } finally {
+      setRecSubmitting(null);
+    }
+  }
+
+  function recRemainingLabel(rec) {
+    if (rec.remaining_quantity == null) return quotaLabel(rec.item.daily_quota);
+    return `剩餘 ${rec.remaining_quantity} 份`;
+  }
+
   return (
     <div>
       <div className="page-header">
         <FacilityScopeLabel label="Random meal facility" />
-        <p className="eyebrow">Employee / Random Meal</p>
-        <h2>Let the menu decide</h2>
+        <p className="eyebrow">Employee / 推薦與隨機抽餐</p>
+        <h2>今天吃什麼？</h2>
       </div>
 
+      {/* Shared selectors */}
       <section className="random-meal-layout">
         <div className="panel random-meal-controls">
           <label className="field-label" htmlFor="random-meal-date">
-            Meal date
+            用餐日期
           </label>
           <input
             className="date-input"
@@ -130,108 +193,217 @@ export default function RandomMealPage() {
             }}
           />
 
-          <div className="random-vendor-header">
-            <div>
-              <p className="field-label">Restaurants</p>
-              <p className="panel-copy">{selectedCount} selected</p>
-            </div>
-            <label className="toggle-row">
-              <input
-                type="checkbox"
-                checked={allVendors}
-                onChange={(event) => {
-                  setAllVendors(event.target.checked);
-                  setDraw(null);
-                  setSubmitted(false);
-                }}
-              />
-              <span>All restaurants</span>
-            </label>
-          </div>
-
-          {loading && <p className="loading-state compact-state">Loading restaurants...</p>}
-          {error && <p className="error-state">Could not load restaurants.</p>}
-
-          {!loading && !error && !allVendors && (
-            <div className="vendor-check-list">
-              {vendors.map((vendor) => (
-                <label className="vendor-check-row" key={vendor.id}>
+          {/* Vendor selector — only shown for 隨機抽餐 tab */}
+          {tab === "random" && (
+            <>
+              <div className="random-vendor-header">
+                <div>
+                  <p className="field-label">Restaurants</p>
+                  <p className="panel-copy">{selectedCount} selected</p>
+                </div>
+                <label className="toggle-row">
                   <input
                     type="checkbox"
-                    checked={selectedVendorIds.includes(vendor.id)}
-                    onChange={() => toggleVendor(vendor.id)}
+                    checked={allVendors}
+                    onChange={(event) => {
+                      setAllVendors(event.target.checked);
+                      setDraw(null);
+                      setSubmitted(false);
+                    }}
                   />
-                  <span>{vendor.name}</span>
+                  <span>All restaurants</span>
                 </label>
-              ))}
-            </div>
-          )}
-
-          <button
-            className="primary-button random-draw-button"
-            type="button"
-            onClick={handleDraw}
-            disabled={!canDraw}
-          >
-            {drawing ? "Drawing..." : draw ? "Draw again" : "Draw a meal"}
-          </button>
-        </div>
-
-        <div className="panel random-meal-result">
-          {!draw && !drawError && (
-            <div className="random-placeholder">
-              <p className="eyebrow">Ready</p>
-              <h3>Pick a date and restaurant range.</h3>
-              <p className="panel-copy">The result will be selected completely at random from meals that still have quota left.</p>
-            </div>
-          )}
-
-          {drawError && <p className="error-state">{drawError}</p>}
-
-          {draw && (
-            <div className="random-result-card">
-              <p className="eyebrow">{draw.vendor.name}</p>
-              <h3>{draw.item.name}</h3>
-              <p className="random-price">{formatPrice(draw.item.price_cents)}</p>
-              {draw.item.description && (
-                <p className="panel-copy">{draw.item.description}</p>
-              )}
-              <div className="item-badges">
-                <span className="badge badge-available">Available</span>
-                <span className="badge badge-quota">
-                  {remainingLabel ?? quotaLabel(draw.item.daily_quota)}
-                </span>
               </div>
 
-              {submitted ? (
-                <div className="success-state">
-                  <p>Order sent for {mealDate}.</p>
-                  <button
-                    className="ghost-button"
-                    type="button"
-                    onClick={() => navigate("/employee/orders")}
-                  >
-                    View orders
-                  </button>
+              {loading && <p className="loading-state compact-state">Loading restaurants...</p>}
+              {error && <p className="error-state">Could not load restaurants.</p>}
+
+              {!loading && !error && !allVendors && (
+                <div className="vendor-check-list">
+                  {vendors.map((vendor) => (
+                    <label className="vendor-check-row" key={vendor.id}>
+                      <input
+                        type="checkbox"
+                        checked={selectedVendorIds.includes(vendor.id)}
+                        onChange={() => toggleVendor(vendor.id)}
+                      />
+                      <span>{vendor.name}</span>
+                    </label>
+                  ))}
                 </div>
-              ) : (
-                <div className="random-result-actions">
-                  <button
-                    className="ghost-button"
-                    type="button"
-                    onClick={handleDraw}
-                    disabled={drawing || submitting}
-                  >
-                    Draw again
-                  </button>
-                  <button
-                    className="primary-button"
-                    type="button"
-                    onClick={handleConfirm}
-                    disabled={submitting}
-                  >
-                    {submitting ? "Sending..." : "Choose this meal"}
-                  </button>
+              )}
+
+              <button
+                className="primary-button random-draw-button"
+                type="button"
+                onClick={handleDraw}
+                disabled={!canDraw}
+              >
+                {drawing ? "Drawing..." : draw ? "Draw again" : "Draw a meal"}
+              </button>
+            </>
+          )}
+        </div>
+
+        {/* Tab content panel */}
+        <div className="panel random-meal-result" style={{ flexDirection: "column", alignItems: "stretch" }}>
+          {/* Tab buttons */}
+          <div className="range-pills" style={{ marginBottom: "16px" }}>
+            <button
+              type="button"
+              className={`range-pill${tab === "recommend" ? " is-active" : ""}`}
+              onClick={() => setTab("recommend")}
+            >
+              熱門推薦
+            </button>
+            <button
+              type="button"
+              className={`range-pill${tab === "random" ? " is-active" : ""}`}
+              onClick={() => setTab("random")}
+            >
+              隨機抽餐
+            </button>
+          </div>
+
+          {/* 熱門推薦 tab */}
+          {tab === "recommend" && (
+            <div>
+              {recLoading && <p className="loading-state compact-state">載入推薦中…</p>}
+              {recError && <p className="error-state">{recError}</p>}
+              {!recLoading && !recError && recommendations.length === 0 && (
+                <p className="panel-copy" style={{ textAlign: "center", marginTop: "24px" }}>
+                  目前沒有可推薦的餐點
+                </p>
+              )}
+              {recSubmitError && <p className="error-state">{recSubmitError}</p>}
+              {!recLoading && !recError && recommendations.length > 0 && (
+                <ol style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                  {recommendations.map((rec, index) => (
+                    <li
+                      key={`${rec.vendor.id}-${rec.item.id}`}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "12px",
+                        padding: "12px 0",
+                        borderBottom: "1px solid var(--line)",
+                      }}
+                    >
+                      <span
+                        style={{
+                          minWidth: "28px",
+                          fontWeight: 700,
+                          fontSize: "1.1rem",
+                          color: index < 3 ? "var(--brand)" : "var(--muted)",
+                        }}
+                      >
+                        {index + 1}
+                      </span>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <p className="eyebrow" style={{ marginBottom: "2px" }}>{rec.vendor.name}</p>
+                        <p style={{ fontWeight: 600, margin: "0 0 4px" }}>{rec.item.name}</p>
+                        <div className="item-badges">
+                          <span className="badge badge-quota">
+                            {formatPrice(rec.item.price_cents)}
+                          </span>
+                          {rec.from_sales && rec.quantity_sold > 0 && (
+                            <span className="badge badge-available">
+                              已售 {rec.quantity_sold} 份
+                            </span>
+                          )}
+                          <span className="badge badge-quota">
+                            {recRemainingLabel(rec)}
+                          </span>
+                        </div>
+                      </div>
+                      {recSubmitted === rec.item.id ? (
+                        <div style={{ textAlign: "center" }}>
+                          <p className="eyebrow" style={{ color: "var(--brand)", marginBottom: "4px" }}>已訂購</p>
+                          <button
+                            className="ghost-button"
+                            type="button"
+                            onClick={() => navigate("/employee/orders")}
+                          >
+                            查看訂單
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          className="primary-button"
+                          type="button"
+                          style={{ whiteSpace: "nowrap", flexShrink: 0 }}
+                          onClick={() => handleRecOrder(rec)}
+                          disabled={recSubmitting === rec.item.id}
+                        >
+                          {recSubmitting === rec.item.id ? "訂購中…" : "訂購"}
+                        </button>
+                      )}
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+          )}
+
+          {/* 隨機抽餐 tab */}
+          {tab === "random" && (
+            <div>
+              {!draw && !drawError && (
+                <div className="random-placeholder">
+                  <p className="eyebrow">Ready</p>
+                  <h3>Pick a date and restaurant range.</h3>
+                  <p className="panel-copy">The result will be selected completely at random from meals that still have quota left.</p>
+                </div>
+              )}
+
+              {drawError && <p className="error-state">{drawError}</p>}
+
+              {draw && (
+                <div className="random-result-card">
+                  <p className="eyebrow">{draw.vendor.name}</p>
+                  <h3>{draw.item.name}</h3>
+                  <p className="random-price">{formatPrice(draw.item.price_cents)}</p>
+                  {draw.item.description && (
+                    <p className="panel-copy">{draw.item.description}</p>
+                  )}
+                  <div className="item-badges">
+                    <span className="badge badge-available">Available</span>
+                    <span className="badge badge-quota">
+                      {remainingLabel ?? quotaLabel(draw.item.daily_quota)}
+                    </span>
+                  </div>
+
+                  {submitted ? (
+                    <div className="success-state">
+                      <p>Order sent for {mealDate}.</p>
+                      <button
+                        className="ghost-button"
+                        type="button"
+                        onClick={() => navigate("/employee/orders")}
+                      >
+                        View orders
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="random-result-actions">
+                      <button
+                        className="ghost-button"
+                        type="button"
+                        onClick={handleDraw}
+                        disabled={drawing || submitting}
+                      >
+                        Draw again
+                      </button>
+                      <button
+                        className="primary-button"
+                        type="button"
+                        onClick={handleConfirm}
+                        disabled={submitting}
+                      >
+                        {submitting ? "Sending..." : "Choose this meal"}
+                      </button>
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -19,10 +19,10 @@ function addDaysIso(days) {
 
 function drawErrorMessage(err) {
   if (err.code === "no_random_meal_available") {
-    return "No available meals remain for the selected date and restaurants.";
+    return "所選日期與餐廳目前沒有可抽的餐點。";
   }
-  if (err.code === "validation_error") return err.message ?? "Choose a valid date and restaurant range.";
-  return "Could not draw a meal. Please try again.";
+  if (err.code === "validation_error") return err.message ?? "請選擇有效的日期與餐廳範圍。";
+  return "抽籤失敗，請再試一次。";
 }
 
 export default function RandomMealPage() {
@@ -57,8 +57,8 @@ export default function RandomMealPage() {
   const canDraw = mealDateInRange && selectedCount > 0 && !drawing && !loading;
   const remainingLabel = useMemo(() => {
     if (!draw) return null;
-    if (draw.remaining_quantity == null) return "Unlimited";
-    return `${draw.remaining_quantity} left`;
+    if (draw.remaining_quantity == null) return "不限量";
+    return `剩餘 ${draw.remaining_quantity} 份`;
   }, [draw]);
 
   useEffect(() => {
@@ -169,8 +169,8 @@ export default function RandomMealPage() {
   return (
     <div>
       <div className="page-header">
-        <FacilityScopeLabel label="Random meal facility" />
-        <p className="eyebrow">Employee / 推薦與隨機抽餐</p>
+        <FacilityScopeLabel label="隨機抽餐設施" />
+        <p className="eyebrow">員工 / 推薦與隨機抽餐</p>
         <h2>今天吃什麼？</h2>
       </div>
 
@@ -199,8 +199,8 @@ export default function RandomMealPage() {
             <>
               <div className="random-vendor-header">
                 <div>
-                  <p className="field-label">Restaurants</p>
-                  <p className="panel-copy">{selectedCount} selected</p>
+                  <p className="field-label">餐廳</p>
+                  <p className="panel-copy">已選 {selectedCount} 間</p>
                 </div>
                 <label className="toggle-row">
                   <input
@@ -212,12 +212,12 @@ export default function RandomMealPage() {
                       setSubmitted(false);
                     }}
                   />
-                  <span>All restaurants</span>
+                  <span>全部餐廳</span>
                 </label>
               </div>
 
-              {loading && <p className="loading-state compact-state">Loading restaurants...</p>}
-              {error && <p className="error-state">Could not load restaurants.</p>}
+              {loading && <p className="loading-state compact-state">載入餐廳中…</p>}
+              {error && <p className="error-state">無法載入餐廳。</p>}
 
               {!loading && !error && !allVendors && (
                 <div className="vendor-check-list">
@@ -240,7 +240,7 @@ export default function RandomMealPage() {
                 onClick={handleDraw}
                 disabled={!canDraw}
               >
-                {drawing ? "Drawing..." : draw ? "Draw again" : "Draw a meal"}
+                {drawing ? "抽籤中…" : draw ? "重新抽" : "抽一份"}
               </button>
             </>
           )}
@@ -354,9 +354,9 @@ export default function RandomMealPage() {
             <div className="random-draw-panel">
               {!draw && !drawError && (
                 <div className="random-placeholder">
-                  <p className="eyebrow">Ready</p>
-                  <h3>Pick a date and restaurant range.</h3>
-                  <p className="panel-copy">The result will be selected completely at random from meals that still have quota left.</p>
+                  <p className="eyebrow">準備就緒</p>
+                  <h3>選擇日期與餐廳範圍。</h3>
+                  <p className="panel-copy">系統會從仍有額度的餐點中完全隨機抽出一份。</p>
                 </div>
               )}
 
@@ -371,7 +371,7 @@ export default function RandomMealPage() {
                     <p className="panel-copy">{draw.item.description}</p>
                   )}
                   <div className="item-badges">
-                    <span className="badge badge-available">Available</span>
+                    <span className="badge badge-available">可供選擇</span>
                     <span className="badge badge-quota">
                       {remainingLabel ?? quotaLabel(draw.item.daily_quota)}
                     </span>
@@ -379,13 +379,13 @@ export default function RandomMealPage() {
 
                   {submitted ? (
                     <div className="success-state">
-                      <p>Order sent for {mealDate}.</p>
+                      <p>已加入訂單（{mealDate}）。</p>
                       <button
                         className="ghost-button"
                         type="button"
                         onClick={() => navigate("/employee/orders")}
                       >
-                        View orders
+                        查看訂單
                       </button>
                     </div>
                   ) : (
@@ -396,7 +396,7 @@ export default function RandomMealPage() {
                         onClick={handleDraw}
                         disabled={drawing || submitting}
                       >
-                        Draw again
+                        重新抽
                       </button>
                       <button
                         className="primary-button"
@@ -404,7 +404,7 @@ export default function RandomMealPage() {
                         onClick={handleConfirm}
                         disabled={submitting}
                       >
-                        {submitting ? "Sending..." : "Choose this meal"}
+                        {submitting ? "送出中…" : "選這份"}
                       </button>
                     </div>
                   )}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -927,7 +927,94 @@ p {
 .random-meal-result {
   min-height: 360px;
   display: grid;
+  grid-template-rows: auto 1fr;
+  align-items: start;
+}
+
+/* 熱門推薦 panel — top-aligned, normal block flow */
+.recommend-panel {
+  display: grid;
+  gap: 16px;
+  align-self: start;
+}
+
+.recommend-limit-row {
+  display: flex;
   align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+/* Responsive card grid for recommendation items */
+.recommend-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.recommend-card {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.55);
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+.recommend-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px rgba(78, 49, 23, 0.1);
+}
+
+.recommend-card-rank {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--muted);
+}
+
+.recommend-card-rank[data-top] {
+  color: var(--brand);
+}
+
+.recommend-card-body {
+  display: grid;
+  gap: 6px;
+}
+
+.recommend-card-name {
+  font-weight: 600;
+  font-size: 0.97rem;
+  line-height: 1.35;
+  margin: 0;
+}
+
+.recommend-card-action {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-top: 4px;
+}
+
+.recommend-card-action .primary-button,
+.recommend-card-action .ghost-button {
+  width: 100%;
+}
+
+.recommend-empty {
+  text-align: center;
+  padding: 28px 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+/* 隨機抽餐 draw panel — fill remaining height, center card vertically */
+.random-draw-panel {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 300px;
 }
 
 .random-placeholder {


### PR DESCRIPTION
Closes #105.

First step of requirement 4 (餐點推薦): a **sales-based 熱門推薦** for employees (weather + nutrition signals remain out of scope per the spec).

## Feature
The employee RandomMealPage is split into two tabs:
- **熱門推薦** (default): items ranked by **actual sales over the last 30 days**, intersected with what's currently orderable; each row shows units-sold / remaining / price and is one-click orderable.
- **隨機抽餐**: the existing random draw, moved under its own tab (unchanged).

## Changes
- **`ReportingRepository.top_items`** (in-memory + Postgres): sales ranking, excludes cancelled, optional vendor filter — reuses the shared aggregation layer from #106.
- **`EmployeeOrderingService.recommend()`**: reuses the existing facility filter + remaining-quota + availability checks, intersected with `top_items`; **graceful fallback** to currently-orderable items when there is no sales history (never silently empty). Added an optional `reporting_repository` to the constructor (existing callers unaffected).
- **`GET /employee/recommendations`** (employee-only; facility_id / meal_date / limit).
- **Frontend**: two-tab RandomMealPage + `getRecommendations`; orders reuse the existing `submitSelection` flow.

## Tests
- Unit: in-memory `top_items`; `recommend()` ranking / availability+quota exclusion / fallback; route RBAC.
- Integration (Postgres): `top_items` against a live DB (cancelled excluded, vendor filter).
- Full suite: 248 passed, 20 skipped, 0 failed.

## Design notes
- Ranking is by **historical 30-day sales**, not real-time; fallback uses **current availability**.
- Recommendations only include facility-visible + available + remaining-quota>0 items (never recommends something un-orderable).
