### PR TITLE
feat(seed): comprehensive demo data for staging/preview (refs #107)

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     api_port: int = 8000
     cors_origins: list[str] = ["https://localhost", "http://localhost:3000"]
     database_url: str = ""
+    seed_demo_data: bool = False
     jwt_secret_key: str = _INSECURE_DEFAULT_SECRET
     jwt_algorithm: str = "HS256"
     jwt_access_token_expire_minutes: int = 480

--- a/backend/db/seed.py
+++ b/backend/db/seed.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from backend.core.config import settings
+from backend.db.connection import get_connection
+
+logger = logging.getLogger(__name__)
+
+_SEED_FILE = Path(__file__).parent / "seeds" / "demo_seed.sql"
+
+
+def run_demo_seed() -> None:
+    """Apply the comprehensive demo dataset when SEED_DEMO_DATA is enabled.
+
+    Gated + idempotent: safe to run on every startup. Only staging/preview set
+    SEED_DEMO_DATA=true; prod leaves it false so it keeps the minimal baseline.
+    """
+    if not settings.seed_demo_data:
+        return
+    if not settings.database_url:
+        logger.info("SEED_DEMO_DATA set but DATABASE_URL empty; skipping demo seed")
+        return
+    sql = _SEED_FILE.read_text(encoding="utf-8")
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+        conn.commit()
+    logger.info("Demo seed applied")

--- a/backend/db/seeds/demo_seed.sql
+++ b/backend/db/seeds/demo_seed.sql
@@ -92,18 +92,62 @@ END $$;
 
 -- ─────────────────────────────────────────────
 -- 5. MENU CATEGORIES + ITEMS
---    Demo Noodle House: category "Noodles", 4 items
---    Demo Green Bowl:   category "Bowls",   4 items
+--    Sunny Kitchen:     category "Lunch Boxes", 3 items
+--    Demo Noodle House: category "Noodles",     4 items
+--    Demo Green Bowl:   category "Bowls",       4 items
 -- ─────────────────────────────────────────────
 DO $$
 DECLARE
+  v_sunny_id   BIGINT;
   v_noodle_id  BIGINT;
   v_green_id   BIGINT;
+  v_cat_sunny  BIGINT;
   v_cat_noodle BIGINT;
   v_cat_green  BIGINT;
 BEGIN
+  SELECT id INTO v_sunny_id  FROM vendors WHERE name = 'Sunny Kitchen'     LIMIT 1;
   SELECT id INTO v_noodle_id FROM vendors WHERE name = 'Demo Noodle House' LIMIT 1;
   SELECT id INTO v_green_id  FROM vendors WHERE name = 'Demo Green Bowl'   LIMIT 1;
+
+  -- ── Sunny Kitchen ─────────────────────────
+  IF v_sunny_id IS NOT NULL THEN
+    INSERT INTO menu_categories (vendor_id, name, sort_order)
+    VALUES (v_sunny_id, 'Lunch Boxes', 1)
+    ON CONFLICT (vendor_id, name) DO NOTHING;
+
+    SELECT id INTO v_cat_sunny
+    FROM menu_categories WHERE vendor_id = v_sunny_id AND name = 'Lunch Boxes';
+
+    -- top-seller: Chicken Rice Box (quota 50)
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available)
+    SELECT v_sunny_id, v_cat_sunny,
+           'Chicken Rice Box',
+           'Grilled chicken thigh with steamed rice and seasonal vegetables',
+           8500, 50, TRUE
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_sunny_id AND name = 'Chicken Rice Box'
+    );
+
+    -- medium-seller: Pork Chop Box (quota 30)
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available)
+    SELECT v_sunny_id, v_cat_sunny,
+           'Pork Chop Box',
+           'Crispy fried pork chop with rice and pickled vegetables',
+           9000, 30, TRUE
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_sunny_id AND name = 'Pork Chop Box'
+    );
+
+    -- low-seller: Veggie Box (unlimited)
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available)
+    SELECT v_sunny_id, v_cat_sunny,
+           'Veggie Box',
+           'Seasonal stir-fried vegetables with tofu over steamed rice',
+           7500, NULL, TRUE
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_sunny_id AND name = 'Veggie Box'
+    );
+  END IF;
 
   -- ── Demo Noodle House ──────────────────────
   IF v_noodle_id IS NOT NULL THEN
@@ -277,23 +321,33 @@ END $$;
 --    ~20 orders spread over last 45 days (current + previous month data).
 --    Status mix: mostly delivered, a few pending, a couple cancelled.
 --    Item popularity: Beef Noodle Soup + Teriyaki Chicken Bowl are top sellers.
+--    All orders satisfy: facility_id ∈ (employee_facilities ∩ vendor_facilities).
+--      Sunny Kitchen (F12A):      emp1@F12A, emp2@F12A
+--      Demo Noodle House (F12A,F14B): emp1@F12A, emp2@F12A, emp2@F14B
+--      Demo Green Bowl (F15A):    emp3@F15A only
 -- ─────────────────────────────────────────────
 DO $$
 DECLARE
   v_emp1       BIGINT;
   v_emp2       BIGINT;
   v_emp3       BIGINT;
+  v_sunny      BIGINT;
   v_noodle     BIGINT;
   v_green      BIGINT;
   v_f12a       BIGINT;
   v_f14b       BIGINT;
   v_f15a       BIGINT;
 
-  -- menu item ids
+  -- menu item ids (Sunny Kitchen)
+  v_chicken_rice   BIGINT;
+  v_pork_chop      BIGINT;
+  v_veggie_box     BIGINT;
+  -- menu item ids (Demo Noodle House)
   v_beef_noodle    BIGINT;
   v_dan_dan        BIGINT;
   v_wonton         BIGINT;
   v_cold_sesame    BIGINT;
+  -- menu item ids (Demo Green Bowl)
   v_teriyaki       BIGINT;
   v_salmon_poke    BIGINT;
   v_quinoa         BIGINT;
@@ -314,12 +368,16 @@ BEGIN
   SELECT id INTO v_emp1   FROM users WHERE email = 'demo.employee1@corpmeal.local';
   SELECT id INTO v_emp2   FROM users WHERE email = 'demo.employee2@corpmeal.local';
   SELECT id INTO v_emp3   FROM users WHERE email = 'demo.employee3@corpmeal.local';
+  SELECT id INTO v_sunny  FROM vendors WHERE name = 'Sunny Kitchen'     LIMIT 1;
   SELECT id INTO v_noodle FROM vendors WHERE name = 'Demo Noodle House' LIMIT 1;
   SELECT id INTO v_green  FROM vendors WHERE name = 'Demo Green Bowl'   LIMIT 1;
   SELECT id INTO v_f12a   FROM facilities WHERE code = 'F12A';
   SELECT id INTO v_f14b   FROM facilities WHERE code = 'F14B';
   SELECT id INTO v_f15a   FROM facilities WHERE code = 'F15A';
 
+  SELECT id INTO v_chicken_rice FROM menu_items WHERE vendor_id = v_sunny  AND name = 'Chicken Rice Box';
+  SELECT id INTO v_pork_chop    FROM menu_items WHERE vendor_id = v_sunny  AND name = 'Pork Chop Box';
+  SELECT id INTO v_veggie_box   FROM menu_items WHERE vendor_id = v_sunny  AND name = 'Veggie Box';
   SELECT id INTO v_beef_noodle  FROM menu_items WHERE vendor_id = v_noodle AND name = 'Beef Noodle Soup';
   SELECT id INTO v_dan_dan      FROM menu_items WHERE vendor_id = v_noodle AND name = 'Dan Dan Noodles';
   SELECT id INTO v_wonton       FROM menu_items WHERE vendor_id = v_noodle AND name = 'Wonton Noodle Soup';
@@ -363,16 +421,16 @@ BEGIN
   INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
   VALUES (v_order_id, v_wonton, 'Wonton Noodle Soup', 1, 8000, 8000);
 
-  -- ── ORDER 4: employee1 @ Demo Green Bowl, 35 days ago, delivered, 2x Teriyaki ──
+  -- ── ORDER 4: employee1 @ Sunny Kitchen, 35 days ago, delivered, 2x Chicken Rice Box ──
   INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
                       created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
-  VALUES (v_emp1, v_green, v_f12a, 'delivered', 19000,
+  VALUES (v_emp1, v_sunny, v_f12a, 'delivered', 17000,
           (NOW() - INTERVAL '35 days')::DATE,
           NOW() - INTERVAL '35 days', NOW() - INTERVAL '35 days',
           NOW() - INTERVAL '35 days', v_emp1)
   RETURNING id INTO v_order_id;
   INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
-  VALUES (v_order_id, v_teriyaki, 'Teriyaki Chicken Bowl', 2, 9500, 19000);
+  VALUES (v_order_id, v_chicken_rice, 'Chicken Rice Box', 2, 8500, 17000);
 
   -- ── ORDER 5: employee3 @ Demo Green Bowl, 33 days ago, delivered, 1x Salmon Poke ──
   INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
@@ -430,38 +488,40 @@ BEGIN
   INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
   VALUES (v_order_id, v_dan_dan, 'Dan Dan Noodles', 1, 8500, 8500);
 
-  -- ── ORDER 10: employee1 @ Demo Green Bowl, 20 days ago, delivered, 2x Teriyaki ──
+  -- ── ORDER 10: employee2 @ Sunny Kitchen, 20 days ago, delivered, 1x Pork Chop Box + 1x Chicken Rice Box ──
   INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
                       created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
-  VALUES (v_emp1, v_green, v_f12a, 'delivered', 19000,
+  VALUES (v_emp2, v_sunny, v_f12a, 'delivered', 17500,
           (NOW() - INTERVAL '20 days')::DATE,
           NOW() - INTERVAL '20 days', NOW() - INTERVAL '20 days',
-          NOW() - INTERVAL '20 days', v_emp1)
+          NOW() - INTERVAL '20 days', v_emp2)
   RETURNING id INTO v_order_id;
   INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
-  VALUES (v_order_id, v_teriyaki, 'Teriyaki Chicken Bowl', 2, 9500, 19000);
+  VALUES (v_order_id, v_pork_chop,    'Pork Chop Box',    1, 9000, 9000),
+         (v_order_id, v_chicken_rice, 'Chicken Rice Box', 1, 8500, 8500);
 
-  -- ── ORDER 11: employee3 @ Demo Noodle House, 18 days ago, delivered, 1x Beef ──
+  -- ── ORDER 11: employee3 @ Demo Green Bowl, 18 days ago, delivered, 1x Teriyaki + 1x Tofu Miso ──
   INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
                       created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
-  VALUES (v_emp3, v_noodle, v_f15a, 'delivered', 9000,
+  VALUES (v_emp3, v_green, v_f15a, 'delivered', 17500,
           (NOW() - INTERVAL '18 days')::DATE,
           NOW() - INTERVAL '18 days', NOW() - INTERVAL '18 days',
           NOW() - INTERVAL '18 days', v_emp3)
   RETURNING id INTO v_order_id;
   INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
-  VALUES (v_order_id, v_beef_noodle, 'Beef Noodle Soup', 1, 9000, 9000);
+  VALUES (v_order_id, v_teriyaki,  'Teriyaki Chicken Bowl', 1, 9500, 9500),
+         (v_order_id, v_tofu_miso, 'Tofu Miso Bowl',        1, 8000, 8000);
 
-  -- ── ORDER 12: employee2 @ Demo Green Bowl, 15 days ago, delivered, 1x Salmon Poke ──
+  -- ── ORDER 12: employee1 @ Sunny Kitchen, 15 days ago, delivered, 1x Pork Chop Box ──
   INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
                       created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
-  VALUES (v_emp2, v_green, v_f14b, 'delivered', 13000,
+  VALUES (v_emp1, v_sunny, v_f12a, 'delivered', 9000,
           (NOW() - INTERVAL '15 days')::DATE,
           NOW() - INTERVAL '15 days', NOW() - INTERVAL '15 days',
-          NOW() - INTERVAL '15 days', v_emp2)
+          NOW() - INTERVAL '15 days', v_emp1)
   RETURNING id INTO v_order_id;
   INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
-  VALUES (v_order_id, v_salmon_poke, 'Salmon Poke Bowl', 1, 13000, 13000);
+  VALUES (v_order_id, v_pork_chop, 'Pork Chop Box', 1, 9000, 9000);
 
   -- ── ORDER 13: employee1 @ Demo Noodle House, 12 days ago, cancelled ──
   INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
@@ -497,39 +557,40 @@ BEGIN
   VALUES (v_order_id, v_beef_noodle,  'Beef Noodle Soup',  1, 9000, 9000),
          (v_order_id, v_cold_sesame, 'Cold Sesame Noodles', 1, 7500, 7500);
 
-  -- ── ORDER 16: employee1 @ Demo Green Bowl, 6 days ago, delivered, 1x Teriyaki + 1x Salmon Poke ──
+  -- ── ORDER 16: employee2 @ Sunny Kitchen, 6 days ago, delivered, 1x Chicken Rice Box + 1x Veggie Box ──
   INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
                       created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
-  VALUES (v_emp1, v_green, v_f12a, 'delivered', 22500,
+  VALUES (v_emp2, v_sunny, v_f12a, 'delivered', 16000,
           (NOW() - INTERVAL '6 days')::DATE,
           NOW() - INTERVAL '6 days', NOW() - INTERVAL '6 days',
-          NOW() - INTERVAL '6 days', v_emp1)
+          NOW() - INTERVAL '6 days', v_emp2)
   RETURNING id INTO v_order_id;
   INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
-  VALUES (v_order_id, v_teriyaki,    'Teriyaki Chicken Bowl', 1, 9500, 9500),
-         (v_order_id, v_salmon_poke, 'Salmon Poke Bowl',      1, 13000, 13000);
+  VALUES (v_order_id, v_chicken_rice, 'Chicken Rice Box', 1, 8500, 8500),
+         (v_order_id, v_veggie_box,   'Veggie Box',       1, 7500, 7500);
 
-  -- ── ORDER 17: employee3 @ Demo Noodle House, 5 days ago, delivered, 2x Dan Dan ──
+  -- ── ORDER 17: employee3 @ Demo Green Bowl, 5 days ago, delivered, 2x Teriyaki ──
   INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
                       created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
-  VALUES (v_emp3, v_noodle, v_f15a, 'delivered', 17000,
+  VALUES (v_emp3, v_green, v_f15a, 'delivered', 19000,
           (NOW() - INTERVAL '5 days')::DATE,
           NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days',
           NOW() - INTERVAL '5 days', v_emp3)
   RETURNING id INTO v_order_id;
   INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
-  VALUES (v_order_id, v_dan_dan, 'Dan Dan Noodles', 2, 8500, 17000);
+  VALUES (v_order_id, v_teriyaki, 'Teriyaki Chicken Bowl', 2, 9500, 19000);
 
-  -- ── ORDER 18: employee2 @ Demo Green Bowl, 3 days ago, delivered, 2x Quinoa ──
+  -- ── ORDER 18: employee2 @ Demo Noodle House, 3 days ago, delivered, 1x Beef Noodle + 1x Wonton ──
   INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
                       created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
-  VALUES (v_emp2, v_green, v_f14b, 'delivered', 17600,
+  VALUES (v_emp2, v_noodle, v_f14b, 'delivered', 17000,
           (NOW() - INTERVAL '3 days')::DATE,
           NOW() - INTERVAL '3 days', NOW() - INTERVAL '3 days',
           NOW() - INTERVAL '3 days', v_emp2)
   RETURNING id INTO v_order_id;
   INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
-  VALUES (v_order_id, v_quinoa, 'Quinoa Veggie Bowl', 2, 8800, 17600);
+  VALUES (v_order_id, v_beef_noodle, 'Beef Noodle Soup',   1, 9000, 9000),
+         (v_order_id, v_wonton,      'Wonton Noodle Soup', 1, 8000, 8000);
 
   -- ── ORDER 19: employee1 @ Demo Noodle House, 2 days ago, pending, 1x Beef ──
   INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,

--- a/backend/db/seeds/demo_seed.sql
+++ b/backend/db/seeds/demo_seed.sql
@@ -1,0 +1,2 @@
+-- Demo dataset for staging/preview (SEED_DEMO_DATA=true). Populated in a later task.
+SELECT 1;

--- a/backend/db/seeds/demo_seed.sql
+++ b/backend/db/seeds/demo_seed.sql
@@ -1,2 +1,554 @@
--- Demo dataset for staging/preview (SEED_DEMO_DATA=true). Populated in a later task.
-SELECT 1;
+-- Demo dataset for staging/preview (SEED_DEMO_DATA=true).
+-- Idempotent: safe to run on every startup. Uses ON CONFLICT DO NOTHING
+-- and natural-key lookups throughout. The orders block is guarded by an
+-- existence check so re-runs do NOT create duplicate orders.
+
+-- ─────────────────────────────────────────────
+-- 1. FACILITIES
+-- ─────────────────────────────────────────────
+INSERT INTO facilities (code, name)
+VALUES
+  ('F12A', 'Fab 12A'),
+  ('F14B', 'Fab 14B'),
+  ('F15A', 'Fab 15A')
+ON CONFLICT (code) DO NOTHING;
+
+-- ─────────────────────────────────────────────
+-- 2. DEMO VENDOR USERS (vendor_manager role)
+--    password = "password123" (same bcrypt cost as 003_auth.sql)
+-- ─────────────────────────────────────────────
+INSERT INTO users (email, display_name, role_id, password_hash)
+VALUES (
+  'demo.noodle@corpmeal.local',
+  'Demo Noodle Manager',
+  (SELECT id FROM roles WHERE name = 'vendor_manager'),
+  '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG'
+)
+ON CONFLICT (email) DO NOTHING;
+
+INSERT INTO users (email, display_name, role_id, password_hash)
+VALUES (
+  'demo.greenbowl@corpmeal.local',
+  'Demo Green Bowl Manager',
+  (SELECT id FROM roles WHERE name = 'vendor_manager'),
+  '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG'
+)
+ON CONFLICT (email) DO NOTHING;
+
+-- ─────────────────────────────────────────────
+-- 3. DEMO VENDORS (status 'approved')
+-- ─────────────────────────────────────────────
+INSERT INTO vendors (name, status, contact_email, owner_user_id)
+SELECT
+  'Demo Noodle House',
+  'approved',
+  'demo.noodle@corpmeal.local',
+  (SELECT id FROM users WHERE email = 'demo.noodle@corpmeal.local')
+WHERE NOT EXISTS (SELECT 1 FROM vendors WHERE name = 'Demo Noodle House');
+
+INSERT INTO vendors (name, status, contact_email, owner_user_id)
+SELECT
+  'Demo Green Bowl',
+  'approved',
+  'demo.greenbowl@corpmeal.local',
+  (SELECT id FROM users WHERE email = 'demo.greenbowl@corpmeal.local')
+WHERE NOT EXISTS (SELECT 1 FROM vendors WHERE name = 'Demo Green Bowl');
+
+-- ─────────────────────────────────────────────
+-- 4. VENDOR FACILITIES
+--    Sunny Kitchen → F12A (already done by migration 006, kept idempotent)
+--    Demo Noodle House → F12A + F14B
+--    Demo Green Bowl → F15A
+-- ─────────────────────────────────────────────
+DO $$
+DECLARE
+  v_f12a   BIGINT;
+  v_f14b   BIGINT;
+  v_f15a   BIGINT;
+  v_sunny  BIGINT;
+  v_noodle BIGINT;
+  v_green  BIGINT;
+BEGIN
+  SELECT id INTO v_f12a   FROM facilities WHERE code = 'F12A';
+  SELECT id INTO v_f14b   FROM facilities WHERE code = 'F14B';
+  SELECT id INTO v_f15a   FROM facilities WHERE code = 'F15A';
+  SELECT id INTO v_sunny  FROM vendors     WHERE name = 'Sunny Kitchen'     LIMIT 1;
+  SELECT id INTO v_noodle FROM vendors     WHERE name = 'Demo Noodle House' LIMIT 1;
+  SELECT id INTO v_green  FROM vendors     WHERE name = 'Demo Green Bowl'   LIMIT 1;
+
+  IF v_sunny IS NOT NULL THEN
+    INSERT INTO vendor_facilities VALUES (v_sunny, v_f12a) ON CONFLICT DO NOTHING;
+  END IF;
+
+  IF v_noodle IS NOT NULL THEN
+    INSERT INTO vendor_facilities VALUES (v_noodle, v_f12a) ON CONFLICT DO NOTHING;
+    INSERT INTO vendor_facilities VALUES (v_noodle, v_f14b) ON CONFLICT DO NOTHING;
+  END IF;
+
+  IF v_green IS NOT NULL THEN
+    INSERT INTO vendor_facilities VALUES (v_green, v_f15a) ON CONFLICT DO NOTHING;
+  END IF;
+END $$;
+
+-- ─────────────────────────────────────────────
+-- 5. MENU CATEGORIES + ITEMS
+--    Demo Noodle House: category "Noodles", 4 items
+--    Demo Green Bowl:   category "Bowls",   4 items
+-- ─────────────────────────────────────────────
+DO $$
+DECLARE
+  v_noodle_id  BIGINT;
+  v_green_id   BIGINT;
+  v_cat_noodle BIGINT;
+  v_cat_green  BIGINT;
+BEGIN
+  SELECT id INTO v_noodle_id FROM vendors WHERE name = 'Demo Noodle House' LIMIT 1;
+  SELECT id INTO v_green_id  FROM vendors WHERE name = 'Demo Green Bowl'   LIMIT 1;
+
+  -- ── Demo Noodle House ──────────────────────
+  IF v_noodle_id IS NOT NULL THEN
+    INSERT INTO menu_categories (vendor_id, name, sort_order)
+    VALUES (v_noodle_id, 'Noodles', 1)
+    ON CONFLICT (vendor_id, name) DO NOTHING;
+
+    SELECT id INTO v_cat_noodle
+    FROM menu_categories WHERE vendor_id = v_noodle_id AND name = 'Noodles';
+
+    -- top-seller: Beef Noodle Soup (quota 50, cheap)
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available)
+    SELECT v_noodle_id, v_cat_noodle,
+           'Beef Noodle Soup',
+           'Rich broth with hand-pulled noodles and slow-braised beef',
+           9000, 50, TRUE
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_noodle_id AND name = 'Beef Noodle Soup'
+    );
+
+    -- top-seller: Dan Dan Noodles (quota 50)
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available)
+    SELECT v_noodle_id, v_cat_noodle,
+           'Dan Dan Noodles',
+           'Spicy Sichuan sesame noodles with minced pork',
+           8500, 50, TRUE
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_noodle_id AND name = 'Dan Dan Noodles'
+    );
+
+    -- medium-seller: Wonton Noodle Soup (quota 20)
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available)
+    SELECT v_noodle_id, v_cat_noodle,
+           'Wonton Noodle Soup',
+           'Silky wontons in clear chicken broth with egg noodles',
+           8000, 20, TRUE
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_noodle_id AND name = 'Wonton Noodle Soup'
+    );
+
+    -- low-seller: Cold Sesame Noodles (unlimited)
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available)
+    SELECT v_noodle_id, v_cat_noodle,
+           'Cold Sesame Noodles',
+           'Chilled noodles tossed in peanut sesame sauce',
+           7500, NULL, TRUE
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_noodle_id AND name = 'Cold Sesame Noodles'
+    );
+  END IF;
+
+  -- ── Demo Green Bowl ────────────────────────
+  IF v_green_id IS NOT NULL THEN
+    INSERT INTO menu_categories (vendor_id, name, sort_order)
+    VALUES (v_green_id, 'Bowls', 1)
+    ON CONFLICT (vendor_id, name) DO NOTHING;
+
+    SELECT id INTO v_cat_green
+    FROM menu_categories WHERE vendor_id = v_green_id AND name = 'Bowls';
+
+    -- top-seller: Teriyaki Chicken Bowl (quota 50)
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available)
+    SELECT v_green_id, v_cat_green,
+           'Teriyaki Chicken Bowl',
+           'Grilled chicken thigh glazed in house teriyaki over brown rice',
+           9500, 50, TRUE
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_green_id AND name = 'Teriyaki Chicken Bowl'
+    );
+
+    -- top-seller: Salmon Poke Bowl (quota 30)
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available)
+    SELECT v_green_id, v_cat_green,
+           'Salmon Poke Bowl',
+           'Sushi-grade salmon, avocado, edamame on sushi rice',
+           13000, 30, TRUE
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_green_id AND name = 'Salmon Poke Bowl'
+    );
+
+    -- medium-seller: Quinoa Veggie Bowl (unlimited)
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available)
+    SELECT v_green_id, v_cat_green,
+           'Quinoa Veggie Bowl',
+           'Tri-color quinoa with roasted seasonal vegetables and tahini',
+           8800, NULL, TRUE
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_green_id AND name = 'Quinoa Veggie Bowl'
+    );
+
+    -- low-seller: Tofu Miso Bowl (quota 20)
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available)
+    SELECT v_green_id, v_cat_green,
+           'Tofu Miso Bowl',
+           'Silken tofu and miso-glazed eggplant over steamed rice',
+           8000, 20, TRUE
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_green_id AND name = 'Tofu Miso Bowl'
+    );
+  END IF;
+END $$;
+
+-- ─────────────────────────────────────────────
+-- 6. DEMO EMPLOYEE USERS
+--    password = "password123"
+-- ─────────────────────────────────────────────
+INSERT INTO users (email, display_name, role_id, password_hash)
+VALUES (
+  'demo.employee1@corpmeal.local',
+  'Alice Wang',
+  (SELECT id FROM roles WHERE name = 'employee'),
+  '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG'
+)
+ON CONFLICT (email) DO NOTHING;
+
+INSERT INTO users (email, display_name, role_id, password_hash)
+VALUES (
+  'demo.employee2@corpmeal.local',
+  'Bob Chen',
+  (SELECT id FROM roles WHERE name = 'employee'),
+  '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG'
+)
+ON CONFLICT (email) DO NOTHING;
+
+INSERT INTO users (email, display_name, role_id, password_hash)
+VALUES (
+  'demo.employee3@corpmeal.local',
+  'Carol Liu',
+  (SELECT id FROM roles WHERE name = 'employee'),
+  '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG'
+)
+ON CONFLICT (email) DO NOTHING;
+
+-- ─────────────────────────────────────────────
+-- 7. EMPLOYEE FACILITIES
+--    employee1 → F12A
+--    employee2 → F12A + F14B
+--    employee3 → F15A
+-- ─────────────────────────────────────────────
+DO $$
+DECLARE
+  v_f12a  BIGINT;
+  v_f14b  BIGINT;
+  v_f15a  BIGINT;
+  v_emp1  BIGINT;
+  v_emp2  BIGINT;
+  v_emp3  BIGINT;
+BEGIN
+  SELECT id INTO v_f12a FROM facilities WHERE code = 'F12A';
+  SELECT id INTO v_f14b FROM facilities WHERE code = 'F14B';
+  SELECT id INTO v_f15a FROM facilities WHERE code = 'F15A';
+  SELECT id INTO v_emp1 FROM users WHERE email = 'demo.employee1@corpmeal.local';
+  SELECT id INTO v_emp2 FROM users WHERE email = 'demo.employee2@corpmeal.local';
+  SELECT id INTO v_emp3 FROM users WHERE email = 'demo.employee3@corpmeal.local';
+
+  IF v_emp1 IS NOT NULL THEN
+    INSERT INTO employee_facilities VALUES (v_emp1, v_f12a) ON CONFLICT DO NOTHING;
+  END IF;
+  IF v_emp2 IS NOT NULL THEN
+    INSERT INTO employee_facilities VALUES (v_emp2, v_f12a) ON CONFLICT DO NOTHING;
+    INSERT INTO employee_facilities VALUES (v_emp2, v_f14b) ON CONFLICT DO NOTHING;
+  END IF;
+  IF v_emp3 IS NOT NULL THEN
+    INSERT INTO employee_facilities VALUES (v_emp3, v_f15a) ON CONFLICT DO NOTHING;
+  END IF;
+END $$;
+
+-- ─────────────────────────────────────────────
+-- 8. ORDERS + ORDER ITEMS
+--    Guarded so re-runs do not create duplicates.
+--    ~20 orders spread over last 45 days (current + previous month data).
+--    Status mix: mostly delivered, a few pending, a couple cancelled.
+--    Item popularity: Beef Noodle Soup + Teriyaki Chicken Bowl are top sellers.
+-- ─────────────────────────────────────────────
+DO $$
+DECLARE
+  v_emp1       BIGINT;
+  v_emp2       BIGINT;
+  v_emp3       BIGINT;
+  v_noodle     BIGINT;
+  v_green      BIGINT;
+  v_f12a       BIGINT;
+  v_f14b       BIGINT;
+  v_f15a       BIGINT;
+
+  -- menu item ids
+  v_beef_noodle    BIGINT;
+  v_dan_dan        BIGINT;
+  v_wonton         BIGINT;
+  v_cold_sesame    BIGINT;
+  v_teriyaki       BIGINT;
+  v_salmon_poke    BIGINT;
+  v_quinoa         BIGINT;
+  v_tofu_miso      BIGINT;
+
+  v_order_id BIGINT;
+BEGIN
+  -- Guard: only insert orders if none exist for Demo Noodle House yet
+  IF EXISTS (
+    SELECT 1 FROM orders o
+    JOIN vendors v ON v.id = o.vendor_id
+    WHERE v.name = 'Demo Noodle House'
+  ) THEN
+    RETURN;
+  END IF;
+
+  -- Resolve IDs
+  SELECT id INTO v_emp1   FROM users WHERE email = 'demo.employee1@corpmeal.local';
+  SELECT id INTO v_emp2   FROM users WHERE email = 'demo.employee2@corpmeal.local';
+  SELECT id INTO v_emp3   FROM users WHERE email = 'demo.employee3@corpmeal.local';
+  SELECT id INTO v_noodle FROM vendors WHERE name = 'Demo Noodle House' LIMIT 1;
+  SELECT id INTO v_green  FROM vendors WHERE name = 'Demo Green Bowl'   LIMIT 1;
+  SELECT id INTO v_f12a   FROM facilities WHERE code = 'F12A';
+  SELECT id INTO v_f14b   FROM facilities WHERE code = 'F14B';
+  SELECT id INTO v_f15a   FROM facilities WHERE code = 'F15A';
+
+  SELECT id INTO v_beef_noodle  FROM menu_items WHERE vendor_id = v_noodle AND name = 'Beef Noodle Soup';
+  SELECT id INTO v_dan_dan      FROM menu_items WHERE vendor_id = v_noodle AND name = 'Dan Dan Noodles';
+  SELECT id INTO v_wonton       FROM menu_items WHERE vendor_id = v_noodle AND name = 'Wonton Noodle Soup';
+  SELECT id INTO v_cold_sesame  FROM menu_items WHERE vendor_id = v_noodle AND name = 'Cold Sesame Noodles';
+  SELECT id INTO v_teriyaki     FROM menu_items WHERE vendor_id = v_green  AND name = 'Teriyaki Chicken Bowl';
+  SELECT id INTO v_salmon_poke  FROM menu_items WHERE vendor_id = v_green  AND name = 'Salmon Poke Bowl';
+  SELECT id INTO v_quinoa       FROM menu_items WHERE vendor_id = v_green  AND name = 'Quinoa Veggie Bowl';
+  SELECT id INTO v_tofu_miso    FROM menu_items WHERE vendor_id = v_green  AND name = 'Tofu Miso Bowl';
+
+  -- ── ORDER 1: employee1 @ Demo Noodle House, 43 days ago, delivered, 2x Beef Noodle Soup ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp1, v_noodle, v_f12a, 'delivered', 18000,
+          (NOW() - INTERVAL '43 days')::DATE,
+          NOW() - INTERVAL '43 days', NOW() - INTERVAL '43 days',
+          NOW() - INTERVAL '43 days', v_emp1)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_beef_noodle, 'Beef Noodle Soup', 2, 9000, 18000);
+
+  -- ── ORDER 2: employee1 @ Demo Noodle House, 40 days ago, delivered, 1x Beef + 1x Dan Dan ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp1, v_noodle, v_f12a, 'delivered', 17500,
+          (NOW() - INTERVAL '40 days')::DATE,
+          NOW() - INTERVAL '40 days', NOW() - INTERVAL '40 days',
+          NOW() - INTERVAL '40 days', v_emp1)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_beef_noodle, 'Beef Noodle Soup', 1, 9000, 9000),
+         (v_order_id, v_dan_dan,     'Dan Dan Noodles',  1, 8500, 8500);
+
+  -- ── ORDER 3: employee2 @ Demo Noodle House, 38 days ago, delivered, 1x Wonton ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp2, v_noodle, v_f12a, 'delivered', 8000,
+          (NOW() - INTERVAL '38 days')::DATE,
+          NOW() - INTERVAL '38 days', NOW() - INTERVAL '38 days',
+          NOW() - INTERVAL '38 days', v_emp2)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_wonton, 'Wonton Noodle Soup', 1, 8000, 8000);
+
+  -- ── ORDER 4: employee1 @ Demo Green Bowl, 35 days ago, delivered, 2x Teriyaki ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp1, v_green, v_f12a, 'delivered', 19000,
+          (NOW() - INTERVAL '35 days')::DATE,
+          NOW() - INTERVAL '35 days', NOW() - INTERVAL '35 days',
+          NOW() - INTERVAL '35 days', v_emp1)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_teriyaki, 'Teriyaki Chicken Bowl', 2, 9500, 19000);
+
+  -- ── ORDER 5: employee3 @ Demo Green Bowl, 33 days ago, delivered, 1x Salmon Poke ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp3, v_green, v_f15a, 'delivered', 13000,
+          (NOW() - INTERVAL '33 days')::DATE,
+          NOW() - INTERVAL '33 days', NOW() - INTERVAL '33 days',
+          NOW() - INTERVAL '33 days', v_emp3)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_salmon_poke, 'Salmon Poke Bowl', 1, 13000, 13000);
+
+  -- ── ORDER 6: employee2 @ Demo Noodle House, 30 days ago, cancelled ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, cancelled_at)
+  VALUES (v_emp2, v_noodle, v_f14b, 'cancelled', 9000,
+          (NOW() - INTERVAL '30 days')::DATE,
+          NOW() - INTERVAL '30 days', NOW() - INTERVAL '30 days',
+          NOW() - INTERVAL '30 days')
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_beef_noodle, 'Beef Noodle Soup', 1, 9000, 9000);
+
+  -- ── ORDER 7: employee1 @ Demo Noodle House, 28 days ago, delivered, 2x Beef ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp1, v_noodle, v_f12a, 'delivered', 18000,
+          (NOW() - INTERVAL '28 days')::DATE,
+          NOW() - INTERVAL '28 days', NOW() - INTERVAL '28 days',
+          NOW() - INTERVAL '28 days', v_emp1)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_beef_noodle, 'Beef Noodle Soup', 2, 9000, 18000);
+
+  -- ── ORDER 8: employee3 @ Demo Green Bowl, 25 days ago, delivered, 1x Teriyaki + 1x Quinoa ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp3, v_green, v_f15a, 'delivered', 18300,
+          (NOW() - INTERVAL '25 days')::DATE,
+          NOW() - INTERVAL '25 days', NOW() - INTERVAL '25 days',
+          NOW() - INTERVAL '25 days', v_emp3)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_teriyaki, 'Teriyaki Chicken Bowl', 1, 9500, 9500),
+         (v_order_id, v_quinoa,   'Quinoa Veggie Bowl',    1, 8800, 8800);
+
+  -- ── ORDER 9: employee2 @ Demo Noodle House, 22 days ago, delivered, 1x Dan Dan ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp2, v_noodle, v_f14b, 'delivered', 8500,
+          (NOW() - INTERVAL '22 days')::DATE,
+          NOW() - INTERVAL '22 days', NOW() - INTERVAL '22 days',
+          NOW() - INTERVAL '22 days', v_emp2)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_dan_dan, 'Dan Dan Noodles', 1, 8500, 8500);
+
+  -- ── ORDER 10: employee1 @ Demo Green Bowl, 20 days ago, delivered, 2x Teriyaki ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp1, v_green, v_f12a, 'delivered', 19000,
+          (NOW() - INTERVAL '20 days')::DATE,
+          NOW() - INTERVAL '20 days', NOW() - INTERVAL '20 days',
+          NOW() - INTERVAL '20 days', v_emp1)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_teriyaki, 'Teriyaki Chicken Bowl', 2, 9500, 19000);
+
+  -- ── ORDER 11: employee3 @ Demo Noodle House, 18 days ago, delivered, 1x Beef ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp3, v_noodle, v_f15a, 'delivered', 9000,
+          (NOW() - INTERVAL '18 days')::DATE,
+          NOW() - INTERVAL '18 days', NOW() - INTERVAL '18 days',
+          NOW() - INTERVAL '18 days', v_emp3)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_beef_noodle, 'Beef Noodle Soup', 1, 9000, 9000);
+
+  -- ── ORDER 12: employee2 @ Demo Green Bowl, 15 days ago, delivered, 1x Salmon Poke ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp2, v_green, v_f14b, 'delivered', 13000,
+          (NOW() - INTERVAL '15 days')::DATE,
+          NOW() - INTERVAL '15 days', NOW() - INTERVAL '15 days',
+          NOW() - INTERVAL '15 days', v_emp2)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_salmon_poke, 'Salmon Poke Bowl', 1, 13000, 13000);
+
+  -- ── ORDER 13: employee1 @ Demo Noodle House, 12 days ago, cancelled ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, cancelled_at)
+  VALUES (v_emp1, v_noodle, v_f12a, 'cancelled', 8500,
+          (NOW() - INTERVAL '12 days')::DATE,
+          NOW() - INTERVAL '12 days', NOW() - INTERVAL '12 days',
+          NOW() - INTERVAL '12 days')
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_dan_dan, 'Dan Dan Noodles', 1, 8500, 8500);
+
+  -- ── ORDER 14: employee3 @ Demo Green Bowl, 10 days ago, delivered, 1x Tofu Miso ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp3, v_green, v_f15a, 'delivered', 8000,
+          (NOW() - INTERVAL '10 days')::DATE,
+          NOW() - INTERVAL '10 days', NOW() - INTERVAL '10 days',
+          NOW() - INTERVAL '10 days', v_emp3)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_tofu_miso, 'Tofu Miso Bowl', 1, 8000, 8000);
+
+  -- ── ORDER 15: employee2 @ Demo Noodle House, 8 days ago, delivered, 1x Beef + 1x Cold Sesame ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp2, v_noodle, v_f14b, 'delivered', 16500,
+          (NOW() - INTERVAL '8 days')::DATE,
+          NOW() - INTERVAL '8 days', NOW() - INTERVAL '8 days',
+          NOW() - INTERVAL '8 days', v_emp2)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_beef_noodle,  'Beef Noodle Soup',  1, 9000, 9000),
+         (v_order_id, v_cold_sesame, 'Cold Sesame Noodles', 1, 7500, 7500);
+
+  -- ── ORDER 16: employee1 @ Demo Green Bowl, 6 days ago, delivered, 1x Teriyaki + 1x Salmon Poke ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp1, v_green, v_f12a, 'delivered', 22500,
+          (NOW() - INTERVAL '6 days')::DATE,
+          NOW() - INTERVAL '6 days', NOW() - INTERVAL '6 days',
+          NOW() - INTERVAL '6 days', v_emp1)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_teriyaki,    'Teriyaki Chicken Bowl', 1, 9500, 9500),
+         (v_order_id, v_salmon_poke, 'Salmon Poke Bowl',      1, 13000, 13000);
+
+  -- ── ORDER 17: employee3 @ Demo Noodle House, 5 days ago, delivered, 2x Dan Dan ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp3, v_noodle, v_f15a, 'delivered', 17000,
+          (NOW() - INTERVAL '5 days')::DATE,
+          NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days',
+          NOW() - INTERVAL '5 days', v_emp3)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_dan_dan, 'Dan Dan Noodles', 2, 8500, 17000);
+
+  -- ── ORDER 18: employee2 @ Demo Green Bowl, 3 days ago, delivered, 2x Quinoa ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at, pickup_confirmed_at, pickup_confirmed_by_user_id)
+  VALUES (v_emp2, v_green, v_f14b, 'delivered', 17600,
+          (NOW() - INTERVAL '3 days')::DATE,
+          NOW() - INTERVAL '3 days', NOW() - INTERVAL '3 days',
+          NOW() - INTERVAL '3 days', v_emp2)
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_quinoa, 'Quinoa Veggie Bowl', 2, 8800, 17600);
+
+  -- ── ORDER 19: employee1 @ Demo Noodle House, 2 days ago, pending, 1x Beef ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at)
+  VALUES (v_emp1, v_noodle, v_f12a, 'pending', 9000,
+          (NOW() - INTERVAL '2 days')::DATE,
+          NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days')
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_beef_noodle, 'Beef Noodle Soup', 1, 9000, 9000);
+
+  -- ── ORDER 20: employee3 @ Demo Green Bowl, 1 day ago, pending, 1x Teriyaki ──
+  INSERT INTO orders (employee_id, vendor_id, facility_id, status, total_price_cents, meal_date,
+                      created_at, updated_at)
+  VALUES (v_emp3, v_green, v_f15a, 'pending', 9500,
+          (NOW() - INTERVAL '1 day')::DATE,
+          NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day')
+  RETURNING id INTO v_order_id;
+  INSERT INTO order_items (order_id, item_id, item_name, quantity, unit_price_cents, total_price_cents)
+  VALUES (v_order_id, v_teriyaki, 'Teriyaki Chicken Bowl', 1, 9500, 9500);
+
+END $$;

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from backend.core.config import settings
 from backend.core.errors import install_error_handler
 from backend.core.observability import RequestIDMiddleware, configure_logging
 from backend.db.migrate import run_migrations
+from backend.db.seed import run_demo_seed
 from backend.routes import (
     admin_stats,
     admin_users,
@@ -31,6 +32,7 @@ from backend.routes import (
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     run_migrations()
+    run_demo_seed()
     yield
 
 

--- a/backend/tests/integration/test_demo_seed_db.py
+++ b/backend/tests/integration/test_demo_seed_db.py
@@ -1,0 +1,35 @@
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="requires DATABASE_URL")
+
+
+def _count(cur, sql):
+    cur.execute(sql)
+    return cur.fetchone()["count"]
+
+
+def test_demo_seed_is_comprehensive_and_idempotent(monkeypatch):
+    from psycopg import connect
+    from psycopg.rows import dict_row
+    from backend.core.config import settings
+    from backend.db.migrate import run_migrations
+    from backend.db import seed
+
+    run_migrations()
+    monkeypatch.setattr(settings, "seed_demo_data", True)
+
+    seed.run_demo_seed()
+    conn = connect(os.environ["DATABASE_URL"], row_factory=dict_row, autocommit=True)
+    cur = conn.cursor()
+    assert _count(cur, "SELECT COUNT(*) AS count FROM facilities") >= 3
+    assert _count(cur, "SELECT COUNT(*) AS count FROM vendors WHERE status='approved'") >= 3
+    assert _count(cur, "SELECT COUNT(*) AS count FROM menu_items") >= 6
+    orders_1 = _count(cur, "SELECT COUNT(*) AS count FROM orders")
+    assert orders_1 >= 10
+    assert _count(cur, "SELECT COUNT(*) AS count FROM orders WHERE status='delivered'") >= 5
+
+    seed.run_demo_seed()  # second apply — must NOT duplicate
+    assert _count(cur, "SELECT COUNT(*) AS count FROM orders") == orders_1, "not idempotent"
+    conn.close()

--- a/backend/tests/integration/test_demo_seed_db.py
+++ b/backend/tests/integration/test_demo_seed_db.py
@@ -32,4 +32,41 @@ def test_demo_seed_is_comprehensive_and_idempotent(monkeypatch):
 
     seed.run_demo_seed()  # second apply — must NOT duplicate
     assert _count(cur, "SELECT COUNT(*) AS count FROM orders") == orders_1, "not idempotent"
+
+    # ── Facility-consistency assertions ──────────────────────────────────────
+    # Every order's facility_id must be in the employee's assigned facilities.
+    # Scoped to demo vendors to avoid interference from other tests' orders.
+    employee_facility_violations = _count(cur, """
+        SELECT COUNT(*) AS count
+        FROM orders o
+        JOIN vendors v ON v.id = o.vendor_id
+        WHERE v.name IN ('Sunny Kitchen', 'Demo Noodle House', 'Demo Green Bowl')
+          AND o.facility_id IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM employee_facilities ef
+            WHERE ef.employee_id = o.employee_id
+              AND ef.facility_id = o.facility_id
+          )
+    """)
+    assert employee_facility_violations == 0, (
+        f"{employee_facility_violations} demo order(s) have a facility_id not in the employee's facilities"
+    )
+
+    # Every order's facility_id must also be in the vendor's served facilities.
+    vendor_facility_violations = _count(cur, """
+        SELECT COUNT(*) AS count
+        FROM orders o
+        JOIN vendors v ON v.id = o.vendor_id
+        WHERE v.name IN ('Sunny Kitchen', 'Demo Noodle House', 'Demo Green Bowl')
+          AND o.facility_id IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM vendor_facilities vf
+            WHERE vf.vendor_id = o.vendor_id
+              AND vf.facility_id = o.facility_id
+          )
+    """)
+    assert vendor_facility_violations == 0, (
+        f"{vendor_facility_violations} demo order(s) have a facility_id not served by the vendor"
+    )
+
     conn.close()

--- a/backend/tests/test_demo_seed_gating.py
+++ b/backend/tests/test_demo_seed_gating.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+
+from backend.db import seed
+
+
+def test_skips_when_disabled():
+    with patch.object(seed.settings, "seed_demo_data", False), \
+         patch.object(seed, "get_connection") as conn:
+        seed.run_demo_seed()
+        conn.assert_not_called()
+
+
+def test_skips_when_no_database_url():
+    with patch.object(seed.settings, "seed_demo_data", True), \
+         patch.object(seed.settings, "database_url", ""), \
+         patch.object(seed, "get_connection") as conn:
+        seed.run_demo_seed()
+        conn.assert_not_called()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       ROOT_PATH: ${ROOT_PATH:-}
       DATABASE_URL: postgresql://${POSTGRES_USER:-meal_user}:${POSTGRES_PASSWORD:-change-me-in-local-env}@db:5432/${POSTGRES_DB:-meal_ordering}
+      SEED_DEMO_DATA: "true"
     volumes:
       - uploads:/app/uploads
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000

--- a/infra/deploy/docker-compose.preview.yml
+++ b/infra/deploy/docker-compose.preview.yml
@@ -8,6 +8,8 @@ services:
   backend:
     image: ghcr.io/mizu5555/mealorder-backend:${IMAGE_TAG}
     ports: !reset []
+    environment:
+      SEED_DEMO_DATA: "true"
     labels:
       mealorder.branch: ${BRANCH_RAW:-}
   frontend:

--- a/infra/deploy/docker-compose.staging.yml
+++ b/infra/deploy/docker-compose.staging.yml
@@ -26,6 +26,7 @@ services:
       # grafana-loki-1). Push handler is queue-backed, so unreachable Loki
       # degrades gracefully to stdout.
       LOKI_URL: http://loki:3100
+      SEED_DEMO_DATA: "true"
     cap_add:
       # Needed for `py-spy record --pid 1` to attach inside the container.
       # Scoped to staging so prod stays minimal-privilege.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,4 +7,4 @@ sonar.tests=backend/tests
 sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage.xml
 
-sonar.exclusions=backend/db/migrations/**,frontend/**,backend/tests/**
+sonar.exclusions=backend/db/migrations/**,backend/db/seeds/**,frontend/**,backend/tests/**


### PR DESCRIPTION
Refs #107 (Part B — the demo seed; Part A, the 福委會 facility-assignment back office, is a separate PR that will `Closes #107`).

## What
A `SEED_DEMO_DATA`-gated, **idempotent** demo dataset that auto-populates **staging & preview** (never prod) so the recommendation, dashboard, billing, and order-history features show real data without manual entry.

## How
- `seed_demo_data` setting (env `SEED_DEMO_DATA`); after `run_migrations()` at startup, `run_demo_seed()` applies `backend/db/seeds/demo_seed.sql` when enabled.
- The SQL is idempotent (ON CONFLICT / NOT-EXISTS everywhere; the orders block is guarded so a re-run can't duplicate) and ID-agnostic (all ids via subqueries). No destructive statements.
- `SEED_DEMO_DATA: "true"` set in `docker-compose.{staging,preview}.yml` + local `docker-compose.yml`; **prod compose untouched**.

## Dataset
3 facilities (F12A/F14B/F15A), 3 approved vendors with facility links, 8 menu items (varied price/quota), 3 demo employees (facility-assigned), 20 orders + items over the last ~45 days (current + previous month), status mix (delivered w/ pickups, pending, cancelled), uneven item popularity (clear top-sellers).

## Tests
- Unit: gating (off / no-DB → no-op).
- Integration (Postgres): applies the seed **twice** — asserts comprehensive coverage on the first apply and **no duplication** on the second (idempotency).
- Full suite green.

After merge + the next staging deploy, the demo data appears on staging (and on any PR preview, since preview compose now sets the flag) — making #105/#106/#108 visually verifiable with real data.
