### PR TITLE
feat(committee): facility-to-vendor assignment back office (#107)

### DIFF
--- a/backend/core/facilities.py
+++ b/backend/core/facilities.py
@@ -1,0 +1,15 @@
+"""Facility repository singletons + selection factory."""
+from __future__ import annotations
+
+from backend.core.config import settings
+from backend.repositories.facility_repository import FacilityRepository
+from backend.repositories.postgres_facility_repository import PostgresFacilityRepository
+
+_IN_MEMORY = FacilityRepository()
+_POSTGRES = PostgresFacilityRepository()
+
+
+def get_facility_repository():
+    if settings.database_url:
+        return _POSTGRES
+    return _IN_MEMORY

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ from backend.core.observability import RequestIDMiddleware, configure_logging
 from backend.db.migrate import run_migrations
 from backend.db.seed import run_demo_seed
 from backend.routes import (
+    admin_facilities,
     admin_stats,
     admin_users,
     admin_vendors,
@@ -63,6 +64,7 @@ def create_app() -> FastAPI:
     app.include_router(auth.router)
     app.include_router(admin_users.router)
     app.include_router(admin_vendors.router)
+    app.include_router(admin_facilities.router)
     app.include_router(committee_reviews.router)
     app.include_router(vendor_application.router)
     app.include_router(vendor_profile.router)

--- a/backend/repositories/facility_repository.py
+++ b/backend/repositories/facility_repository.py
@@ -1,0 +1,48 @@
+"""In-memory facility repository used when no DATABASE_URL is set."""
+from __future__ import annotations
+
+from backend.schemas.vendor_self import Facility
+
+
+class FacilityRepository:
+    """In-memory implementation of the facility admin repository."""
+
+    def __init__(self) -> None:
+        self._facilities: dict[int, Facility] = {}
+        self._code_index: dict[str, int] = {}  # code -> id
+        self._next_id: int = 1
+        self._vendor_facilities: dict[int, list[int]] = {}  # vendor_id -> [facility_id]
+
+    # ------------------------------------------------------------------
+    # Facilities
+    # ------------------------------------------------------------------
+
+    def list_facilities(self) -> list[Facility]:
+        """Return all facilities ordered by code."""
+        return sorted(self._facilities.values(), key=lambda f: f.code)
+
+    def create_facility(self, code: str, name: str) -> Facility:
+        """Create a facility; idempotent on code (returns existing row, no name overwrite)."""
+        if code in self._code_index:
+            return self._facilities[self._code_index[code]]
+        facility = Facility(id=self._next_id, code=code, name=name)
+        self._facilities[self._next_id] = facility
+        self._code_index[code] = self._next_id
+        self._next_id += 1
+        return facility
+
+    def facility_exists(self, facility_id: int) -> bool:
+        """Return True if a facility with the given id exists."""
+        return facility_id in self._facilities
+
+    # ------------------------------------------------------------------
+    # Vendor ↔ Facility assignments
+    # ------------------------------------------------------------------
+
+    def get_vendor_facility_ids(self, vendor_id: int) -> list[int]:
+        """Return the list of facility IDs assigned to a vendor."""
+        return list(self._vendor_facilities.get(vendor_id, []))
+
+    def set_vendor_facilities(self, vendor_id: int, facility_ids: list[int]) -> None:
+        """Replace the vendor's facility set with the given list."""
+        self._vendor_facilities[vendor_id] = list(facility_ids)

--- a/backend/repositories/postgres_facility_repository.py
+++ b/backend/repositories/postgres_facility_repository.py
@@ -1,0 +1,74 @@
+"""PostgreSQL-backed facility admin repository."""
+from __future__ import annotations
+
+from backend.db.connection import get_connection
+from backend.schemas.vendor_self import Facility
+
+
+class PostgresFacilityRepository:
+    """Postgres implementation of the facility admin repository."""
+
+    # ------------------------------------------------------------------
+    # Facilities
+    # ------------------------------------------------------------------
+
+    def list_facilities(self) -> list[Facility]:
+        """Return all facilities ordered by code."""
+        with get_connection() as conn:
+            rows = conn.execute(
+                "SELECT id, code, name FROM facilities ORDER BY code"
+            ).fetchall()
+        return [Facility(**dict(row)) for row in rows]
+
+    def create_facility(self, code: str, name: str) -> Facility:
+        """Create a facility; idempotent on code — returns existing row, no name overwrite."""
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                INSERT INTO facilities (code, name)
+                VALUES (%s, %s)
+                ON CONFLICT (code) DO UPDATE SET name = facilities.name
+                RETURNING id, code, name
+                """,
+                (code, name),
+            ).fetchone()
+        return Facility(**dict(row))
+
+    def facility_exists(self, facility_id: int) -> bool:
+        """Return True if a facility with the given id exists."""
+        with get_connection() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM facilities WHERE id = %s",
+                (facility_id,),
+            ).fetchone()
+        return row is not None
+
+    # ------------------------------------------------------------------
+    # Vendor ↔ Facility assignments
+    # ------------------------------------------------------------------
+
+    def get_vendor_facility_ids(self, vendor_id: int) -> list[int]:
+        """Return the list of facility IDs assigned to a vendor."""
+        with get_connection() as conn:
+            rows = conn.execute(
+                "SELECT facility_id FROM vendor_facilities WHERE vendor_id = %s",
+                (vendor_id,),
+            ).fetchall()
+        return [row["facility_id"] for row in rows]
+
+    def set_vendor_facilities(self, vendor_id: int, facility_ids: list[int]) -> None:
+        """Replace the vendor's facility set with the given list (within one transaction)."""
+        with get_connection() as conn:
+            conn.execute(
+                "DELETE FROM vendor_facilities WHERE vendor_id = %s",
+                (vendor_id,),
+            )
+            for fid in facility_ids:
+                conn.execute(
+                    """
+                    INSERT INTO vendor_facilities (vendor_id, facility_id)
+                    VALUES (%s, %s)
+                    ON CONFLICT DO NOTHING
+                    """,
+                    (vendor_id, fid),
+                )

--- a/backend/routes/admin_facilities.py
+++ b/backend/routes/admin_facilities.py
@@ -1,0 +1,74 @@
+"""Admin routes for facility management and vendor-facility assignments."""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+
+from backend.core.facilities import get_facility_repository
+from backend.core.rbac import get_current_user_id, get_current_user_role, require_roles
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.schemas.facility_admin import FacilityCreate, VendorFacilitiesUpdate
+from backend.schemas.vendor_self import Facility
+from backend.services.facility_admin_service import FacilityAdminService
+
+router = APIRouter(prefix="/admin", tags=["admin-facilities"])
+
+
+def _service(facility_repo, vendor_repo=None) -> FacilityAdminService:
+    return FacilityAdminService(
+        facility_repository=facility_repo,
+        vendor_repository=vendor_repo,
+    )
+
+
+@router.get("/facilities", response_model=list[Facility])
+def list_facilities(
+    _role: Annotated[str, Depends(require_roles("admin", "committee_reviewer"))],
+    repo: Annotated[object, Depends(get_facility_repository)],
+) -> list[Facility]:
+    return _service(repo).list_facilities()
+
+
+@router.post("/facilities", response_model=Facility, status_code=status.HTTP_201_CREATED)
+def create_facility(
+    body: FacilityCreate,
+    _role: Annotated[str, Depends(require_roles("admin", "committee_reviewer"))],
+    repo: Annotated[object, Depends(get_facility_repository)],
+    actor_id: Annotated[int | None, Depends(get_current_user_id)] = None,
+    actor_role: Annotated[str, Depends(get_current_user_role)] = "anonymous",
+) -> Facility:
+    return _service(repo).create_facility(
+        body.code,
+        body.name,
+        actor_user_id=actor_id,
+        actor_role=actor_role,
+    )
+
+
+@router.get("/vendors/{vendor_id}/facilities", response_model=list[Facility])
+def get_vendor_facilities(
+    vendor_id: int,
+    _role: Annotated[str, Depends(require_roles("admin", "committee_reviewer"))],
+    repo: Annotated[object, Depends(get_facility_repository)],
+    vendor_repo: Annotated[object, Depends(get_vendor_profile_repository)],
+) -> list[Facility]:
+    return _service(repo, vendor_repo).get_vendor_facilities(vendor_id)
+
+
+@router.put("/vendors/{vendor_id}/facilities", response_model=list[Facility])
+def set_vendor_facilities(
+    vendor_id: int,
+    body: VendorFacilitiesUpdate,
+    _role: Annotated[str, Depends(require_roles("admin", "committee_reviewer"))],
+    repo: Annotated[object, Depends(get_facility_repository)],
+    vendor_repo: Annotated[object, Depends(get_vendor_profile_repository)],
+    actor_id: Annotated[int | None, Depends(get_current_user_id)] = None,
+    actor_role: Annotated[str, Depends(get_current_user_role)] = "anonymous",
+) -> list[Facility]:
+    return _service(repo, vendor_repo).set_vendor_facilities(
+        vendor_id,
+        body.facility_ids,
+        actor_user_id=actor_id,
+        actor_role=actor_role,
+    )

--- a/backend/schemas/facility_admin.py
+++ b/backend/schemas/facility_admin.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class FacilityCreate(BaseModel):
+    code: str
+    name: str
+
+
+class VendorFacilitiesUpdate(BaseModel):
+    facility_ids: list[int]

--- a/backend/services/facility_admin_service.py
+++ b/backend/services/facility_admin_service.py
@@ -1,0 +1,95 @@
+"""FacilityAdminService — audited facility create and vendor assignment."""
+from __future__ import annotations
+
+from backend.core.errors import CodedHTTPException
+from backend.core.facilities import get_facility_repository
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.repositories.audit_log_repository import AuditLogRepository
+from backend.schemas.vendor_self import Facility
+
+
+class FacilityAdminService:
+    def __init__(
+        self,
+        facility_repository=None,
+        vendor_repository=None,
+        audit_log_repository: AuditLogRepository | None = None,
+    ) -> None:
+        self.facility_repository = facility_repository or get_facility_repository()
+        self.vendor_repository = vendor_repository or get_vendor_profile_repository()
+        self.audit_log_repository = audit_log_repository or AuditLogRepository()
+
+    # ------------------------------------------------------------------
+    # Facilities
+    # ------------------------------------------------------------------
+
+    def list_facilities(self) -> list[Facility]:
+        return self.facility_repository.list_facilities()
+
+    def create_facility(
+        self,
+        code: str,
+        name: str,
+        *,
+        actor_user_id: int | None = None,
+        actor_role: str | None = None,
+    ) -> Facility:
+        facility = self.facility_repository.create_facility(code, name)
+        self.audit_log_repository.record(
+            actor_user_id=actor_user_id,
+            actor_role=actor_role,
+            action="facility.create",
+            target_type="facility",
+            target_id=facility.id,
+            metadata={"code": code, "name": name},
+        )
+        return facility
+
+    # ------------------------------------------------------------------
+    # Vendor ↔ Facility assignments
+    # ------------------------------------------------------------------
+
+    def get_vendor_facilities(self, vendor_id: int) -> list[Facility]:
+        self._assert_vendor_exists(vendor_id)
+        facility_ids = set(self.facility_repository.get_vendor_facility_ids(vendor_id))
+        return [f for f in self.facility_repository.list_facilities() if f.id in facility_ids]
+
+    def set_vendor_facilities(
+        self,
+        vendor_id: int,
+        facility_ids: list[int],
+        *,
+        actor_user_id: int | None = None,
+        actor_role: str | None = None,
+    ) -> list[Facility]:
+        self._assert_vendor_exists(vendor_id)
+        for fid in facility_ids:
+            if not self.facility_repository.facility_exists(fid):
+                raise CodedHTTPException(
+                    status_code=404,
+                    code="not_found",
+                    detail="facility not found",
+                )
+        self.facility_repository.set_vendor_facilities(vendor_id, facility_ids)
+        self.audit_log_repository.record(
+            actor_user_id=actor_user_id,
+            actor_role=actor_role,
+            action="facility.assign",
+            target_type="vendor",
+            target_id=vendor_id,
+            metadata={"vendor_id": vendor_id, "facility_ids": list(facility_ids)},
+        )
+        return self.get_vendor_facilities(vendor_id)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _assert_vendor_exists(self, vendor_id: int) -> None:
+        record = self.vendor_repository.get(vendor_id)
+        if record is None:
+            raise CodedHTTPException(
+                status_code=404,
+                code="not_found",
+                detail="vendor not found",
+            )

--- a/backend/tests/integration/test_facility_repository_db.py
+++ b/backend/tests/integration/test_facility_repository_db.py
@@ -1,0 +1,101 @@
+"""Integration test for PostgresFacilityRepository — requires a live DATABASE_URL."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="requires DATABASE_URL")
+
+DATABASE_URL = os.getenv("DATABASE_URL", "")
+
+
+@pytest.fixture(scope="module")
+def migrated_db():
+    from backend.db.migrate import run_migrations
+
+    run_migrations()
+
+
+@pytest.fixture()
+def pg_conn():
+    """Raw psycopg connection for setup/teardown that bypasses the app's get_connection()."""
+    from psycopg import connect
+    from psycopg.rows import dict_row
+
+    conn = connect(DATABASE_URL, row_factory=dict_row, autocommit=True)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture()
+def vendor_id(migrated_db, pg_conn):
+    """Insert a temporary vendor and return its id; clean up afterwards."""
+    cur = pg_conn.cursor()
+    cur.execute(
+        "INSERT INTO vendors (name, status, contact_email) "
+        "VALUES ('Facility Test', 'approved', 'ft@example.com') RETURNING id"
+    )
+    vid = cur.fetchone()["id"]
+    yield vid
+    cur.execute("DELETE FROM vendor_facilities WHERE vendor_id = %s", (vid,))
+    cur.execute("DELETE FROM vendors WHERE id = %s", (vid,))
+
+
+def test_create_and_list(migrated_db, pg_conn, vendor_id):
+    from backend.repositories.postgres_facility_repository import PostgresFacilityRepository
+
+    repo = PostgresFacilityRepository()
+
+    fa = repo.create_facility("FTEST_A", "Integration Fab A")
+    fb = repo.create_facility("FTEST_B", "Integration Fab B")
+
+    try:
+        all_codes = [f.code for f in repo.list_facilities()]
+        assert "FTEST_A" in all_codes
+        assert "FTEST_B" in all_codes
+
+        # idempotency: second call with different name must return same row
+        fa_dup = repo.create_facility("FTEST_A", "Should Not Override")
+        assert fa_dup.id == fa.id
+        assert fa_dup.name == "Integration Fab A"
+    finally:
+        cur = pg_conn.cursor()
+        cur.execute("DELETE FROM facilities WHERE code IN ('FTEST_A', 'FTEST_B')")
+
+
+def test_set_and_get_vendor_facilities(migrated_db, pg_conn, vendor_id):
+    from backend.repositories.postgres_facility_repository import PostgresFacilityRepository
+
+    repo = PostgresFacilityRepository()
+
+    fa = repo.create_facility("FTEST_C", "Integration Fab C")
+    fb = repo.create_facility("FTEST_D", "Integration Fab D")
+
+    try:
+        repo.set_vendor_facilities(vendor_id, [fa.id, fb.id])
+        ids = repo.get_vendor_facility_ids(vendor_id)
+        assert sorted(ids) == sorted([fa.id, fb.id])
+
+        # Replace with only one facility
+        repo.set_vendor_facilities(vendor_id, [fa.id])
+        ids = repo.get_vendor_facility_ids(vendor_id)
+        assert ids == [fa.id]
+    finally:
+        cur = pg_conn.cursor()
+        cur.execute("DELETE FROM vendor_facilities WHERE vendor_id = %s", (vendor_id,))
+        cur.execute("DELETE FROM facilities WHERE code IN ('FTEST_C', 'FTEST_D')")
+
+
+def test_facility_exists(migrated_db, pg_conn):
+    from backend.repositories.postgres_facility_repository import PostgresFacilityRepository
+
+    repo = PostgresFacilityRepository()
+
+    f = repo.create_facility("FTEST_E", "Integration Fab E")
+    try:
+        assert repo.facility_exists(f.id)
+        assert not repo.facility_exists(99999)
+    finally:
+        cur = pg_conn.cursor()
+        cur.execute("DELETE FROM facilities WHERE code = 'FTEST_E'")

--- a/backend/tests/test_admin_facilities_route.py
+++ b/backend/tests/test_admin_facilities_route.py
@@ -1,0 +1,199 @@
+"""Route tests for GET/POST /admin/facilities and GET/PUT /admin/vendors/{id}/facilities."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from backend.core.facilities import get_facility_repository
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.facility_repository import FacilityRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+
+client = TestClient(app)
+
+_ADMIN_HEADERS = {"x-user-role": "admin"}
+_COMMITTEE_HEADERS = {"x-user-role": "committee_reviewer"}
+_EMPLOYEE_HEADERS = {"x-user-role": "employee"}
+
+
+def _override_facility_repo(repo: FacilityRepository) -> None:
+    app.dependency_overrides[get_facility_repository] = lambda: repo
+
+
+def _override_vendor_repo(repo: VendorProfileRepository) -> None:
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: repo
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# RBAC guard
+# ---------------------------------------------------------------------------
+
+
+def test_list_facilities_employee_forbidden() -> None:
+    _override_facility_repo(FacilityRepository())
+    r = client.get("/admin/facilities", headers=_EMPLOYEE_HEADERS)
+    assert r.status_code == 403
+
+
+def test_create_facility_employee_forbidden() -> None:
+    _override_facility_repo(FacilityRepository())
+    r = client.post(
+        "/admin/facilities",
+        json={"code": "FAB1", "name": "Fab 1"},
+        headers=_EMPLOYEE_HEADERS,
+    )
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/facilities
+# ---------------------------------------------------------------------------
+
+
+def test_list_facilities_empty_for_admin() -> None:
+    _override_facility_repo(FacilityRepository())
+    r = client.get("/admin/facilities", headers=_ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_list_facilities_returns_seeded_data() -> None:
+    repo = FacilityRepository()
+    repo.create_facility("F12A", "Fab 12A")
+    repo.create_facility("F12B", "Fab 12B")
+    _override_facility_repo(repo)
+    r = client.get("/admin/facilities", headers=_COMMITTEE_HEADERS)
+    assert r.status_code == 200
+    codes = [f["code"] for f in r.json()]
+    assert codes == ["F12A", "F12B"]
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/facilities
+# ---------------------------------------------------------------------------
+
+
+def test_create_facility_returns_201() -> None:
+    _override_facility_repo(FacilityRepository())
+    r = client.post(
+        "/admin/facilities",
+        json={"code": "FAB9", "name": "Fab 9"},
+        headers=_ADMIN_HEADERS,
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["code"] == "FAB9"
+    assert body["name"] == "Fab 9"
+    assert isinstance(body["id"], int)
+
+
+def test_create_facility_idempotent_on_code() -> None:
+    """Posting the same code twice returns the same facility (no 4xx)."""
+    _override_facility_repo(FacilityRepository())
+    r1 = client.post("/admin/facilities", json={"code": "DUP", "name": "First"}, headers=_ADMIN_HEADERS)
+    r2 = client.post("/admin/facilities", json={"code": "DUP", "name": "Second"}, headers=_ADMIN_HEADERS)
+    assert r1.status_code == 201
+    assert r2.status_code == 201
+    assert r1.json()["id"] == r2.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/vendors/{vendor_id}/facilities
+# ---------------------------------------------------------------------------
+
+
+def _setup_vendor_and_facility():
+    """Return (facility_repo, vendor_repo) with vendor id=1 and facility id seeded."""
+    f_repo = FacilityRepository()
+    f_repo.create_facility("F01", "Fab 01")  # id=1
+    v_repo = VendorProfileRepository()
+    v_repo.seed(VendorRecord(id=1, name="Sunny Kitchen", status="approved"))
+    return f_repo, v_repo
+
+
+def test_get_vendor_facilities_empty() -> None:
+    f_repo, v_repo = _setup_vendor_and_facility()
+    _override_facility_repo(f_repo)
+    _override_vendor_repo(v_repo)
+    r = client.get("/admin/vendors/1/facilities", headers=_ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_get_vendor_facilities_returns_assigned() -> None:
+    f_repo, v_repo = _setup_vendor_and_facility()
+    f_repo.set_vendor_facilities(1, [1])
+    _override_facility_repo(f_repo)
+    _override_vendor_repo(v_repo)
+    r = client.get("/admin/vendors/1/facilities", headers=_ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json()[0]["code"] == "F01"
+
+
+def test_get_vendor_facilities_missing_vendor_404() -> None:
+    f_repo = FacilityRepository()
+    v_repo = VendorProfileRepository()  # no vendors seeded
+    _override_facility_repo(f_repo)
+    _override_vendor_repo(v_repo)
+    r = client.get("/admin/vendors/999/facilities", headers=_ADMIN_HEADERS)
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PUT /admin/vendors/{vendor_id}/facilities
+# ---------------------------------------------------------------------------
+
+
+def test_put_vendor_facilities_assigns_correctly() -> None:
+    f_repo, v_repo = _setup_vendor_and_facility()
+    _override_facility_repo(f_repo)
+    _override_vendor_repo(v_repo)
+    r = client.put(
+        "/admin/vendors/1/facilities",
+        json={"facility_ids": [1]},
+        headers=_ADMIN_HEADERS,
+    )
+    assert r.status_code == 200
+    assert r.json()[0]["code"] == "F01"
+
+
+def test_put_vendor_facilities_nonexistent_facility_404() -> None:
+    f_repo, v_repo = _setup_vendor_and_facility()
+    _override_facility_repo(f_repo)
+    _override_vendor_repo(v_repo)
+    r = client.put(
+        "/admin/vendors/1/facilities",
+        json={"facility_ids": [999]},  # facility 999 does not exist
+        headers=_ADMIN_HEADERS,
+    )
+    assert r.status_code == 404
+
+
+def test_put_vendor_facilities_missing_vendor_404() -> None:
+    f_repo = FacilityRepository()
+    f_repo.create_facility("F01", "Fab 01")
+    v_repo = VendorProfileRepository()  # no vendor seeded
+    _override_facility_repo(f_repo)
+    _override_vendor_repo(v_repo)
+    r = client.put(
+        "/admin/vendors/999/facilities",
+        json={"facility_ids": [1]},
+        headers=_ADMIN_HEADERS,
+    )
+    assert r.status_code == 404
+
+
+def test_put_vendor_facilities_employee_forbidden() -> None:
+    f_repo, v_repo = _setup_vendor_and_facility()
+    _override_facility_repo(f_repo)
+    _override_vendor_repo(v_repo)
+    r = client.put(
+        "/admin/vendors/1/facilities",
+        json={"facility_ids": []},
+        headers=_EMPLOYEE_HEADERS,
+    )
+    assert r.status_code == 403

--- a/backend/tests/test_facility_admin_service.py
+++ b/backend/tests/test_facility_admin_service.py
@@ -1,0 +1,130 @@
+"""Tests for FacilityAdminService — audited facility create/assign."""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.errors import CodedHTTPException
+from backend.repositories.audit_log_repository import AuditLogRepository
+from backend.repositories.facility_repository import FacilityRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.services.facility_admin_service import FacilityAdminService
+
+
+def _make_service() -> tuple[FacilityAdminService, FacilityRepository, VendorProfileRepository, AuditLogRepository]:
+    facility_repo = FacilityRepository()
+    vendor_repo = VendorProfileRepository()
+    vendor_repo.seed(VendorRecord(id=1, name="Sunny Kitchen", status="approved"))
+    audit_repo = AuditLogRepository()
+    svc = FacilityAdminService(
+        facility_repository=facility_repo,
+        vendor_repository=vendor_repo,
+        audit_log_repository=audit_repo,
+    )
+    return svc, facility_repo, vendor_repo, audit_repo
+
+
+# ------------------------------------------------------------------
+# create_facility
+# ------------------------------------------------------------------
+
+def test_create_facility_returns_facility_and_audits() -> None:
+    svc, _, _, audit_repo = _make_service()
+
+    facility = svc.create_facility("HQ1", "Headquarters 1", actor_user_id=99, actor_role="admin")
+
+    assert facility.code == "HQ1"
+    assert facility.name == "Headquarters 1"
+    assert facility.id is not None
+
+    entries = audit_repo.list(action="facility.create")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.target_type == "facility"
+    assert entry.target_id == facility.id
+    assert entry.actor_user_id == 99
+    assert entry.actor_role == "admin"
+    assert entry.metadata["code"] == "HQ1"
+    assert entry.metadata["name"] == "Headquarters 1"
+
+
+# ------------------------------------------------------------------
+# set_vendor_facilities / get_vendor_facilities
+# ------------------------------------------------------------------
+
+def test_set_and_get_vendor_facilities() -> None:
+    svc, facility_repo, _, audit_repo = _make_service()
+
+    f1 = facility_repo.create_facility("F01", "Facility One")
+    f2 = facility_repo.create_facility("F02", "Facility Two")
+
+    result = svc.set_vendor_facilities(1, [f1.id, f2.id], actor_user_id=10, actor_role="admin")
+
+    assert {f.id for f in result} == {f1.id, f2.id}
+
+    # audit entry
+    entries = audit_repo.list(action="facility.assign")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.target_type == "vendor"
+    assert entry.target_id == 1
+    assert entry.actor_user_id == 10
+    assert entry.actor_role == "admin"
+    assert entry.metadata["vendor_id"] == 1
+    assert set(entry.metadata["facility_ids"]) == {f1.id, f2.id}
+
+    # get_vendor_facilities reflects the new assignment
+    fetched = svc.get_vendor_facilities(1)
+    assert {f.id for f in fetched} == {f1.id, f2.id}
+
+
+def test_set_vendor_facilities_replaces_previous_assignment() -> None:
+    svc, facility_repo, _, _ = _make_service()
+
+    f1 = facility_repo.create_facility("A1", "Alpha")
+    f2 = facility_repo.create_facility("B1", "Beta")
+
+    svc.set_vendor_facilities(1, [f1.id])
+    svc.set_vendor_facilities(1, [f2.id])
+
+    fetched = svc.get_vendor_facilities(1)
+    assert len(fetched) == 1
+    assert fetched[0].id == f2.id
+
+
+# ------------------------------------------------------------------
+# Error cases — invalid facility id
+# ------------------------------------------------------------------
+
+def test_set_vendor_facilities_invalid_facility_raises_404() -> None:
+    svc, _, _, _ = _make_service()
+
+    with pytest.raises(CodedHTTPException) as exc_info:
+        svc.set_vendor_facilities(1, [9999])
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.code == "not_found"
+
+
+# ------------------------------------------------------------------
+# Error cases — non-existent vendor
+# ------------------------------------------------------------------
+
+def test_get_vendor_facilities_unknown_vendor_raises_404() -> None:
+    svc, _, _, _ = _make_service()
+
+    with pytest.raises(CodedHTTPException) as exc_info:
+        svc.get_vendor_facilities(9999)
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.code == "not_found"
+
+
+def test_set_vendor_facilities_unknown_vendor_raises_404() -> None:
+    svc, facility_repo, _, _ = _make_service()
+    f = facility_repo.create_facility("X1", "X Facility")
+
+    with pytest.raises(CodedHTTPException) as exc_info:
+        svc.set_vendor_facilities(9999, [f.id])
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.code == "not_found"

--- a/backend/tests/test_facility_repository.py
+++ b/backend/tests/test_facility_repository.py
@@ -1,0 +1,26 @@
+from backend.repositories.facility_repository import FacilityRepository
+
+
+def test_create_is_idempotent_on_code():
+    repo = FacilityRepository()
+    a = repo.create_facility("F99", "Fab 99")
+    b = repo.create_facility("F99", "Fab 99 dup")
+    assert a.id == b.id
+    assert any(f.code == "F99" for f in repo.list_facilities())
+
+
+def test_set_and_get_vendor_facilities():
+    repo = FacilityRepository()
+    f1 = repo.create_facility("F1", "One")
+    f2 = repo.create_facility("F2", "Two")
+    repo.set_vendor_facilities(7, [f1.id, f2.id])
+    assert sorted(repo.get_vendor_facility_ids(7)) == sorted([f1.id, f2.id])
+    repo.set_vendor_facilities(7, [f1.id])
+    assert repo.get_vendor_facility_ids(7) == [f1.id]
+
+
+def test_facility_exists():
+    repo = FacilityRepository()
+    f = repo.create_facility("F1", "One")
+    assert repo.facility_exists(f.id)
+    assert not repo.facility_exists(99999)

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -56,3 +56,27 @@ export function getStats({ start, end } = {}) {
 export function getBillingVendors({ year, month }) {
   return apiFetch(`/admin/billing/vendors?year=${year}&month=${month}`);
 }
+
+export function getFacilities() {
+  return apiFetch("/admin/facilities");
+}
+
+export function createFacility({ code, name }) {
+  return apiFetch("/admin/facilities", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code, name }),
+  });
+}
+
+export function getVendorFacilities(vendorId) {
+  return apiFetch(`/admin/vendors/${vendorId}/facilities`);
+}
+
+export function setVendorFacilities(vendorId, facilityIds) {
+  return apiFetch(`/admin/vendors/${vendorId}/facilities`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ facility_ids: facilityIds }),
+  });
+}

--- a/frontend/src/layout/navigation.js
+++ b/frontend/src/layout/navigation.js
@@ -21,6 +21,7 @@ export const navigationByRole = {
   admin: [
     { label: "統計儀表板", to: "/admin/stats" },
     { label: "商家審核", to: "/admin/vendors" },
+    { label: "廠區管理", to: "/admin/facilities" },
     { label: "權限管理", to: "/admin/permissions" },
     { label: "稽核紀錄", to: "/admin/audit" },
     { label: "月度結帳", to: "/admin/billing" },

--- a/frontend/src/pages/admin/AdminFacilitiesPage.jsx
+++ b/frontend/src/pages/admin/AdminFacilitiesPage.jsx
@@ -1,0 +1,290 @@
+import { useEffect, useState } from "react";
+
+import {
+  createFacility,
+  getFacilities,
+  getVendorApplications,
+  getVendorFacilities,
+  setVendorFacilities,
+} from "../../api/admin";
+
+// ── Panel A: 廠區列表 + 新增表單 ────────────────────────────────────────────
+
+function FacilitiesPanel() {
+  const [facilities, setFacilities] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const [code, setCode] = useState("");
+  const [name, setName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState(null);
+
+  function loadFacilities() {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    getFacilities()
+      .then((data) => { if (active) setFacilities(data); })
+      .catch(() => { if (active) setError("無法載入廠區資料。"); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }
+
+  useEffect(loadFacilities, []);
+
+  function handleCreate(e) {
+    e.preventDefault();
+    if (!code.trim() || !name.trim()) return;
+    setCreating(true);
+    setCreateError(null);
+    createFacility({ code: code.trim(), name: name.trim() })
+      .then((newFac) => {
+        setFacilities((prev) => [...prev, newFac]);
+        setCode("");
+        setName("");
+      })
+      .catch(() => setCreateError("新增廠區失敗，請稍後再試。"))
+      .finally(() => setCreating(false));
+  }
+
+  return (
+    <article className="panel">
+      <p className="eyebrow">廠區管理</p>
+      <h2>廠區</h2>
+
+      {loading && <p className="panel-copy">載入中…</p>}
+      {error && <p className="error-state">{error}</p>}
+
+      {!loading && !error && (
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>代碼</th>
+              <th>名稱</th>
+            </tr>
+          </thead>
+          <tbody>
+            {facilities.map((f) => (
+              <tr key={f.id}>
+                <td>{f.code}</td>
+                <td>{f.name}</td>
+              </tr>
+            ))}
+            {facilities.length === 0 && (
+              <tr>
+                <td colSpan={2} className="table-empty">尚無廠區</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      )}
+
+      <form onSubmit={handleCreate} style={{ marginTop: 20, display: "flex", gap: 8, flexWrap: "wrap", alignItems: "flex-end" }}>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span style={{ fontSize: "0.8rem" }}>代碼</span>
+          <input
+            className="form-input"
+            type="text"
+            placeholder="例：A棟"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            required
+            style={{ width: 120 }}
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+          <span style={{ fontSize: "0.8rem" }}>名稱</span>
+          <input
+            className="form-input"
+            type="text"
+            placeholder="例：研發一廠"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            style={{ width: 180 }}
+          />
+        </label>
+        <button
+          type="submit"
+          className="range-pill is-active"
+          disabled={creating || !code.trim() || !name.trim()}
+          style={{ alignSelf: "flex-end" }}
+        >
+          {creating ? "新增中…" : "新增廠區"}
+        </button>
+      </form>
+      {createError && <p className="error-state" style={{ marginTop: 8 }}>{createError}</p>}
+    </article>
+  );
+}
+
+// ── Panel B: 商家服務廠區指派 ────────────────────────────────────────────────
+
+function VendorFacilitiesPanel() {
+  const [vendors, setVendors] = useState([]);
+  const [vendorsLoading, setVendorsLoading] = useState(true);
+  const [vendorsError, setVendorsError] = useState(null);
+
+  const [allFacilities, setAllFacilities] = useState([]);
+  const [facLoading, setFacLoading] = useState(true);
+  const [facError, setFacError] = useState(null);
+
+  const [selectedVendorId, setSelectedVendorId] = useState("");
+  const [checkedIds, setCheckedIds] = useState(new Set());
+  const [assignLoading, setAssignLoading] = useState(false);
+  const [assignError, setAssignError] = useState(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  // Load approved vendors
+  useEffect(() => {
+    let active = true;
+    setVendorsLoading(true);
+    setVendorsError(null);
+    getVendorApplications("approved")
+      .then((data) => { if (active) setVendors(data); })
+      .catch(() => { if (active) setVendorsError("無法載入商家清單。"); })
+      .finally(() => { if (active) setVendorsLoading(false); });
+    return () => { active = false; };
+  }, []);
+
+  // Load all facilities
+  useEffect(() => {
+    let active = true;
+    setFacLoading(true);
+    setFacError(null);
+    getFacilities()
+      .then((data) => { if (active) setAllFacilities(data); })
+      .catch(() => { if (active) setFacError("無法載入廠區清單。"); })
+      .finally(() => { if (active) setFacLoading(false); });
+    return () => { active = false; };
+  }, []);
+
+  // When vendor changes, fetch its current facilities
+  useEffect(() => {
+    if (!selectedVendorId) {
+      setCheckedIds(new Set());
+      return;
+    }
+    let active = true;
+    setAssignLoading(true);
+    setAssignError(null);
+    setSaveSuccess(false);
+    getVendorFacilities(Number(selectedVendorId))
+      .then((data) => {
+        if (active) setCheckedIds(new Set(data.map((f) => f.id)));
+      })
+      .catch(() => {
+        if (active) setAssignError("無法載入商家已指派廠區。");
+      })
+      .finally(() => {
+        if (active) setAssignLoading(false);
+      });
+    return () => { active = false; };
+  }, [selectedVendorId]);
+
+  function toggleFacility(id) {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+    setSaveSuccess(false);
+  }
+
+  function handleSave(e) {
+    e.preventDefault();
+    if (!selectedVendorId) return;
+    setAssignLoading(true);
+    setAssignError(null);
+    setSaveSuccess(false);
+    setVendorFacilities(Number(selectedVendorId), Array.from(checkedIds))
+      .then(() => setSaveSuccess(true))
+      .catch(() => setAssignError("儲存失敗，請稍後再試。"))
+      .finally(() => setAssignLoading(false));
+  }
+
+  const isLoading = vendorsLoading || facLoading;
+  const hasError = vendorsError || facError;
+
+  return (
+    <article className="panel">
+      <p className="eyebrow">廠區管理</p>
+      <h2>商家服務廠區</h2>
+
+      {isLoading && <p className="panel-copy">載入中…</p>}
+      {hasError && <p className="error-state">{vendorsError ?? facError}</p>}
+
+      {!isLoading && !hasError && (
+        <>
+          <label style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 16 }}>
+            <span style={{ fontSize: "0.8rem" }}>選擇商家（已核准）</span>
+            <select
+              className="form-input"
+              value={selectedVendorId}
+              onChange={(e) => setSelectedVendorId(e.target.value)}
+              style={{ maxWidth: 280 }}
+            >
+              <option value="">— 請選擇 —</option>
+              {vendors.map((v) => (
+                <option key={v.vendor_id} value={v.vendor_id}>
+                  {v.vendor_name}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {selectedVendorId && (
+            <form onSubmit={handleSave}>
+              {assignLoading && <p className="panel-copy">載入中…</p>}
+              {!assignLoading && (
+                <>
+                  {allFacilities.length === 0 ? (
+                    <p className="panel-copy">尚無廠區可指派，請先在上方新增廠區。</p>
+                  ) : (
+                    <fieldset style={{ border: "none", padding: 0, marginBottom: 12 }}>
+                      <legend style={{ fontSize: "0.85rem", marginBottom: 8 }}>服務廠區（可多選）</legend>
+                      <div style={{ display: "flex", flexWrap: "wrap", gap: "8px 20px" }}>
+                        {allFacilities.map((f) => (
+                          <label key={f.id} style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
+                            <input
+                              type="checkbox"
+                              checked={checkedIds.has(f.id)}
+                              onChange={() => toggleFacility(f.id)}
+                            />
+                            <span>{f.code}　{f.name}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </fieldset>
+                  )}
+                  <button
+                    type="submit"
+                    className="range-pill is-active"
+                    disabled={assignLoading}
+                  >
+                    儲存
+                  </button>
+                </>
+              )}
+              {assignError && <p className="error-state" style={{ marginTop: 8 }}>{assignError}</p>}
+              {saveSuccess && <p className="panel-copy" style={{ marginTop: 8, color: "var(--accent)" }}>已儲存。</p>}
+            </form>
+          )}
+        </>
+      )}
+    </article>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
+export default function AdminFacilitiesPage() {
+  return (
+    <section className="dashboard-grid">
+      <FacilitiesPanel />
+      <VendorFacilitiesPanel />
+    </section>
+  );
+}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -3,6 +3,7 @@ import { useAuth } from "../auth/AuthContext";
 import AppShell from "../layout/AppShell";
 import { roleHomePath } from "../layout/navigation";
 import AdminAuditPage from "../pages/admin/AdminAuditPage";
+import AdminFacilitiesPage from "../pages/admin/AdminFacilitiesPage";
 import AdminBillingPage from "../pages/admin/AdminBillingPage";
 import AdminStatsPage from "../pages/admin/AdminStatsPage";
 import AdminPermissionsPage from "../pages/admin/AdminPermissionsPage";
@@ -101,6 +102,7 @@ export function AppRouter() {
             <Route element={<AdminAuditPage />} path="/admin/audit" />
             <Route element={<AdminStatsPage />} path="/admin/stats" />
             <Route element={<AdminBillingPage />} path="/admin/billing" />
+            <Route element={<AdminFacilitiesPage />} path="/admin/facilities" />
           </Route>
 
           <Route


### PR DESCRIPTION
Closes #107.

The 福委會 back-office half of requirement 6 (多廠區商家管理) — letting admin/committee manage facilities and set which facilities each vendor serves. (Employee-side facility filtering already shipped; the demo seed shipped separately.)

## Backend
- **`FacilityRepository` (in-memory + Postgres)** over the existing `facilities` / `vendor_facilities` tables: `list_facilities`, `create_facility` (idempotent on code), `get_vendor_facility_ids`, `set_vendor_facilities` (atomic replace), `facility_exists`; `core/facilities.py` factory.
- **`FacilityAdminService`** (audited): validates the vendor exists + every facility id exists; writes `facility.create` / `facility.assign` audit entries.
- **Routes** (`require_roles("admin","committee_reviewer")`): `GET/POST /admin/facilities`, `GET/PUT /admin/vendors/{vendor_id}/facilities`.

## Frontend
- Admin **廠區管理** page (`/admin/facilities`, in the sidebar): list + create facilities; pick an approved vendor and check which facilities it serves (full-set replace). Uses the vendor's `vendor_id`.

## Tests
- Unit: repository (idempotency, replace), service (audit + 404 validation), route RBAC + 404 paths.
- Integration (Postgres): repository against a live DB.
- Full suite: 272 passed, 0 failed.

## Effect
With the demo seed already on staging, an admin can create facilities + assign vendors and the employee-side facility filtering reflects it immediately.
