### PR TITLE
feat(ops): reliability hardening — healthchecks, restart, DB backup, deploy-trigger verify, alert exit (#109)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,33 +173,72 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Jenkins staging
+      - name: Trigger Jenkins staging and verify build started
         run: |
-          curl -fsS -X POST \
+          set -euo pipefail
+          QUEUE=$(curl -fsS -D - -o /dev/null -X POST \
             "${{ secrets.JENKINS_URL }}/job/Meal-Ordering-Project/job/meal-deploy-staging/buildWithParameters?IMAGE_TAG=${{ needs.meta.outputs.image_tag }}&token=${{ secrets.JENKINS_STAGING_TOKEN }}" \
-            --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}"
+            --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" \
+            | tr -d '\r' | awk 'tolower($1)=="location:"{print $2}')
+          if [ -z "$QUEUE" ]; then echo "::error::Jenkins did not return a queue item (build not queued)"; exit 1; fi
+          echo "Queued: $QUEUE"
+          for i in $(seq 1 24); do
+            BODY=$(curl -fsS "${QUEUE}api/json" --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" || true)
+            NUM=$(printf '%s' "$BODY" | python3 -c "import sys,json; d=json.load(sys.stdin); print((d.get('executable') or {}).get('number') or '')" 2>/dev/null || true)
+            CANCELLED=$(printf '%s' "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cancelled'))" 2>/dev/null || true)
+            if [ -n "$NUM" ]; then echo "Build #$NUM started"; exit 0; fi
+            if [ "$CANCELLED" = "True" ]; then echo "::error::Jenkins queue item was cancelled"; exit 1; fi
+            sleep 5
+          done
+          echo "::error::Jenkins build did not start within timeout"; exit 1
 
   deploy-preview:
     needs: [build-push, meta]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Jenkins preview
+      - name: Trigger Jenkins preview and verify build started
         env:
           PR_BRANCH: ${{ github.head_ref }}
         run: |
+          set -euo pipefail
           PR_BRANCH_ENC=$(python3 -c "import urllib.parse,os;print(urllib.parse.quote(os.environ['PR_BRANCH'],safe=''))")
-          curl -fsS -X POST \
+          QUEUE=$(curl -fsS -D - -o /dev/null -X POST \
             "${{ secrets.JENKINS_URL }}/job/Meal-Ordering-Project/job/meal-deploy-preview/buildWithParameters?IMAGE_TAG=${{ needs.meta.outputs.image_tag }}&PR_NUMBER=${{ github.event.number }}&PR_BRANCH=${PR_BRANCH_ENC}&token=${{ secrets.JENKINS_PREVIEW_TOKEN }}" \
-            --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}"
+            --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" \
+            | tr -d '\r' | awk 'tolower($1)=="location:"{print $2}')
+          if [ -z "$QUEUE" ]; then echo "::error::Jenkins did not return a queue item (build not queued)"; exit 1; fi
+          echo "Queued: $QUEUE"
+          for i in $(seq 1 24); do
+            BODY=$(curl -fsS "${QUEUE}api/json" --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" || true)
+            NUM=$(printf '%s' "$BODY" | python3 -c "import sys,json; d=json.load(sys.stdin); print((d.get('executable') or {}).get('number') or '')" 2>/dev/null || true)
+            CANCELLED=$(printf '%s' "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cancelled'))" 2>/dev/null || true)
+            if [ -n "$NUM" ]; then echo "Build #$NUM started"; exit 0; fi
+            if [ "$CANCELLED" = "True" ]; then echo "::error::Jenkins queue item was cancelled"; exit 1; fi
+            sleep 5
+          done
+          echo "::error::Jenkins build did not start within timeout"; exit 1
 
   deploy-prod:
     needs: promote
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Jenkins prod
+      - name: Trigger Jenkins prod and verify build started
         run: |
-          curl -fsS -X POST \
+          set -euo pipefail
+          QUEUE=$(curl -fsS -D - -o /dev/null -X POST \
             "${{ secrets.JENKINS_URL }}/job/Meal-Ordering-Project/job/meal-deploy-prod/buildWithParameters?IMAGE_TAG=${{ github.ref_name }}&token=${{ secrets.JENKINS_PROD_TOKEN }}" \
-            --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}"
+            --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" \
+            | tr -d '\r' | awk 'tolower($1)=="location:"{print $2}')
+          if [ -z "$QUEUE" ]; then echo "::error::Jenkins did not return a queue item (build not queued)"; exit 1; fi
+          echo "Queued: $QUEUE"
+          for i in $(seq 1 24); do
+            BODY=$(curl -fsS "${QUEUE}api/json" --user "${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_API_TOKEN }}" || true)
+            NUM=$(printf '%s' "$BODY" | python3 -c "import sys,json; d=json.load(sys.stdin); print((d.get('executable') or {}).get('number') or '')" 2>/dev/null || true)
+            CANCELLED=$(printf '%s' "$BODY" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cancelled'))" 2>/dev/null || true)
+            if [ -n "$NUM" ]; then echo "Build #$NUM started"; exit 0; fi
+            if [ "$CANCELLED" = "True" ]; then echo "::error::Jenkins queue item was cancelled"; exit 1; fi
+            sleep 5
+          done
+          echo "::error::Jenkins build did not start within timeout"; exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: backend/Dockerfile
+    restart: unless-stopped
     env_file:
       - .env.example
       - path: .env
@@ -14,6 +15,12 @@ services:
     volumes:
       - uploads:/app/uploads
     command: uvicorn backend.main:app --host 0.0.0.0 --port 8000
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').getcode()==200 else 1)\""]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     ports:
       - "8000:8000"
     networks:
@@ -31,6 +38,13 @@ services:
   frontend:
     build:
       context: ./frontend
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     ports:
       - "3000:80"
     depends_on:
@@ -40,6 +54,7 @@ services:
     build:
       context: .
       dockerfile: backend/db/Dockerfile
+    restart: unless-stopped
     env_file:
       - .env.example
       - path: .env
@@ -58,7 +73,14 @@ services:
     build:
       context: .
       dockerfile: infra/caddy/Dockerfile
+    restart: unless-stopped
     container_name: ${GATEWAY_CONTAINER_NAME:-mealorder-dev-gateway}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:80/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     volumes:
       - caddy_data:/data
       - caddy_config:/config

--- a/infra/deploy/SETUP.md
+++ b/infra/deploy/SETUP.md
@@ -1,5 +1,66 @@
 # NOL One-Time Setup for TBD Deployment
 
+## Database backup & restore
+
+### How it works
+
+A `backup` sidecar container (image `postgres:16-alpine`) runs alongside the `db`
+service in **staging and prod** stacks. It executes `pg_dump` once per day (every
+86400 seconds), compresses the output with gzip, and writes it to the `db_backups`
+named Docker volume mounted at `/backups` inside the container.
+
+Dump filenames follow the pattern `mealorder-YYYYMMDD-HHMMSS.sql.gz`.
+
+**Retention**: after each successful dump, the script automatically deletes all but
+the **newest 7** files (`BACKUP_KEEP=7`). This bounds the volume to at most 7
+compressed snapshots; no manual pruning is required.
+
+**Failure behaviour**: if `pg_dump` exits non-zero, the script logs an error and
+exits non-zero (so Docker/`restart: unless-stopped` will restart the container and
+retry). It does _not_ silently continue.
+
+> **Staging note**: `Jenkinsfile.staging` runs `down -v` on each redeploy which
+> removes all named volumes including `db_backups`. This is intentional for staging
+> (clean slate per deploy). Prod uses `down` (no `-v`), so backups survive deploys.
+
+### Listing current dumps
+
+```bash
+# staging
+docker compose -p mealorder-staging exec backup ls -1t /backups
+
+# prod
+docker compose -p mealorder-prod exec backup ls -1t /backups
+```
+
+### Triggering an on-demand backup immediately
+
+```bash
+# One-shot backup without waiting for the next scheduled run
+docker compose -p mealorder-prod exec backup sh -c 'BACKUP_ONCE=1 sh /backup.sh'
+```
+
+### Restoring a dump
+
+```bash
+# 1. Choose a dump file (list first):
+docker compose -p mealorder-prod exec backup ls -1t /backups
+# Example output:
+#   mealorder-20260529-030000.sql.gz
+#   mealorder-20260528-030000.sql.gz
+
+# 2. Restore — pipe through gunzip into psql inside the db container:
+DUMP=mealorder-20260529-030000.sql.gz
+docker compose -p mealorder-prod exec -T backup cat /backups/${DUMP} \
+  | docker compose -p mealorder-prod exec -T db \
+      sh -c 'gunzip -c | psql -U $POSTGRES_USER -d $POSTGRES_DB'
+```
+
+> The `-T` flag disables pseudo-TTY allocation so binary data flows cleanly through
+> the pipe. Replace `-p mealorder-prod` with `-p mealorder-staging` for staging.
+
+---
+
 All steps run **on the NOL host (A 機)** as a user with docker permission and access to NPM (nginx proxy manager).
 Re-running any block is safe (idempotent) unless explicitly noted.
 

--- a/infra/deploy/backup/backup.sh
+++ b/infra/deploy/backup/backup.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# pg_dump backup loop for the meal-ordering DB.
+#
+# Environment variables (all optional — shown with defaults):
+#   PGHOST                 db
+#   PGUSER                 (required — no default)
+#   PGPASSWORD             (required — no default)
+#   PGDATABASE             meal_ordering
+#   BACKUP_DIR             /backups        (override for local testing)
+#   BACKUP_KEEP            7               (number of newest dumps to keep)
+#   BACKUP_INTERVAL_SECONDS  86400         (seconds between runs; daily default)
+#   BACKUP_ONCE            ""              (set to 1 to run once then exit)
+#
+# Usage (normal, in container):
+#   entrypoint: ["sh", "/backup.sh"]
+#
+# Usage (one-shot local test):
+#   PGHOST=localhost PGUSER=meal_user PGPASSWORD=... PGDATABASE=meal_ordering \
+#   BACKUP_DIR=/tmp/test-backups BACKUP_KEEP=2 BACKUP_ONCE=1 sh backup.sh
+
+set -e
+
+PGHOST="${PGHOST:-db}"
+PGDATABASE="${PGDATABASE:-meal_ordering}"
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+BACKUP_KEEP="${BACKUP_KEEP:-7}"
+BACKUP_INTERVAL_SECONDS="${BACKUP_INTERVAL_SECONDS:-86400}"
+BACKUP_ONCE="${BACKUP_ONCE:-}"
+
+log() {
+    printf '[backup] %s %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+do_backup() {
+    mkdir -p "$BACKUP_DIR"
+    STAMP="$(date -u '+%Y%m%d-%H%M%S')"
+    OUTFILE="$BACKUP_DIR/mealorder-${STAMP}.sql.gz"
+
+    log "Starting pg_dump → $OUTFILE (host=$PGHOST db=$PGDATABASE user=$PGUSER)"
+
+    # pg_dump failure is fatal — do NOT swallow errors.
+    # We cannot rely on the pipe exit code in POSIX sh (no pipefail), so we dump
+    # to a raw temp file first, check the exit code explicitly, then gzip it.
+    TMPFILE="${OUTFILE%.gz}.tmp"
+    if ! pg_dump -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" > "$TMPFILE"; then
+        log "ERROR: pg_dump failed — removing partial file"
+        rm -f "$TMPFILE" "$OUTFILE"
+        exit 1
+    fi
+    gzip -c "$TMPFILE" > "$OUTFILE"
+    rm -f "$TMPFILE"
+
+    SIZE="$(du -sh "$OUTFILE" 2>/dev/null | cut -f1)"
+    log "Dump complete: $OUTFILE ($SIZE)"
+
+    # Prune: keep only newest BACKUP_KEEP files.
+    # `ls -1t` sorts newest-first; tail skips the first BACKUP_KEEP lines;
+    # the remainder are the oldest and get deleted.
+    TO_DELETE="$(ls -1t "$BACKUP_DIR"/mealorder-*.sql.gz 2>/dev/null \
+        | tail -n "+$((BACKUP_KEEP + 1))")"
+
+    if [ -n "$TO_DELETE" ]; then
+        COUNT="$(printf '%s\n' "$TO_DELETE" | wc -l | tr -d ' ')"
+        log "Pruning $COUNT old dump(s) (keeping newest $BACKUP_KEEP):"
+        printf '%s\n' "$TO_DELETE" | while IFS= read -r f; do
+            log "  removing $f"
+            rm -f "$f"
+        done
+    else
+        log "Retention OK — no pruning needed (kept $BACKUP_KEEP or fewer)"
+    fi
+
+    REMAINING="$(ls -1 "$BACKUP_DIR"/mealorder-*.sql.gz 2>/dev/null | wc -l | tr -d ' ')"
+    log "Backups on disk: $REMAINING"
+}
+
+log "Backup sidecar started (BACKUP_KEEP=$BACKUP_KEEP, BACKUP_INTERVAL_SECONDS=$BACKUP_INTERVAL_SECONDS, BACKUP_ONCE=${BACKUP_ONCE:-0})"
+
+while true; do
+    do_backup
+
+    if [ "${BACKUP_ONCE}" = "1" ] || [ -n "$BACKUP_ONCE" ]; then
+        log "BACKUP_ONCE set — exiting after single run"
+        exit 0
+    fi
+
+    log "Sleeping ${BACKUP_INTERVAL_SECONDS}s until next backup…"
+    sleep "$BACKUP_INTERVAL_SECONDS"
+done

--- a/infra/deploy/docker-compose.preview.yml
+++ b/infra/deploy/docker-compose.preview.yml
@@ -7,27 +7,49 @@
 services:
   backend:
     image: ghcr.io/mizu5555/mealorder-backend:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
     environment:
       SEED_DEMO_DATA: "true"
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').getcode()==200 else 1)\""]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     labels:
       mealorder.branch: ${BRANCH_RAW:-}
   frontend:
     image: ghcr.io/mizu5555/mealorder-frontend:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
     environment:
       BASE_PATH: ${BASE_PATH}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     labels:
       mealorder.branch: ${BRANCH_RAW:-}
   db:
     image: ghcr.io/mizu5555/mealorder-db:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
     labels:
       mealorder.branch: ${BRANCH_RAW:-}
   gateway:
     image: ghcr.io/mizu5555/mealorder-gateway:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
     container_name: mealorder-${SLUG:-default}-gateway
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:80/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     networks: [default, preview-net]
     labels:
       mealorder.branch: ${BRANCH_RAW:-}

--- a/infra/deploy/docker-compose.prod.yml
+++ b/infra/deploy/docker-compose.prod.yml
@@ -6,6 +6,7 @@
 services:
   backend:
     image: ghcr.io/mizu5555/mealorder-backend:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
     # See staging override for the rationale: pin Caddy gateway → backend
     # resolution to a single network alias so Docker DNS does not round-robin
@@ -19,17 +20,38 @@ services:
       APP_ENV: prod
       SERVICE_NAME: mealorder-backend
       LOKI_URL: http://loki:3100
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').getcode()==200 else 1)\""]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
   frontend:
     image: ghcr.io/mizu5555/mealorder-frontend:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
     environment:
       BASE_PATH: ${BASE_PATH}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
   db:
     image: ghcr.io/mizu5555/mealorder-db:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
   gateway:
     image: ghcr.io/mizu5555/mealorder-gateway:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:80/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     networks: [default, preview-net, grafana_default]
 
 networks:

--- a/infra/deploy/docker-compose.prod.yml
+++ b/infra/deploy/docker-compose.prod.yml
@@ -54,6 +54,28 @@ services:
       start_period: 20s
     networks: [default, preview-net, grafana_default]
 
+  # DB backup sidecar — runs pg_dump daily, keeps newest 7 dumps.
+  # Volume db_backups persists dumps across stack restarts.
+  backup:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      PGHOST: db
+      PGUSER: ${POSTGRES_USER:-meal_user}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-change-me-in-local-env}
+      PGDATABASE: ${POSTGRES_DB:-meal_ordering}
+      BACKUP_KEEP: "7"
+      BACKUP_INTERVAL_SECONDS: "86400"
+    volumes:
+      - ./infra/deploy/backup/backup.sh:/backup.sh:ro
+      - db_backups:/backups
+    entrypoint: ["sh", "/backup.sh"]
+    depends_on:
+      - db
+
+volumes:
+  db_backups:
+
 networks:
   preview-net:
     external: true

--- a/infra/deploy/docker-compose.staging.yml
+++ b/infra/deploy/docker-compose.staging.yml
@@ -6,6 +6,7 @@
 services:
   backend:
     image: ghcr.io/mizu5555/mealorder-backend:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
     # Per-network aliases pin the Caddy gateway's upstream resolution. `backend`
     # remains reachable as `backend` on grafana_default (Prometheus scrape) and
@@ -27,21 +28,42 @@ services:
       # degrades gracefully to stdout.
       LOKI_URL: http://loki:3100
       SEED_DEMO_DATA: "true"
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/health').getcode()==200 else 1)\""]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     cap_add:
       # Needed for `py-spy record --pid 1` to attach inside the container.
       # Scoped to staging so prod stays minimal-privilege.
       - SYS_PTRACE
   frontend:
     image: ghcr.io/mizu5555/mealorder-frontend:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
     environment:
       BASE_PATH: ${BASE_PATH}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
   db:
     image: ghcr.io/mizu5555/mealorder-db:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
   gateway:
     image: ghcr.io/mizu5555/mealorder-gateway:${IMAGE_TAG}
+    restart: unless-stopped
     ports: !reset []
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:80/ >/dev/null 2>&1 || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
     networks: [default, preview-net, grafana_default]
 
 networks:

--- a/infra/deploy/docker-compose.staging.yml
+++ b/infra/deploy/docker-compose.staging.yml
@@ -66,6 +66,30 @@ services:
       start_period: 20s
     networks: [default, preview-net, grafana_default]
 
+  # DB backup sidecar — runs pg_dump daily, keeps newest 7 dumps.
+  # Volume db_backups persists dumps across stack restarts.
+  # NOTE: `down -v` (used in Jenkins reset) removes named volumes including
+  # db_backups. For staging this is acceptable; prod uses `down` (no -v).
+  backup:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      PGHOST: db
+      PGUSER: ${POSTGRES_USER:-meal_user}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-change-me-in-local-env}
+      PGDATABASE: ${POSTGRES_DB:-meal_ordering}
+      BACKUP_KEEP: "7"
+      BACKUP_INTERVAL_SECONDS: "86400"
+    volumes:
+      - ./infra/deploy/backup/backup.sh:/backup.sh:ro
+      - db_backups:/backups
+    entrypoint: ["sh", "/backup.sh"]
+    depends_on:
+      - db
+
+volumes:
+  db_backups:
+
 networks:
   preview-net:
     external: true

--- a/infra/monitoring/provisioning/alerting/contact-points.yml
+++ b/infra/monitoring/provisioning/alerting/contact-points.yml
@@ -1,0 +1,42 @@
+# Grafana unified-alerting provisioning — contact point + notification policy.
+# Picked up automatically from /etc/grafana/provisioning/alerting/ at startup.
+# Together with rules.yml (WHEN to fire), this file wires WHERE alerts go.
+#
+# TODO operator: before deploying to the NOL Grafana, replace the placeholder
+# webhook URL below with the real endpoint (Slack incoming-webhook, Discord
+# webhook relay, email-relay, or any HTTP sink that accepts Grafana webhook
+# payloads).  Set it on the host via environment variable ALERT_WEBHOOK_URL, or
+# edit the url field directly — then restart the grafana container so Grafana
+# re-reads provisioning.
+#
+# Grafana provisioning does NOT interpolate ${VAR} syntax in this file by
+# default (it is not the same as Grafana env-var expansion in dashboards).
+# The placeholder URL below is therefore a literal string that must be
+# replaced; it is intentionally unreachable (port 0) so misconfigured
+# environments fail fast rather than silently swallow alerts.
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: mealorder-default
+    receivers:
+      - uid: mealorder-webhook-recv
+        type: webhook
+        settings:
+          # TODO operator: replace with the real alert webhook URL on the NOL host.
+          # e.g. https://hooks.slack.com/services/XXX/YYY/ZZZ
+          #      https://discord.com/api/webhooks/NNN/TOKEN/slack  (Discord Slack-compat)
+          #      http://alert-relay:5001/notify  (custom relay inside preview-net)
+          url: "http://localhost:0/alerts"
+          httpMethod: POST
+        disableResolveMessage: false
+
+policies:
+  - orgId: 1
+    receiver: mealorder-default
+    group_by:
+      - alertname
+      - severity
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h

--- a/infra/monitoring/provisioning/alerting/rules.yml
+++ b/infra/monitoring/provisioning/alerting/rules.yml
@@ -1,7 +1,7 @@
 # Grafana unified-alerting provisioning. Picked up automatically from
 # /etc/grafana/provisioning/alerting/ at startup. Contact points and notification
-# policy are managed in the Grafana UI (or in a separate provisioning file); these
-# rules only define WHEN to fire, not WHERE.
+# policy are defined in contact-points.yml (same directory); these rules define
+# WHEN to fire. See contact-points.yml for WHERE alerts are sent (webhook).
 #
 # All thresholds are deliberately conservative for a homework-scale stack — tune
 # after observing real traffic.


### PR DESCRIPTION
Closes #109.

Requirement 10 (運維與可靠性) reliability gaps. (build-push provenance + image-pullable verify already shipped in #118.)

## A. Container healthchecks + restart
`healthcheck:` on backend (python→/health), frontend & gateway (wget), db already had one; `restart: unless-stopped` on all app services — in `docker-compose.yml` + staging/preview/prod overlays. Verified: `docker compose config -q` on all four; backend reaches `healthy` locally.

## B. DB backup with retention
`infra/deploy/backup/backup.sh` — daily `pg_dump | gzip` into the `db_backups` volume, **keeps only the newest 7** (bounded — no unbounded growth), fails loudly if pg_dump errors. `backup` sidecar added to **staging + prod** (not preview). Restore steps documented in `infra/deploy/SETUP.md`. Verified locally with a one-shot run (dump produced, retention prunes to N).

## C. Deploy-trigger verification (no more silent green)
The 3 deploy jobs now capture the Jenkins **queue item** from the trigger response and poll until the build actually starts — failing the GitHub job if Jenkins didn't build. Fixes the "green CI but no deploy" silent failure (hit on pr-110 / pr-117). This PR's own `deploy-preview` exercises it.

## D. Alert exit
`infra/monitoring/provisioning/alerting/contact-points.yml` — a webhook contact point + a root notification policy so the existing alert rules route somewhere (they previously fired into the void). The real webhook URL is set on the host (placeholder ships in the file).

## Tests / verification
Backend suite 272 passed (config-only changes); compose configs valid; YAMLs valid; final holistic review passed.
