### PR TITLE
fix(pickup): reject cross-day pickup; fix vendor orders columns

### DIFF
--- a/backend/services/vendor_order_service.py
+++ b/backend/services/vendor_order_service.py
@@ -82,6 +82,12 @@ class VendorOrderService:
                 code="order_not_ready_for_pickup",
                 detail="only ready orders can be confirmed for pickup",
             )
+        if order.meal_date != date.today():
+            raise CodedHTTPException(
+                status_code=409,
+                code="pickup_wrong_date",
+                detail="pickup is only allowed for today's orders",
+            )
         updated = self._repo.confirm_pickup(
             vendor_id=vendor_id,
             order_id=order_id,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,10 @@ from collections.abc import Generator
 import pytest
 from prometheus_client import REGISTRY
 
+from backend.core.audit import get_audit_log_repository
+from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
+
 
 def _unregister_inprogress() -> None:
     """Remove the http_requests_inprogress collector so it can be re-registered."""
@@ -18,3 +22,12 @@ def _isolate_prometheus_registry() -> Generator[None, None, None]:
     _unregister_inprogress()
     yield
     _unregister_inprogress()
+
+
+@pytest.fixture(autouse=True)
+def _in_memory_audit_repo() -> Generator[None, None, None]:
+    """Unit tests run without a DB — default to the in-memory audit repo so that
+    routes that write audit entries don't try to open a Postgres connection."""
+    app.dependency_overrides.setdefault(get_audit_log_repository, lambda: AuditLogRepository())
+    yield
+    app.dependency_overrides.pop(get_audit_log_repository, None)

--- a/backend/tests/test_pickup_labels.py
+++ b/backend/tests/test_pickup_labels.py
@@ -154,7 +154,7 @@ def test_pickup_confirm_requires_ready_order() -> None:
 def test_vendor_can_confirm_ready_pickup() -> None:
     vendor_repo = _seed_vendor_repo()
     selection_repo = EmployeeSelectionRepository()
-    order = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=None)
+    order = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=date.today())
     selection_repo.update_order_status(vendor_id=1, order_id=order.id, new_status="ready")
 
     resp = _client(vendor_repo, selection_repo).post(
@@ -167,6 +167,22 @@ def test_vendor_can_confirm_ready_pickup() -> None:
     assert body["status"] == "delivered"
     assert body["pickup_confirmed_at"] is not None
     assert body["pickup_confirmed_by_user_id"] == 77
+
+
+def test_pickup_confirm_rejects_non_today_meal_date() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    yesterday = date(2026, 5, 27)
+    order = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=yesterday)
+    selection_repo.update_order_status(vendor_id=1, order_id=order.id, new_status="ready")
+
+    resp = _client(vendor_repo, selection_repo).post(
+        f"/vendor/me/orders/{order.id}/pickup-confirm",
+        headers=_vh(1),
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "pickup_wrong_date"
 
 
 def test_vendor_cannot_view_other_vendors_label() -> None:

--- a/frontend/src/pages/vendor/VendorBadgePickupPage.jsx
+++ b/frontend/src/pages/vendor/VendorBadgePickupPage.jsx
@@ -11,6 +11,13 @@ const STATUS_LABELS = {
   cancelled: "已取消",
 };
 
+function isToday(mealDateStr) {
+  if (!mealDateStr) return false;
+  const today = new Date();
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+  return mealDateStr.slice(0, 10) === todayStr;
+}
+
 function formatItems(items) {
   return (items ?? []).map((item) => `${item.item_name} x${item.quantity}`).join("、");
 }
@@ -301,6 +308,10 @@ export function VendorBadgePickupPage() {
               <div className="data-actions">
                 {order.status === "delivered" ? (
                   <span className="panel-copy">已領餐</span>
+                ) : !isToday(order.meal_date) ? (
+                  <button className="button-secondary" disabled type="button" title={`此訂單為 ${order.meal_date} 的餐點，無法今日取餐`}>
+                    非今日餐點
+                  </button>
                 ) : (
                   <button
                     className="button-primary"

--- a/frontend/src/pages/vendor/VendorOrdersPage.jsx
+++ b/frontend/src/pages/vendor/VendorOrdersPage.jsx
@@ -105,7 +105,7 @@ export default function VendorOrdersPage() {
             <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "56px 120px 110px 1fr 110px 100px 36px",
+                gridTemplateColumns: "150px 110px 1fr 110px 100px 36px",
                 padding: "10px 20px",
                 borderBottom: "1px solid var(--line)",
                 color: "var(--muted)",
@@ -115,8 +115,7 @@ export default function VendorOrdersPage() {
                 letterSpacing: "0.05em",
               }}
             >
-              <span>#</span>
-              <span>來源</span>
+              <span>日期 · 訂單</span>
               <span>取餐碼</span>
               <span>品項</span>
               <span style={{ textAlign: "right" }}>合計</span>
@@ -131,7 +130,7 @@ export default function VendorOrdersPage() {
                 onClick={() => navigate(`/vendor/orders/${order.id}`)}
                 style={{
                   display: "grid",
-                  gridTemplateColumns: "56px 120px 110px 1fr 110px 100px 36px",
+                  gridTemplateColumns: "150px 110px 1fr 110px 100px 36px",
                   alignItems: "center",
                   width: "100%",
                   padding: "14px 20px",
@@ -145,9 +144,12 @@ export default function VendorOrdersPage() {
                 onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(23,33,43,0.03)")}
                 onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
               >
-                <p style={{ margin: 0, fontSize: 12, color: "var(--muted)" }}>#{order.id}</p>
+                <div>
+                  <p style={{ margin: 0, fontSize: 13, fontWeight: 600 }}>{order.meal_date ?? "—"}</p>
+                  <p style={{ margin: "2px 0 0", fontSize: 11, color: "var(--muted)" }}>#{order.id}</p>
+                </div>
                 <p style={{ margin: 0, fontWeight: 700, fontSize: 13 }}>
-                  {order.pickup_code ?? "-"}
+                  {order.pickup_code ?? "—"}
                 </p>
                 <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>
                   {itemsSummary(order.items)}


### PR DESCRIPTION
Closes #141
Closes #143

## Summary

### #141 — 跨日取餐拒絕
- **Backend** `confirm_pickup`：當 `order.meal_date != date.today()` 時回 409 `pickup_wrong_date`（在原有 `order_not_ready_for_pickup` 檢查之後）
- **Frontend** `VendorBadgePickupPage`：非今日訂單顯示 disabled 灰色按鈕「非今日餐點」，hover 有 tooltip 說明日期，不等送出才失敗

### #143 — Vendor Orders 欄位修正
- 移除孤立的「來源」header 欄（後端 `_deidentify_order` 已把 `employee_id` 設為 null，該欄永遠空白，導致所有 row cell 往左錯位一格）
- 第一欄改為顯示 `meal_date`（主）+ `#order.id`（副）
- Grid 從 `56px 120px 110px 1fr 110px 100px 36px`（7 欄）修正為 `150px 110px 1fr 110px 100px 36px`（6 欄）

### 附帶修正
- `backend/tests/conftest.py` 新增 autouse fixture，讓所有 unit test 預設使用 in-memory audit repo，消滅因 `get_audit_log_repository` → Postgres 造成的 6 個既有 DB 連線錯誤

## Test plan

- [ ] 301 unit tests pass (`pytest backend/tests/ --ignore=backend/tests/integration`)
- [ ] 後端接 DB：將訂單 `meal_date` 設為昨天，嘗試 pickup-confirm → 應得 409 `pickup_wrong_date`
- [ ] Badge pickup 頁面查詢有昨日訂單的員工 → 確認按鈕為灰色 disabled
- [ ] 今日訂單仍可正常取餐
- [ ] Vendor Orders 頁面欄位對齊正確（日期+單號 / 取餐碼 / 品項 / 合計 / 狀態）