### PR TITLE
feat(employee): account settings — change password + persistent home facility

### DIFF
--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,9 +1,12 @@
-from fastapi import APIRouter, status
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
 
 from backend.core.errors import CodedHTTPException
+from backend.core.rbac import get_current_user_id
 from backend.core.security import create_access_token, hash_password, verify_password
 from backend.db.connection import get_connection
-from backend.schemas.auth import LoginRequest, RegisterRequest, TokenResponse
+from backend.schemas.auth import ChangePasswordRequest, LoginRequest, RegisterRequest, TokenResponse
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -116,3 +119,42 @@ def register(payload: RegisterRequest) -> TokenResponse:
         vendor_id=None,
         badge_code=row["badge_code"],
     )
+
+
+@router.patch("/me/password", status_code=status.HTTP_204_NO_CONTENT)
+def change_password(
+    payload: ChangePasswordRequest,
+    user_id: Annotated[int | None, Depends(get_current_user_id)],
+) -> None:
+    if user_id is None:
+        raise CodedHTTPException(status_code=401, code="unauthenticated", detail="Login required")
+
+    if len(payload.new_password) < 8:
+        raise CodedHTTPException(
+            status_code=422,
+            code="password_too_short",
+            detail="New password must be at least 8 characters",
+        )
+
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT password_hash FROM users WHERE id = %s",
+            (user_id,),
+        ).fetchone()
+
+    if not row or not row["password_hash"]:
+        raise CodedHTTPException(status_code=404, code="user_not_found", detail="User not found")
+
+    if not verify_password(payload.current_password, row["password_hash"]):
+        raise CodedHTTPException(
+            status_code=403,
+            code="wrong_current_password",
+            detail="Current password is incorrect",
+        )
+
+    with get_connection() as conn:
+        conn.execute(
+            "UPDATE users SET password_hash = %s, updated_at = NOW() WHERE id = %s",
+            (hash_password(payload.new_password), user_id),
+        )
+        conn.commit()

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -15,6 +15,11 @@ class RegisterRequest(BaseModel):
     role: Literal["employee", "vendor_manager"]
 
 
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str
+
+
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,10 @@ from collections.abc import Generator
 import pytest
 from prometheus_client import REGISTRY
 
+from backend.core.audit import get_audit_log_repository
+from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
+
 
 def _unregister_inprogress() -> None:
     """Remove the http_requests_inprogress collector so it can be re-registered."""
@@ -18,3 +22,12 @@ def _isolate_prometheus_registry() -> Generator[None, None, None]:
     _unregister_inprogress()
     yield
     _unregister_inprogress()
+
+
+@pytest.fixture(autouse=True)
+def _in_memory_audit_repo() -> Generator[None, None, None]:
+    """Unit tests run without a DB — default to the in-memory audit repo so that
+    routes that write audit entries don't try to open a Postgres connection."""
+    app.dependency_overrides.setdefault(get_audit_log_repository, lambda: AuditLogRepository())
+    yield
+    app.dependency_overrides.pop(get_audit_log_repository, None)

--- a/backend/tests/test_change_password.py
+++ b/backend/tests/test_change_password.py
@@ -1,0 +1,97 @@
+"""Tests for PATCH /auth/me/password."""
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from backend.core.security import create_access_token, hash_password
+from backend.main import app
+
+client = TestClient(app)
+
+_PASSWORD = "oldpassword123"
+_TOKEN = create_access_token({"sub": "42", "role": "employee"})
+_HEADERS = {"Authorization": f"Bearer {_TOKEN}"}
+
+
+def _pw_row(password: str = _PASSWORD) -> MagicMock:
+    row = MagicMock()
+    row.__getitem__ = lambda s, k: hash_password(password) if k == "password_hash" else None
+    row.__bool__ = lambda s: True
+    return row
+
+
+def _conn_ctx(row=None, execute_side_effects=None) -> MagicMock:
+    conn = MagicMock()
+    if execute_side_effects:
+        conn.execute.side_effect = execute_side_effects
+    else:
+        result = MagicMock()
+        result.fetchone.return_value = row
+        conn.execute.return_value = result
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=conn)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+def test_change_password_success_returns_204() -> None:
+    fetch_result = MagicMock()
+    fetch_result.fetchone.return_value = {"password_hash": hash_password(_PASSWORD)}
+    update_result = MagicMock()
+
+    conn = MagicMock()
+    conn.execute.side_effect = [fetch_result, update_result]
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=conn)
+    ctx.__exit__ = MagicMock(return_value=False)
+
+    with patch("backend.routes.auth.get_connection", return_value=ctx):
+        resp = client.patch(
+            "/auth/me/password",
+            headers=_HEADERS,
+            json={"current_password": _PASSWORD, "new_password": "newpassword123"},
+        )
+
+    assert resp.status_code == 204
+
+
+def test_change_password_wrong_current_returns_403() -> None:
+    fetch_result = MagicMock()
+    fetch_result.fetchone.return_value = {"password_hash": hash_password(_PASSWORD)}
+
+    conn = MagicMock()
+    conn.execute.return_value = fetch_result
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=conn)
+    ctx.__exit__ = MagicMock(return_value=False)
+
+    with patch("backend.routes.auth.get_connection", return_value=ctx):
+        resp = client.patch(
+            "/auth/me/password",
+            headers=_HEADERS,
+            json={"current_password": "wrongpassword", "new_password": "newpassword123"},
+        )
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "wrong_current_password"
+
+
+def test_change_password_too_short_returns_422() -> None:
+    resp = client.patch(
+        "/auth/me/password",
+        headers=_HEADERS,
+        json={"current_password": _PASSWORD, "new_password": "short"},
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["code"] == "password_too_short"
+
+
+def test_change_password_unauthenticated_returns_401() -> None:
+    resp = client.patch(
+        "/auth/me/password",
+        json={"current_password": _PASSWORD, "new_password": "newpassword123"},
+    )
+
+    assert resp.status_code == 401
+    assert resp.json()["code"] == "unauthenticated"

--- a/frontend/src/api/employee.js
+++ b/frontend/src/api/employee.js
@@ -148,3 +148,11 @@ export function drawRandomMeal({ mealDate, vendorIds, facilityId }) {
     () => mockRandomMeal({ mealDate, vendorIds, facilityId }),
   );
 }
+
+export function changePassword(currentPassword, newPassword) {
+  return apiFetch("/auth/me/password", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ current_password: currentPassword, new_password: newPassword }),
+  });
+}

--- a/frontend/src/facility/FacilityContext.jsx
+++ b/frontend/src/facility/FacilityContext.jsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { getMyFacilities as getEmployeeFacilities } from "../api/employee";
 import { getMyFacilities as getVendorFacilities } from "../api/vendor";
 import { useAuth } from "../auth/AuthContext";
-import { chooseFacilityId } from "./facilitySelection";
+import { chooseFacilityId, loadHomeFacilityId } from "./facilitySelection";
 
 const FacilityContext = createContext(null);
 
@@ -46,7 +46,8 @@ export function FacilityProvider({ children }) {
         if (cancelled) return;
         const nextFacilities = Array.isArray(data) ? data : [];
         setFacilities(nextFacilities);
-        setSelectedFacilityId((current) => chooseFacilityId(nextFacilities, current));
+        const savedHome = loadHomeFacilityId(user?.numericId);
+        setSelectedFacilityId((current) => chooseFacilityId(nextFacilities, savedHome ?? current));
       })
       .catch((err) => {
         if (cancelled) return;

--- a/frontend/src/facility/facilitySelection.js
+++ b/frontend/src/facility/facilitySelection.js
@@ -1,3 +1,20 @@
+const HOME_FACILITY_KEY = (userId) => `corpmeal:home_facility:${userId}`;
+
+export function loadHomeFacilityId(userId) {
+  if (!userId) return null;
+  const raw = window.localStorage.getItem(HOME_FACILITY_KEY(userId));
+  return raw != null ? Number(raw) : null;
+}
+
+export function saveHomeFacilityId(userId, facilityId) {
+  if (!userId) return;
+  if (facilityId == null) {
+    window.localStorage.removeItem(HOME_FACILITY_KEY(userId));
+  } else {
+    window.localStorage.setItem(HOME_FACILITY_KEY(userId), String(facilityId));
+  }
+}
+
 export function chooseFacilityId(facilities, currentId) {
   if (!Array.isArray(facilities) || facilities.length === 0) return null;
 

--- a/frontend/src/layout/navigation.js
+++ b/frontend/src/layout/navigation.js
@@ -11,6 +11,7 @@ export const navigationByRole = {
     { label: "Random Meal", to: "/employee/random-meal" },
     { label: "Current Orders", to: "/employee/orders" },
     { label: "My Badge", to: "/employee/badge" },
+    { label: "帳號設定", to: "/employee/account" },
     { label: "Notifications", to: "/notifications" },
   ],
   vendor_manager: [

--- a/frontend/src/pages/employee/AccountPage.jsx
+++ b/frontend/src/pages/employee/AccountPage.jsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import { useAuth } from "../../auth/AuthContext";
+import { changePassword } from "../../api/employee";
+import { useFacility } from "../../facility/FacilityContext";
+import { saveHomeFacilityId } from "../../facility/facilitySelection";
+
+function ChangePasswordForm() {
+  const [current, setCurrent] = useState("");
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+    setSuccess(false);
+
+    if (next !== confirm) {
+      setError("新密碼與確認密碼不一致");
+      return;
+    }
+    if (next.length < 8) {
+      setError("新密碼至少需要 8 個字元");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await changePassword(current, next);
+      setSuccess(true);
+      setCurrent("");
+      setNext("");
+      setConfirm("");
+    } catch (err) {
+      if (err.code === "wrong_current_password") {
+        setError("目前密碼不正確");
+      } else {
+        setError(err.message ?? "修改失敗，請稍後再試");
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="panel" style={{ marginBottom: 24 }}>
+      <h3 style={{ margin: "0 0 16px" }}>修改密碼</h3>
+      <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 14, maxWidth: 360 }}>
+        <label className="field">
+          <span>目前密碼</span>
+          <input
+            required
+            type="password"
+            value={current}
+            onChange={(e) => setCurrent(e.target.value)}
+            autoComplete="current-password"
+          />
+        </label>
+        <label className="field">
+          <span>新密碼</span>
+          <input
+            required
+            type="password"
+            value={next}
+            onChange={(e) => setNext(e.target.value)}
+            autoComplete="new-password"
+            minLength={8}
+          />
+        </label>
+        <label className="field">
+          <span>確認新密碼</span>
+          <input
+            required
+            type="password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            autoComplete="new-password"
+          />
+        </label>
+        {error && <p className="form-error" style={{ margin: 0 }}>{error}</p>}
+        {success && <p style={{ margin: 0, color: "var(--success)", fontSize: 14 }}>密碼修改成功。</p>}
+        <button className="button-primary" disabled={saving} type="submit" style={{ alignSelf: "flex-start" }}>
+          {saving ? "儲存中..." : "儲存"}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+function HomeFacilityForm() {
+  const { user } = useAuth();
+  const { facilities, selectedFacilityId, setSelectedFacilityId } = useFacility();
+  const [saved, setSaved] = useState(false);
+
+  if (!facilities || facilities.length === 0) return null;
+
+  function handleChange(e) {
+    const id = Number(e.target.value);
+    saveHomeFacilityId(user?.numericId, id);
+    setSelectedFacilityId(id);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  }
+
+  return (
+    <div className="panel">
+      <h3 style={{ margin: "0 0 8px" }}>預設廠區</h3>
+      <p className="panel-copy" style={{ margin: "0 0 14px" }}>
+        設定後，每次登入自動選取這個廠區，不再每次從第一個開始。
+      </p>
+      <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+        <select
+          value={selectedFacilityId ?? ""}
+          onChange={handleChange}
+          style={{
+            padding: "8px 14px",
+            borderRadius: "var(--radius-md)",
+            border: "1px solid var(--line)",
+            background: "var(--surface-strong)",
+            fontSize: 14,
+            cursor: "pointer",
+          }}
+        >
+          {facilities.map((f) => (
+            <option key={f.id} value={f.id}>
+              {f.code} — {f.name}
+            </option>
+          ))}
+        </select>
+        {saved && <span style={{ fontSize: 13, color: "var(--success)" }}>已儲存</span>}
+      </div>
+    </div>
+  );
+}
+
+export default function AccountPage() {
+  return (
+    <div>
+      <div className="page-header">
+        <p className="eyebrow">Employee · Account</p>
+        <h2>帳號設定</h2>
+      </div>
+      <ChangePasswordForm />
+      <HomeFacilityForm />
+    </div>
+  );
+}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -9,6 +9,7 @@ import AdminStatsPage from "../pages/admin/AdminStatsPage";
 import AdminPermissionsPage from "../pages/admin/AdminPermissionsPage";
 import AdminVendorReviewDetailPage from "../pages/admin/AdminVendorReviewDetailPage";
 import AdminVendorReviewListPage from "../pages/admin/AdminVendorReviewListPage";
+import AccountPage from "../pages/employee/AccountPage";
 import BadgePage from "../pages/employee/BadgePage";
 import CartPage from "../pages/employee/CartPage";
 import EmployeeHomePage from "../pages/employee/EmployeeHomePage";
@@ -78,6 +79,7 @@ export function AppRouter() {
             <Route element={<CartPage />} path="/employee/cart" />
             <Route element={<OrdersPage />} path="/employee/orders" />
             <Route element={<BadgePage />} path="/employee/badge" />
+            <Route element={<AccountPage />} path="/employee/account" />
           </Route>
 
           <Route element={<RoleRoute allowedRoles={["vendor_manager"]} />}>


### PR DESCRIPTION
Closes #142

## Summary

### Change password (`PATCH /auth/me/password`)
- 驗證目前密碼，錯誤回 403 `wrong_current_password`
- 新密碼 < 8 字元回 422 `password_too_short`
- 未登入回 401 `unauthenticated`
- 成功回 204，密碼即時更新

### Home facility (localStorage 持久化)
- `facilitySelection.js` 新增 `loadHomeFacilityId` / `saveHomeFacilityId`，以 `corpmeal:home_facility:{userId}` 為 key 存入 localStorage
- `FacilityContext` 載入設施時優先讀取 localStorage 偏好，再 fallback 到現有邏輯（current-or-first）
- 設定後立即更新 Topbar 廠區 chip，不需重整頁面

### AccountPage (`/employee/account`)
- Change password 表單：目前密碼 / 新密碼 / 確認新密碼，前端先驗證一致性與長度
- 預設廠區下拉選單：存入 localStorage 並更新 Context
- Navigation sidebar 新增「帳號設定」入口

## Test plan
- [ ] 304 unit tests pass
- [ ] 員工登入 → 帳號設定 → 修改密碼（正確流程）→ 204 成功
- [ ] 輸入錯誤的目前密碼 → 顯示「目前密碼不正確」
- [ ] 新密碼 < 8 字 → 前端顯示錯誤（不送 API）
- [ ] 設定預設廠區 → Topbar 即時切換 → 重整頁面仍保留設定