### PR TITLE
fix(quota): expose remaining_quantity on menu and disable sold-out items

### DIFF
--- a/backend/schemas/employee.py
+++ b/backend/schemas/employee.py
@@ -28,6 +28,7 @@ class EmployeeMenuItem(BaseModel):
     price_cents: int
     available: bool
     daily_quota: int | None
+    remaining_quantity: int | None = None
     photo_path: str | None
 
 

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -79,13 +79,15 @@ class EmployeeOrderingService:
         vendor = self._vendor_to_schema(self._get_approved_vendor(vendor_id))
         if employee_id is not None:
             self._assert_facility_access(vendor, employee_id, facility_id=facility_id)
+        items = self.menu_item_repository.list(
+            vendor_id=vendor_id, category_id=category_id, available=available
+        )
+        used_by_item = self.selection_repository.item_quantities_for_date(
+            meal_date=date.today(), vendor_ids=[vendor_id]
+        )
         return [
-            self._menu_item_to_schema(item)
-            for item in self.menu_item_repository.list(
-                vendor_id=vendor_id,
-                category_id=category_id,
-                available=available,
-            )
+            self._menu_item_to_schema(item, remaining=self._remaining_quantity(item, used_by_item.get(item.id, 0)))
+            for item in items
         ]
 
     def select_meal(
@@ -486,7 +488,7 @@ class EmployeeOrderingService:
         )
 
     @staticmethod
-    def _menu_item_to_schema(item: VendorMenuItem) -> EmployeeMenuItem:
+    def _menu_item_to_schema(item: VendorMenuItem, remaining: int | None = None) -> EmployeeMenuItem:
         return EmployeeMenuItem(
             id=item.id,
             vendor_id=item.vendor_id,
@@ -496,6 +498,7 @@ class EmployeeOrderingService:
             price_cents=item.price_cents,
             available=item.available,
             daily_quota=item.daily_quota,
+            remaining_quantity=remaining,
             photo_path=item.photo_path,
         )
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,10 @@ from collections.abc import Generator
 import pytest
 from prometheus_client import REGISTRY
 
+from backend.core.audit import get_audit_log_repository
+from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
+
 
 def _unregister_inprogress() -> None:
     """Remove the http_requests_inprogress collector so it can be re-registered."""
@@ -18,3 +22,12 @@ def _isolate_prometheus_registry() -> Generator[None, None, None]:
     _unregister_inprogress()
     yield
     _unregister_inprogress()
+
+
+@pytest.fixture(autouse=True)
+def _in_memory_audit_repo() -> Generator[None, None, None]:
+    """Unit tests run without a DB — default to the in-memory audit repo so that
+    routes that write audit entries don't try to open a Postgres connection."""
+    app.dependency_overrides.setdefault(get_audit_log_repository, lambda: AuditLogRepository())
+    yield
+    app.dependency_overrides.pop(get_audit_log_repository, None)

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -592,3 +592,46 @@ def test_select_meal_requires_employee_id() -> None:
 
     assert resp.status_code == 400
     assert resp.json()["code"] == "validation_error"
+
+
+# --- remaining_quantity in menu response ---
+
+def test_list_menu_includes_remaining_quantity_when_quota_set() -> None:
+    client, item_repo, selection_repo = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=5)
+    # place 2 orders for today to consume some quota
+    selection_repo.create_order(
+        employee_id=100, vendor_id=1, meal_date=date.today(),
+        items=[OrderItemSnapshot(item_id=item.id, item_name="Rice Bowl", quantity=2, unit_price_cents=120)],
+    )
+
+    resp = client.get("/employee/vendors/1/menu", headers=_browse_h())
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["remaining_quantity"] == 3  # 5 - 2 = 3
+
+
+def test_list_menu_remaining_quantity_is_null_when_no_quota() -> None:
+    client, item_repo, _ = _setup()
+    item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=None)
+
+    resp = client.get("/employee/vendors/1/menu", headers=_browse_h())
+
+    assert resp.status_code == 200
+    assert resp.json()[0]["remaining_quantity"] is None
+
+
+def test_list_menu_shows_zero_remaining_when_quota_exhausted() -> None:
+    client, item_repo, selection_repo = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=2)
+    selection_repo.create_order(
+        employee_id=100, vendor_id=1, meal_date=date.today(),
+        items=[OrderItemSnapshot(item_id=item.id, item_name="Rice Bowl", quantity=2, unit_price_cents=120)],
+    )
+
+    resp = client.get("/employee/vendors/1/menu", headers=_browse_h())
+
+    assert resp.status_code == 200
+    assert resp.json()[0]["remaining_quantity"] == 0

--- a/frontend/src/components/employee/MealDetailModal.jsx
+++ b/frontend/src/components/employee/MealDetailModal.jsx
@@ -4,15 +4,15 @@ import { formatPrice, photoUrl, quotaLabel } from "../../utils/format";
 
 export default function MealDetailModal({ item, onClose }) {
   const photo = photoUrl(item.photo_path);
-  const quota = quotaLabel(item.daily_quota);
-  const soldOut = item.daily_quota === 0;
+  const soldOut = item.remaining_quantity === 0;
   const unavailable = !item.available || soldOut;
+  const quota = quotaLabel(item.remaining_quantity);
 
   const [quantity, setQuantity] = useState(1);
   const [added, setAdded] = useState(false);
   const { addItem } = useCart();
 
-  const maxQty = item.daily_quota > 0 ? Math.min(item.daily_quota, 99) : 99;
+  const maxQty = item.remaining_quantity > 0 ? Math.min(item.remaining_quantity, 99) : 99;
 
   useEffect(() => {
     function onKey(e) {

--- a/frontend/src/components/employee/MenuItemCard.jsx
+++ b/frontend/src/components/employee/MenuItemCard.jsx
@@ -2,9 +2,9 @@ import { formatPrice, photoUrl, quotaLabel } from "../../utils/format";
 
 export default function MenuItemCard({ item, onClick }) {
   const photo = photoUrl(item.photo_path);
-  const quota = quotaLabel(item.daily_quota);
-  const soldOut = item.daily_quota === 0;
+  const soldOut = item.remaining_quantity === 0;
   const unavailable = !item.available || soldOut;
+  const quota = quotaLabel(item.remaining_quantity);
 
   return (
     <button

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -11,10 +11,10 @@ export function formatMoney(cents) {
   return `NT$ ${Number.isInteger(amount) ? amount : amount.toFixed(1)}`;
 }
 
-export function quotaLabel(dailyQuota) {
-  if (dailyQuota === null || dailyQuota === undefined) return null;
-  if (dailyQuota === 0) return "今日售完";
-  return `剩餘 ${dailyQuota} 份`;
+export function quotaLabel(remainingQuantity) {
+  if (remainingQuantity === null || remainingQuantity === undefined) return null;
+  if (remainingQuantity === 0) return null;
+  return `剩餘 ${remainingQuantity} 份`;
 }
 
 export function photoUrl(photoPath, version) {


### PR DESCRIPTION
Closes #138

## Summary

### 問題
後端已有完整的每日配額檢查（訂單超量回 409 `quota_exhausted`），但 `EmployeeMenuItem` 沒有 `remaining_quantity` 欄位，前端無法得知今日剩餘數量。前端又用了錯誤的 `daily_quota === 0`（total cap，不是今日剩餘）判斷售完，導致：
- 商品賣完後還能點選
- 顯示的是總配額而非剩餘數量

### 修正

**Backend**
- `EmployeeMenuItem` schema 新增 `remaining_quantity: int | None`
- `list_menu` 計算今日已用量（`item_quantities_for_date(date.today())`）並傳入 `_menu_item_to_schema`
- `_menu_item_to_schema` 接受並填入 `remaining` 參數

**Frontend**
- `MenuItemCard` / `MealDetailModal`：`soldOut = remaining_quantity === 0`（非 null 且為 0 才算售完）
- `MealDetailModal`：`maxQty` 限制改為 `remaining_quantity`
- `quotaLabel`：接受 `remaining_quantity` 顯示「剩餘 N 份」，0 則返回 null（由 soldOut badge 表達）

## Test plan
- [ ] 303 unit tests pass
- [ ] 設定 daily_quota=3 的商品，下 2 份訂單 → menu API 回 remaining_quantity=1 → 顯示「剩餘 1 份」
- [ ] 下完剩餘最後 1 份 → 商品顯示「今日售完」且按鈕 disabled
- [ ] 沒設 daily_quota 的商品 → remaining_quantity=null → 正常顯示「供應中」
- [ ] 嘗試訂購超過 remaining → 後端回 409 quota_exhausted → CartPage 顯示錯誤訊息