### PR TITLE
fix(ui): button contrast, admin chart removal, vendor orders columns

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,10 @@ from collections.abc import Generator
 import pytest
 from prometheus_client import REGISTRY
 
+from backend.core.audit import get_audit_log_repository
+from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
+
 
 def _unregister_inprogress() -> None:
     """Remove the http_requests_inprogress collector so it can be re-registered."""
@@ -18,3 +22,12 @@ def _isolate_prometheus_registry() -> Generator[None, None, None]:
     _unregister_inprogress()
     yield
     _unregister_inprogress()
+
+
+@pytest.fixture(autouse=True)
+def _in_memory_audit_repo() -> Generator[None, None, None]:
+    """Unit tests run without a DB — default to the in-memory audit repo so that
+    routes that write audit entries don't try to open a Postgres connection."""
+    app.dependency_overrides.setdefault(get_audit_log_repository, lambda: AuditLogRepository())
+    yield
+    app.dependency_overrides.pop(get_audit_log_repository, None)

--- a/frontend/src/pages/admin/AdminStatsPage.jsx
+++ b/frontend/src/pages/admin/AdminStatsPage.jsx
@@ -20,68 +20,6 @@ function sharePct(part, total) {
   return `${((part / total) * 100).toFixed(1)}%`;
 }
 
-function shortDay(iso) {
-  const [, m, d] = iso.split("-");
-  return `${Number(m)}/${Number(d)}`;
-}
-
-// Vertical column chart for the daily order trend. Pure inline SVG — no chart
-// library — so it stays within the plain HTML/CSS stack. Column height is
-// proportional to that day's order count relative to the busiest day.
-function ColumnChart({ data }) {
-  if (data.length === 0) return <p className="panel-copy">此區間無訂單資料。</p>;
-
-  const max = Math.max(1, ...data.map((p) => p.order_count));
-  const STEP = 34;
-  const BAR = 18;
-  const H = 200;
-  const PAD_TOP = 22;
-  const PAD_BOTTOM = 28;
-  const plotH = H - PAD_TOP - PAD_BOTTOM;
-  const W = Math.max(data.length * STEP, STEP);
-  const labelEvery = Math.ceil(data.length / 12);
-
-  return (
-    <svg
-      className="col-chart"
-      viewBox={`0 0 ${W} ${H}`}
-      role="img"
-      aria-label="每日訂單數柱狀圖"
-      preserveAspectRatio="xMidYMid meet"
-    >
-      <defs>
-        <linearGradient id="colFill" x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" style={{ stopColor: "var(--accent)" }} />
-          <stop offset="100%" style={{ stopColor: "var(--brand)" }} />
-        </linearGradient>
-      </defs>
-      <line x1="0" y1={H - PAD_BOTTOM} x2={W} y2={H - PAD_BOTTOM} stroke="var(--line)" />
-      {data.map((p, i) => {
-        const h = (p.order_count / max) * plotH;
-        const x = i * STEP + (STEP - BAR) / 2;
-        const y = H - PAD_BOTTOM - h;
-        const cx = i * STEP + STEP / 2;
-        return (
-          <g key={p.day}>
-            <title>{`${p.day}：${p.order_count} 筆`}</title>
-            <rect x={x} y={y} width={BAR} height={Math.max(h, 2)} rx="4" fill="url(#colFill)" />
-            {data.length <= 14 && (
-              <text x={cx} y={y - 6} textAnchor="middle" className="col-chart-val">
-                {p.order_count}
-              </text>
-            )}
-            {i % labelEvery === 0 && (
-              <text x={cx} y={H - PAD_BOTTOM + 16} textAnchor="middle" className="col-chart-lab">
-                {shortDay(p.day)}
-              </text>
-            )}
-          </g>
-        );
-      })}
-    </svg>
-  );
-}
-
 export default function AdminStatsPage() {
   const [stats, setStats] = useState(null);
   const [error, setError] = useState(null);
@@ -166,11 +104,6 @@ export default function AdminStatsPage() {
               <span>活躍商家</span>
               <strong>{stats.summary.active_vendor_count}</strong>
             </div>
-          </article>
-
-          <article className="panel">
-            <h3>每日訂單</h3>
-            <ColumnChart data={stats.daily_trend} />
           </article>
 
           <article className="panel">

--- a/frontend/src/pages/vendor/VendorOrdersPage.jsx
+++ b/frontend/src/pages/vendor/VendorOrdersPage.jsx
@@ -105,7 +105,7 @@ export default function VendorOrdersPage() {
             <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "56px 120px 110px 1fr 110px 100px 36px",
+                gridTemplateColumns: "150px 110px 1fr 110px 100px 36px",
                 padding: "10px 20px",
                 borderBottom: "1px solid var(--line)",
                 color: "var(--muted)",
@@ -115,8 +115,7 @@ export default function VendorOrdersPage() {
                 letterSpacing: "0.05em",
               }}
             >
-              <span>#</span>
-              <span>來源</span>
+              <span>日期 · 訂單</span>
               <span>取餐碼</span>
               <span>品項</span>
               <span style={{ textAlign: "right" }}>合計</span>
@@ -131,7 +130,7 @@ export default function VendorOrdersPage() {
                 onClick={() => navigate(`/vendor/orders/${order.id}`)}
                 style={{
                   display: "grid",
-                  gridTemplateColumns: "56px 120px 110px 1fr 110px 100px 36px",
+                  gridTemplateColumns: "150px 110px 1fr 110px 100px 36px",
                   alignItems: "center",
                   width: "100%",
                   padding: "14px 20px",
@@ -145,9 +144,12 @@ export default function VendorOrdersPage() {
                 onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(23,33,43,0.03)")}
                 onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
               >
-                <p style={{ margin: 0, fontSize: 12, color: "var(--muted)" }}>#{order.id}</p>
+                <div>
+                  <p style={{ margin: 0, fontSize: 13, fontWeight: 600 }}>{order.meal_date ?? "—"}</p>
+                  <p style={{ margin: "2px 0 0", fontSize: 11, color: "var(--muted)" }}>#{order.id}</p>
+                </div>
                 <p style={{ margin: 0, fontWeight: 700, fontSize: 13 }}>
-                  {order.pickup_code ?? "-"}
+                  {order.pickup_code ?? "—"}
                 </p>
                 <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>
                   {itemsSummary(order.items)}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -188,6 +188,18 @@ p {
   transform: translateY(-1px);
 }
 
+/* Ghost buttons inside panels sit on a light surface — override to dark contrast. */
+.panel .ghost-button {
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--text);
+}
+
+.panel .ghost-button:hover {
+  background: rgba(23, 33, 43, 0.05);
+  transform: none;
+}
+
 .app-shell {
   display: grid;
   grid-template-columns: 320px minmax(0, 1fr);


### PR DESCRIPTION
Closes #143

## Summary

**1. Button contrast**
- 新增 `.panel .ghost-button` CSS 覆蓋：在 light panel 背景下改為深色文字（`var(--text)`）和 `var(--line)` 邊框
- Topbar / Sidebar 的 ghost-button 不受影響（仍是白色，深色背景下 OK）

**2. Admin stats dashboard 去蕪**
- 移除 `ColumnChart` SVG 元件和「每日訂單」panel（純 CSS chart 不夠精確且版面擁擠）
- 保留：摘要 KPI 卡、商家排行表、廠區分布表

**3. Vendor orders 欄位對齊**
- 移除孤立的「來源」header（後端 `_deidentify_order` 已把 `employee_id` 設為 null，該欄永遠空白）
- Grid 從 7 欄（`56px 120px 110px 1fr 110px 100px 36px`）修正為 6 欄（`150px 110px 1fr 110px 100px 36px`）
- 第一欄改為日期 + 訂單號

## Test plan
- [ ] 300 unit tests pass
- [ ] Vendor menu 頁面的「編輯」「刪除」按鈕可見（深色文字、有邊框）
- [ ] Admin stats 頁面不再有柱狀圖，版面整潔
- [ ] Vendor orders 欄位對齊（日期·訂單 / 取餐碼 / 品項 / 合計 / 狀態）