### PR TITLE
feat(vendor): require facilities on applications

### DIFF
--- a/backend/repositories/vendor_repository.py
+++ b/backend/repositories/vendor_repository.py
@@ -3,6 +3,21 @@ from __future__ import annotations
 
 from backend.db.connection import get_connection
 from backend.schemas.vendor import VendorApplicationCreate, VendorApplicationDetail, VendorApplicationSummary
+from backend.schemas.vendor_self import Facility
+
+
+def _vendor_facilities(conn, vendor_id: int) -> list[Facility]:
+    rows = conn.execute(
+        """
+        SELECT f.id, f.code, f.name
+        FROM facilities f
+        JOIN vendor_facilities vf ON vf.facility_id = f.id
+        WHERE vf.vendor_id = %s
+        ORDER BY f.code, f.id
+        """,
+        (vendor_id,),
+    ).fetchall()
+    return [Facility(**dict(row)) for row in rows]
 
 
 class VendorRepository:
@@ -17,6 +32,15 @@ class VendorRepository:
                 (data.vendor_name, data.address, data.business_hours, data.contact_phone, data.contact_email, user_id),
             ).fetchone()
             vendor_id = vendor_row["id"]
+            for facility_id in data.facility_ids:
+                conn.execute(
+                    """
+                    INSERT INTO vendor_facilities (vendor_id, facility_id)
+                    VALUES (%s, %s)
+                    ON CONFLICT DO NOTHING
+                    """,
+                    (vendor_id, facility_id),
+                )
 
             app_row = conn.execute(
                 """
@@ -26,6 +50,7 @@ class VendorRepository:
                 """,
                 (vendor_id, user_id),
             ).fetchone()
+            served_facilities = _vendor_facilities(conn, vendor_id)
 
         return VendorApplicationDetail(
             application_id=app_row["id"],
@@ -36,6 +61,7 @@ class VendorRepository:
             business_hours=data.business_hours,
             contact_phone=data.contact_phone,
             contact_email=data.contact_email,
+            served_facilities=served_facilities,
             submitted_at=app_row["created_at"],
         )
 
@@ -64,9 +90,11 @@ class VendorRepository:
                 (user_id,),
             ).fetchone()
 
-        if row is None:
-            return None
-        return VendorApplicationDetail(**dict(row))
+            if row is None:
+                return None
+            data = dict(row)
+            data["served_facilities"] = _vendor_facilities(conn, data["vendor_id"])
+        return VendorApplicationDetail(**data)
 
     def list_applications(self, *, status: str | None = None) -> list[VendorApplicationSummary]:
         query = """
@@ -119,9 +147,11 @@ class VendorRepository:
                 (application_id,),
             ).fetchone()
 
-        if row is None:
-            return None
-        return VendorApplicationDetail(**dict(row))
+            if row is None:
+                return None
+            data = dict(row)
+            data["served_facilities"] = _vendor_facilities(conn, data["vendor_id"])
+        return VendorApplicationDetail(**data)
 
     def mark_application_reviewed(
         self,

--- a/backend/routes/vendor_application.py
+++ b/backend/routes/vendor_application.py
@@ -57,7 +57,7 @@ def _validate_application_payload(payload: VendorApplicationCreate, facility_rep
     return payload.model_copy(update={"facility_ids": facility_ids})
 
 
-@router.get("/facilities", response_model=list[Facility])
+@router.get("/facilities")
 def list_application_facilities(
     _user_id: Annotated[int, Depends(require_vendor_manager)],
     facility_repo: Annotated[object, Depends(get_facility_repository)],

--- a/backend/routes/vendor_application.py
+++ b/backend/routes/vendor_application.py
@@ -5,9 +5,12 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 
+from backend.core.errors import CodedHTTPException
+from backend.core.facilities import get_facility_repository
 from backend.core.vendor_identity import require_vendor_manager
 from backend.repositories.vendor_repository import VendorRepository
 from backend.schemas.vendor import VendorApplicationCreate, VendorApplicationDetail
+from backend.schemas.vendor_self import Facility
 
 router = APIRouter(prefix="/vendor/applications", tags=["vendor-application"])
 
@@ -18,20 +21,65 @@ def get_vendor_repository() -> VendorRepository:
     return _repo
 
 
+_REQUIRED_APPLICATION_FIELDS = {
+    "vendor_name": "vendor_name",
+    "address": "address",
+    "business_hours": "business_hours",
+    "contact_phone": "contact_phone",
+    "contact_email": "contact_email",
+}
+
+
+def _validate_application_payload(payload: VendorApplicationCreate, facility_repo) -> VendorApplicationCreate:
+    missing = [
+        label
+        for field, label in _REQUIRED_APPLICATION_FIELDS.items()
+        if not (getattr(payload, field) or "").strip()
+    ]
+    facility_ids = list(dict.fromkeys(payload.facility_ids))
+    if not facility_ids:
+        missing.append("facility_ids")
+    if missing:
+        raise CodedHTTPException(
+            status_code=400,
+            code="validation_error",
+            detail=f"missing required fields: {', '.join(missing)}",
+        )
+
+    invalid_ids = [facility_id for facility_id in facility_ids if not facility_repo.facility_exists(facility_id)]
+    if invalid_ids:
+        raise CodedHTTPException(
+            status_code=400,
+            code="validation_error",
+            detail=f"facility not found: {', '.join(str(fid) for fid in invalid_ids)}",
+        )
+
+    return payload.model_copy(update={"facility_ids": facility_ids})
+
+
+@router.get("/facilities", response_model=list[Facility])
+def list_application_facilities(
+    _user_id: Annotated[int, Depends(require_vendor_manager)],
+    facility_repo: Annotated[object, Depends(get_facility_repository)],
+) -> list[Facility]:
+    return facility_repo.list_facilities()
+
+
 @router.post("", response_model=VendorApplicationDetail, status_code=status.HTTP_201_CREATED)
 def submit_application(
     payload: VendorApplicationCreate,
     user_id: Annotated[int, Depends(require_vendor_manager)],
     repo: Annotated[VendorRepository, Depends(get_vendor_repository)],
+    facility_repo: Annotated[object, Depends(get_facility_repository)],
 ) -> VendorApplicationDetail:
     existing = repo.get_my_application(user_id)
     if existing is not None:
-        from backend.core.errors import CodedHTTPException
         raise CodedHTTPException(
             status_code=409,
             code="application_already_exists",
             detail="A vendor application already exists for this account",
         )
+    payload = _validate_application_payload(payload, facility_repo)
     return repo.create_application(user_id, payload)
 
 

--- a/backend/schemas/vendor.py
+++ b/backend/schemas/vendor.py
@@ -2,6 +2,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from backend.schemas.vendor_self import Facility
+
 
 class VendorReviewRequest(BaseModel):
     decision: str = Field(pattern="^(approved|rejected)$")
@@ -15,11 +17,12 @@ class VendorReviewResponse(BaseModel):
 
 
 class VendorApplicationCreate(BaseModel):
-    vendor_name: str
+    vendor_name: str = ""
     address: str | None = None
     business_hours: str | None = None
     contact_phone: str | None = None
     contact_email: str | None = None
+    facility_ids: list[int] = Field(default_factory=list)
 
 
 class VendorApplicationSummary(BaseModel):
@@ -37,5 +40,6 @@ class VendorApplicationDetail(VendorApplicationSummary):
     business_hours: str | None = None
     contact_phone: str | None = None
     contact_email: str | None = None
+    served_facilities: list[Facility] = Field(default_factory=list)
     review_reason: str | None = None
     reviewed_at: datetime | None = None

--- a/backend/tests/test_vendor_application.py
+++ b/backend/tests/test_vendor_application.py
@@ -11,9 +11,11 @@ from datetime import datetime, timezone
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.core.facilities import get_facility_repository
 from backend.main import app
 from backend.routes.vendor_application import get_vendor_repository
 from backend.schemas.vendor import VendorApplicationCreate, VendorApplicationDetail
+from backend.schemas.vendor_self import Facility
 
 
 class _FakeVendorRepository:
@@ -39,18 +41,38 @@ class _FakeVendorRepository:
             business_hours=data.business_hours,
             contact_phone=data.contact_phone,
             contact_email=data.contact_email,
+            served_facilities=[
+                Facility(id=fid, code=f"F{fid}", name=f"Facility {fid}")
+                for fid in data.facility_ids
+            ],
         )
         self._by_user[user_id] = detail
         self._next_id += 1
         return detail
 
 
+class _FakeFacilityRepository:
+    def __init__(self) -> None:
+        self._facilities = [
+            Facility(id=1, code="F12A", name="Fab 12A"),
+            Facility(id=2, code="F14B", name="Fab 14B"),
+        ]
+
+    def list_facilities(self) -> list[Facility]:
+        return list(self._facilities)
+
+    def facility_exists(self, facility_id: int) -> bool:
+        return any(facility.id == facility_id for facility in self._facilities)
+
+
 @pytest.fixture()
 def repo():
     fake = _FakeVendorRepository()
     app.dependency_overrides[get_vendor_repository] = lambda: fake
+    app.dependency_overrides[get_facility_repository] = lambda: _FakeFacilityRepository()
     yield fake
     app.dependency_overrides.pop(get_vendor_repository, None)
+    app.dependency_overrides.pop(get_facility_repository, None)
 
 
 @pytest.fixture()
@@ -61,33 +83,93 @@ def client():
 _VM_HEADERS = {"x-user-role": "vendor_manager", "x-user-id": "42"}
 
 
+def _application_payload(**overrides):
+    payload = {
+        "vendor_name": "My Kitchen",
+        "address": "1 Main St",
+        "business_hours": "11:00-14:00",
+        "contact_phone": "02-1234-5678",
+        "contact_email": "k@example.com",
+        "facility_ids": [1, 2],
+    }
+    payload.update(overrides)
+    return payload
+
+
 def test_submit_application_returns_created_detail(client, repo):
     resp = client.post(
         "/vendor/applications",
         headers=_VM_HEADERS,
-        json={
-            "vendor_name": "My Kitchen",
-            "address": "1 Main St",
-            "contact_email": "k@example.com",
-        },
+        json=_application_payload(),
     )
     assert resp.status_code == 201
     body = resp.json()
     assert body["vendor_name"] == "My Kitchen"
     assert body["status"] == "pending"
     assert body["address"] == "1 Main St"
+    assert [facility["id"] for facility in body["served_facilities"]] == [1, 2]
     # the application is persisted under the calling user's id
     assert repo.get_my_application(42) is not None
 
 
 @pytest.mark.usefixtures("repo")
+def test_list_application_facilities_returns_available_facilities(client):
+    resp = client.get("/vendor/applications/facilities", headers=_VM_HEADERS)
+
+    assert resp.status_code == 200
+    assert resp.json() == [
+        {"id": 1, "code": "F12A", "name": "Fab 12A"},
+        {"id": 2, "code": "F14B", "name": "Fab 14B"},
+    ]
+
+
+@pytest.mark.usefixtures("repo")
+def test_submit_application_requires_required_fields(client):
+    resp = client.post(
+        "/vendor/applications",
+        headers=_VM_HEADERS,
+        json=_application_payload(address="   "),
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"
+    assert "address" in resp.json()["detail"]
+
+
+@pytest.mark.usefixtures("repo")
+def test_submit_application_requires_facility_selection(client):
+    resp = client.post(
+        "/vendor/applications",
+        headers=_VM_HEADERS,
+        json=_application_payload(facility_ids=[]),
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"
+    assert "facility_ids" in resp.json()["detail"]
+
+
+@pytest.mark.usefixtures("repo")
+def test_submit_application_rejects_unknown_facility(client):
+    resp = client.post(
+        "/vendor/applications",
+        headers=_VM_HEADERS,
+        json=_application_payload(facility_ids=[999]),
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"
+    assert "999" in resp.json()["detail"]
+
+
+@pytest.mark.usefixtures("repo")
 def test_submit_application_conflicts_when_one_already_exists(client):
     first = client.post(
-        "/vendor/applications", headers=_VM_HEADERS, json={"vendor_name": "First"}
+        "/vendor/applications", headers=_VM_HEADERS, json=_application_payload(vendor_name="First")
     )
     assert first.status_code == 201
     second = client.post(
-        "/vendor/applications", headers=_VM_HEADERS, json={"vendor_name": "Second"}
+        "/vendor/applications", headers=_VM_HEADERS, json=_application_payload(vendor_name="Second")
     )
     assert second.status_code == 409
     assert "application_already_exists" in second.text
@@ -95,10 +177,15 @@ def test_submit_application_conflicts_when_one_already_exists(client):
 
 @pytest.mark.usefixtures("repo")
 def test_get_my_application_returns_submitted_one(client):
-    client.post("/vendor/applications", headers=_VM_HEADERS, json={"vendor_name": "Mine"})
+    client.post(
+        "/vendor/applications",
+        headers=_VM_HEADERS,
+        json=_application_payload(vendor_name="Mine", facility_ids=[1]),
+    )
     resp = client.get("/vendor/applications/me", headers=_VM_HEADERS)
     assert resp.status_code == 200
     assert resp.json()["vendor_name"] == "Mine"
+    assert [facility["id"] for facility in resp.json()["served_facilities"]] == [1]
 
 
 @pytest.mark.usefixtures("repo")
@@ -113,7 +200,7 @@ def test_submit_application_requires_vendor_manager_role(client):
     resp = client.post(
         "/vendor/applications",
         headers={"x-user-role": "employee", "x-user-id": "42"},
-        json={"vendor_name": "X"},
+        json=_application_payload(vendor_name="X"),
     )
     assert resp.status_code == 403
 
@@ -123,6 +210,6 @@ def test_submit_application_requires_user_id_header(client):
     resp = client.post(
         "/vendor/applications",
         headers={"x-user-role": "vendor_manager"},
-        json={"vendor_name": "X"},
+        json=_application_payload(vendor_name="X"),
     )
     assert resp.status_code == 400

--- a/backend/tests/test_vendor_repository.py
+++ b/backend/tests/test_vendor_repository.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from backend.repositories.vendor_repository import VendorRepository
+from backend.schemas.vendor import VendorApplicationCreate
+
+
+def _result(*, one=None, all_rows=None) -> MagicMock:
+    result = MagicMock()
+    result.fetchone.return_value = one
+    result.fetchall.return_value = [] if all_rows is None else all_rows
+    return result
+
+
+def _conn_ctx(*results: MagicMock) -> MagicMock:
+    conn = MagicMock()
+    conn.execute.side_effect = results
+    ctx = MagicMock()
+    ctx.__enter__.return_value = conn
+    ctx.__exit__.return_value = False
+    return ctx
+
+
+def _application_row() -> dict:
+    return {
+        "application_id": 501,
+        "status": "pending",
+        "review_reason": None,
+        "reviewed_at": None,
+        "submitted_at": datetime(2026, 5, 30, tzinfo=timezone.utc),
+        "vendor_id": 77,
+        "vendor_name": "My Kitchen",
+        "address": "1 Main St",
+        "business_hours": "11:00-14:00",
+        "contact_phone": "02-1234-5678",
+        "contact_email": "k@example.com",
+    }
+
+
+def _facility_rows() -> list[dict]:
+    return [
+        {"id": 1, "code": "F12A", "name": "Fab 12A"},
+        {"id": 2, "code": "F14B", "name": "Fab 14B"},
+    ]
+
+
+def test_create_application_persists_and_returns_served_facilities() -> None:
+    submitted_at = datetime(2026, 5, 30, tzinfo=timezone.utc)
+    ctx = _conn_ctx(
+        _result(one={"id": 77}),
+        _result(),
+        _result(),
+        _result(one={"id": 501, "created_at": submitted_at}),
+        _result(all_rows=_facility_rows()),
+    )
+    payload = VendorApplicationCreate(
+        vendor_name="My Kitchen",
+        address="1 Main St",
+        business_hours="11:00-14:00",
+        contact_phone="02-1234-5678",
+        contact_email="k@example.com",
+        facility_ids=[1, 2],
+    )
+
+    with patch("backend.repositories.vendor_repository.get_connection", return_value=ctx):
+        detail = VendorRepository().create_application(user_id=42, data=payload)
+
+    conn = ctx.__enter__.return_value
+    facility_insert_params = [
+        call.args[1]
+        for call in conn.execute.call_args_list
+        if "INSERT INTO vendor_facilities" in call.args[0]
+    ]
+    assert facility_insert_params == [(77, 1), (77, 2)]
+    assert detail.application_id == 501
+    assert detail.vendor_id == 77
+    assert [facility.id for facility in detail.served_facilities] == [1, 2]
+
+
+def test_get_my_application_returns_served_facilities() -> None:
+    ctx = _conn_ctx(
+        _result(one=_application_row()),
+        _result(all_rows=_facility_rows()),
+    )
+
+    with patch("backend.repositories.vendor_repository.get_connection", return_value=ctx):
+        detail = VendorRepository().get_my_application(user_id=42)
+
+    assert detail is not None
+    assert detail.vendor_id == 77
+    assert [facility.code for facility in detail.served_facilities] == ["F12A", "F14B"]
+
+
+def test_get_my_application_returns_none_when_missing() -> None:
+    ctx = _conn_ctx(_result(one=None))
+
+    with patch("backend.repositories.vendor_repository.get_connection", return_value=ctx):
+        detail = VendorRepository().get_my_application(user_id=42)
+
+    assert detail is None
+
+
+def test_get_application_returns_served_facilities() -> None:
+    ctx = _conn_ctx(
+        _result(
+            one={
+                **_application_row(),
+                "submitter_email": "owner@example.com",
+                "submitter_name": "Owner",
+            }
+        ),
+        _result(all_rows=_facility_rows()),
+    )
+
+    with patch("backend.repositories.vendor_repository.get_connection", return_value=ctx):
+        detail = VendorRepository().get_application(application_id=501)
+
+    assert detail is not None
+    assert detail.submitter_email == "owner@example.com"
+    assert [facility.name for facility in detail.served_facilities] == ["Fab 12A", "Fab 14B"]
+
+
+def test_get_application_returns_none_when_missing() -> None:
+    ctx = _conn_ctx(_result(one=None))
+
+    with patch("backend.repositories.vendor_repository.get_connection", return_value=ctx):
+        detail = VendorRepository().get_application(application_id=501)
+
+    assert detail is None

--- a/frontend/src/api/vendor.js
+++ b/frontend/src/api/vendor.js
@@ -84,6 +84,20 @@ export function deleteMenuItemPhoto(itemId) {
   return apiFetch(`/vendor/me/menu/${itemId}/photo`, { method: "DELETE" });
 }
 
+export function getApplicationFacilities() {
+  return withMockFallback(
+    () => apiFetch("/vendor/applications/facilities"),
+    Array.from(
+      new Map(
+        MOCK_VENDORS.flatMap((vendor) => vendor.served_facilities ?? []).map((facility) => [
+          facility.id,
+          facility,
+        ]),
+      ).values(),
+    ),
+  );
+}
+
 export function submitVendorApplication(data) {
   return apiFetch("/vendor/applications", {
     method: "POST",

--- a/frontend/src/pages/admin/AdminVendorReviewDetailPage.jsx
+++ b/frontend/src/pages/admin/AdminVendorReviewDetailPage.jsx
@@ -74,6 +74,9 @@ export default function AdminVendorReviewDetailPage() {
   if (!application) return null;
 
   const isPending = application.status === "pending";
+  const facilityText = (application.served_facilities ?? [])
+    .map((facility) => `${facility.code ?? ""} ${facility.name}`.trim())
+    .join("、");
 
   return (
     <div>
@@ -97,6 +100,7 @@ export default function AdminVendorReviewDetailPage() {
           <InfoRow label="營業時間" value={application.business_hours} />
           <InfoRow label="聯絡電話" value={application.contact_phone} />
           <InfoRow label="聯絡 Email" value={application.contact_email} />
+          <InfoRow label="服務廠區" value={facilityText} />
           <hr style={{ border: "none", borderTop: "1px solid var(--line)", margin: "16px 0" }} />
           <InfoRow label="申請人" value={application.submitter_name} />
           <InfoRow label="Email" value={application.submitter_email} />

--- a/frontend/src/pages/vendor/VendorApplyPage.jsx
+++ b/frontend/src/pages/vendor/VendorApplyPage.jsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from "react";
-import { getMyVendorApplication, submitVendorApplication } from "../../api/vendor";
+import {
+  getApplicationFacilities,
+  getMyVendorApplication,
+  submitVendorApplication,
+} from "../../api/vendor";
 
 function PendingBanner({ application }) {
   const statusLabel = {
@@ -12,6 +16,9 @@ function PendingBanner({ application }) {
     approved: "var(--success)",
     rejected: "var(--brand)",
   };
+  const facilityText = (application.served_facilities ?? [])
+    .map((facility) => `${facility.code ?? ""} ${facility.name}`.trim())
+    .join("、");
 
   return (
     <section className="panel" style={{ maxWidth: 560 }}>
@@ -31,6 +38,11 @@ function PendingBanner({ application }) {
       >
         {statusLabel[application.status] ?? application.status}
       </p>
+      {facilityText && (
+        <p className="panel-copy" style={{ marginBottom: 16 }}>
+          服務廠區：{facilityText}
+        </p>
+      )}
 
       {application.status === "pending" && (
         <p className="panel-copy">您的申請已送出，管理員審核後將更新狀態。審核通過後請重新登入，即可開始管理菜單。</p>
@@ -64,18 +76,56 @@ function ApplicationForm({ onSubmitted }) {
     business_hours: "",
     contact_phone: "",
     contact_email: "",
+    facility_ids: [],
   });
+  const [facilities, setFacilities] = useState([]);
+  const [facilityLoading, setFacilityLoading] = useState(true);
+  const [fieldErrors, setFieldErrors] = useState({});
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
 
+  useEffect(() => {
+    getApplicationFacilities()
+      .then(setFacilities)
+      .catch((err) => setError(err.message ?? "廠區資料載入失敗"))
+      .finally(() => setFacilityLoading(false));
+  }, []);
+
   function handleChange(e) {
     setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+    setFieldErrors((prev) => ({ ...prev, [e.target.name]: null }));
+  }
+
+  function handleFacilityToggle(facilityId) {
+    setForm((prev) => {
+      const selected = new Set(prev.facility_ids);
+      if (selected.has(facilityId)) {
+        selected.delete(facilityId);
+      } else {
+        selected.add(facilityId);
+      }
+      return { ...prev, facility_ids: Array.from(selected) };
+    });
+    setFieldErrors((prev) => ({ ...prev, facility_ids: null }));
+  }
+
+  function validateForm() {
+    const errors = {};
+    if (!form.vendor_name.trim()) errors.vendor_name = "廠商名稱為必填";
+    if (!form.address.trim()) errors.address = "地址為必填";
+    if (!form.business_hours.trim()) errors.business_hours = "營業時間為必填";
+    if (!form.contact_phone.trim()) errors.contact_phone = "聯絡電話為必填";
+    if (!form.contact_email.trim()) errors.contact_email = "聯絡 Email 為必填";
+    if (form.facility_ids.length === 0) errors.facility_ids = "請選擇至少一個服務廠區";
+    return errors;
   }
 
   async function handleSubmit(e) {
     e.preventDefault();
-    if (!form.vendor_name.trim()) {
-      setError("廠商名稱為必填");
+    const errors = validateForm();
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) {
+      setError("請完成必填欄位");
       return;
     }
     setSubmitting(true);
@@ -87,6 +137,7 @@ function ApplicationForm({ onSubmitted }) {
         business_hours: form.business_hours.trim() || null,
         contact_phone: form.contact_phone.trim() || null,
         contact_email: form.contact_email.trim() || null,
+        facility_ids: form.facility_ids,
       });
       onSubmitted(result);
     } catch (err) {
@@ -117,6 +168,15 @@ function ApplicationForm({ onSubmitted }) {
     marginBottom: 16,
   };
 
+  const errorStyle = {
+    display: "block",
+    color: "var(--brand)",
+    fontSize: 12,
+    marginTop: 6,
+  };
+
+  const requiredMark = <span style={{ color: "var(--brand)" }}> *</span>;
+
   return (
     <section className="panel" style={{ maxWidth: 560 }}>
       <p className="eyebrow">Vendor Application</p>
@@ -127,7 +187,7 @@ function ApplicationForm({ onSubmitted }) {
 
       <form onSubmit={handleSubmit}>
         <label style={labelStyle}>
-          廠商名稱 *
+          廠商名稱{requiredMark}
           <input
             name="vendor_name"
             value={form.vendor_name}
@@ -135,10 +195,11 @@ function ApplicationForm({ onSubmitted }) {
             placeholder="例：晴天廚房"
             style={fieldStyle}
           />
+          {fieldErrors.vendor_name && <span style={errorStyle}>{fieldErrors.vendor_name}</span>}
         </label>
 
         <label style={labelStyle}>
-          地址
+          地址{requiredMark}
           <input
             name="address"
             value={form.address}
@@ -146,10 +207,11 @@ function ApplicationForm({ onSubmitted }) {
             placeholder="例：台北市信義區..."
             style={fieldStyle}
           />
+          {fieldErrors.address && <span style={errorStyle}>{fieldErrors.address}</span>}
         </label>
 
         <label style={labelStyle}>
-          營業時間
+          營業時間{requiredMark}
           <input
             name="business_hours"
             value={form.business_hours}
@@ -157,10 +219,11 @@ function ApplicationForm({ onSubmitted }) {
             placeholder="例：11:00 – 14:00"
             style={fieldStyle}
           />
+          {fieldErrors.business_hours && <span style={errorStyle}>{fieldErrors.business_hours}</span>}
         </label>
 
         <label style={labelStyle}>
-          聯絡電話
+          聯絡電話{requiredMark}
           <input
             name="contact_phone"
             value={form.contact_phone}
@@ -168,10 +231,11 @@ function ApplicationForm({ onSubmitted }) {
             placeholder="例：02-1234-5678"
             style={fieldStyle}
           />
+          {fieldErrors.contact_phone && <span style={errorStyle}>{fieldErrors.contact_phone}</span>}
         </label>
 
         <label style={labelStyle}>
-          聯絡 Email
+          聯絡 Email{requiredMark}
           <input
             name="contact_email"
             type="email"
@@ -180,7 +244,45 @@ function ApplicationForm({ onSubmitted }) {
             placeholder="例：vendor@example.com"
             style={fieldStyle}
           />
+          {fieldErrors.contact_email && <span style={errorStyle}>{fieldErrors.contact_email}</span>}
         </label>
+
+        <fieldset
+          style={{
+            border: "1px solid var(--line)",
+            borderRadius: "var(--radius-md)",
+            padding: 14,
+            margin: "0 0 16px",
+          }}
+        >
+          <legend style={{ fontSize: 13, fontWeight: 600, color: "var(--muted)" }}>
+            服務廠區{requiredMark}
+          </legend>
+          {facilityLoading && <p className="panel-copy">載入廠區中...</p>}
+          {!facilityLoading && facilities.length === 0 && (
+            <p className="panel-copy">目前沒有可選廠區</p>
+          )}
+          {!facilityLoading && facilities.map((facility) => (
+            <label
+              key={facility.id}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                marginTop: 10,
+                fontSize: 14,
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={form.facility_ids.includes(facility.id)}
+                onChange={() => handleFacilityToggle(facility.id)}
+              />
+              <span>{facility.code ? `${facility.code} · ${facility.name}` : facility.name}</span>
+            </label>
+          ))}
+          {fieldErrors.facility_ids && <span style={errorStyle}>{fieldErrors.facility_ids}</span>}
+        </fieldset>
 
         {error && (
           <p style={{ color: "var(--brand)", fontSize: 13, marginBottom: 12 }}>{error}</p>
@@ -188,7 +290,7 @@ function ApplicationForm({ onSubmitted }) {
 
         <button
           type="submit"
-          disabled={submitting}
+          disabled={submitting || facilityLoading}
           style={{
             padding: "10px 24px",
             borderRadius: "var(--radius-md)",
@@ -197,8 +299,8 @@ function ApplicationForm({ onSubmitted }) {
             color: "#fff",
             fontWeight: 600,
             fontSize: 14,
-            cursor: submitting ? "not-allowed" : "pointer",
-            opacity: submitting ? 0.7 : 1,
+            cursor: submitting || facilityLoading ? "not-allowed" : "pointer",
+            opacity: submitting || facilityLoading ? 0.7 : 1,
           }}
         >
           {submitting ? "送出中..." : "送出申請"}


### PR DESCRIPTION
## Summary
- Add facility multi-select to the vendor application form.
- Validate required vendor application fields and selected facilities on the server.
- Persist selected facilities through vendor_facilities and show them in vendor/admin review views.

## Tests
- npm run build
- python -m pytest backend/tests --ignore=backend/tests/integration -q -p no:cacheprovider --basetemp .tmp/pytest-run2

Closes #140
