### PR TITLE
feat(admin): show badge codes in user list

### DIFF
--- a/backend/routes/admin_users.py
+++ b/backend/routes/admin_users.py
@@ -16,9 +16,9 @@ def _fetch_users(search: str | None, role: str | None) -> list[dict]:
     params: list = []
 
     if search:
-        conditions.append("(u.email ILIKE %s OR u.display_name ILIKE %s)")
+        conditions.append("(u.email ILIKE %s OR u.display_name ILIKE %s OR u.badge_code ILIKE %s)")
         pattern = f"%{search}%"
-        params.extend([pattern, pattern])
+        params.extend([pattern, pattern, pattern])
 
     if role:
         conditions.append("r.name = %s")
@@ -26,7 +26,7 @@ def _fetch_users(search: str | None, role: str | None) -> list[dict]:
 
     where = " AND ".join(conditions)
     sql = f"""
-        SELECT u.id, u.email, u.display_name, r.name AS role, u.is_active, u.created_at
+        SELECT u.id, u.email, u.display_name, r.name AS role, u.badge_code, u.is_active, u.created_at
         FROM users u
         JOIN roles r ON r.id = u.role_id
         WHERE {where}

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -8,6 +8,7 @@ class AdminUserItem(BaseModel):
     email: str
     display_name: str
     role: str
+    badge_code: str | None = None
     is_active: bool
     created_at: datetime
 

--- a/backend/tests/test_admin_users.py
+++ b/backend/tests/test_admin_users.py
@@ -23,6 +23,7 @@ def _make_user_row(
     email: str = "employee@example.com",
     display_name: str = "Test User",
     role: str = "employee",
+    badge_code: str | None = "EMP-0001",
     is_active: bool = True,
 ) -> dict:
     return {
@@ -30,6 +31,7 @@ def _make_user_row(
         "email": email,
         "display_name": display_name,
         "role": role,
+        "badge_code": badge_code,
         "is_active": is_active,
         "created_at": _NOW,
     }
@@ -92,6 +94,7 @@ def test_list_users_returns_200_with_user_list() -> None:
     assert body["total"] == 1
     assert body["users"][0]["email"] == "employee@example.com"
     assert body["users"][0]["role"] == "employee"
+    assert body["users"][0]["badge_code"] == "EMP-0001"
     assert body["users"][0]["is_active"] is True
 
 
@@ -109,6 +112,9 @@ def test_list_users_search_param_is_forwarded() -> None:
         resp = client.get("/admin/users?search=employee", headers=_ADMIN_HEADERS)
 
     assert resp.status_code == 200
+    execute_call = mock_conn.return_value.__enter__.return_value.execute.call_args
+    assert "u.badge_code ILIKE %s" in execute_call.args[0]
+    assert execute_call.args[1] == ["%employee%", "%employee%", "%employee%"]
 
 
 def test_list_users_role_filter_param_is_forwarded() -> None:

--- a/frontend/src/pages/admin/AdminPermissionsPage.jsx
+++ b/frontend/src/pages/admin/AdminPermissionsPage.jsx
@@ -10,6 +10,7 @@ const ROLE_LABELS = {
   vendor_manager: "Vendor Manager",
   committee_reviewer: "Committee Reviewer",
 };
+const USER_GRID_COLUMNS = "minmax(180px, 1fr) 120px 120px 110px 90px 120px 160px";
 
 function useUsers(search, role) {
   const [users, setUsers] = useState([]);
@@ -162,11 +163,12 @@ export default function AdminPermissionsPage() {
       )}
 
       {!loading && !error && users.length > 0 && (
-        <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
+        <div className="panel" style={{ padding: 0, overflowX: "auto" }}>
           <div
             style={{
               display: "grid",
-              gridTemplateColumns: "1fr 120px 120px 90px 120px 160px",
+              gridTemplateColumns: USER_GRID_COLUMNS,
+              minWidth: 900,
               padding: "10px 20px",
               borderBottom: "1px solid var(--line)",
               color: "var(--muted)",
@@ -180,6 +182,7 @@ export default function AdminPermissionsPage() {
             <span style={{ textAlign: "center" }}>角色</span>
             <span style={{ textAlign: "center" }}>狀態</span>
             <span style={{ textAlign: "center" }}>建立日期</span>
+            <span style={{ textAlign: "center" }}>Badge</span>
             <span></span>
             <span style={{ textAlign: "right" }}>操作</span>
           </div>
@@ -189,7 +192,8 @@ export default function AdminPermissionsPage() {
               key={u.id}
               style={{
                 display: "grid",
-                gridTemplateColumns: "1fr 120px 120px 90px 120px 160px",
+                gridTemplateColumns: USER_GRID_COLUMNS,
+                minWidth: 900,
                 alignItems: "center",
                 padding: "14px 20px",
                 borderBottom: idx < users.length - 1 ? "1px solid var(--line)" : "none",
@@ -205,6 +209,9 @@ export default function AdminPermissionsPage() {
                 <StatusBadge isActive={u.is_active} />
               </div>
               <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>{formatDate(u.created_at)}</p>
+              <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
+                {u.badge_code || "-"}
+              </p>
               <div />
               <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
                 {!isSelf(u.id) && u.is_active && (


### PR DESCRIPTION
## Summary
- Add `badge_code` to the `/admin/users` response.
- Allow admin user search to match employee badge codes.
- Show a Badge column in the admin permissions user list.
- Keep the user table readable on narrow screens with horizontal overflow.

## Tests
- `python -m pytest backend/tests/test_admin_users.py -q -p no:cacheprovider`
- `python -m pytest backend/tests/test_admin_users.py --cov=backend.routes.admin_users --cov=backend.schemas.admin --cov-report=term-missing -q -p no:cacheprovider`
- `python -m pytest backend/tests --ignore=backend/tests/integration -q -p no:cacheprovider --basetemp .tmp/pytest-issue-130`
- `python -m compileall -q backend`
- `npm run build`

Partially addresses #130
