### PR TITLE
feat(vendor): revenue dashboard — today stock + period sales (closes #139)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -27,6 +27,7 @@ from backend.routes import (
     vendor_menu,
     vendor_orders,
     vendor_profile,
+    vendor_revenue,
 )
 
 
@@ -71,6 +72,7 @@ def create_app() -> FastAPI:
     app.include_router(vendor_categories.router)
     app.include_router(vendor_menu.router)
     app.include_router(vendor_orders.router)
+    app.include_router(vendor_revenue.router)
     app.include_router(employee_ordering.router)
     app.include_router(notifications.router)
     app.include_router(audit_logs.router)

--- a/backend/repositories/postgres_reporting_repository.py
+++ b/backend/repositories/postgres_reporting_repository.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 from datetime import date
 
 from backend.db.connection import get_connection
-from backend.schemas.admin_stats import DayPoint, FacilityStat, ItemSales, OrderSummary, VendorStat
+from backend.schemas.admin_stats import (
+    DayPoint,
+    FacilityStat,
+    ItemSales,
+    OrderSummary,
+    VendorItemPeriodAggregate,
+    VendorItemTodayAggregate,
+    VendorRevenueWindowSummary,
+    VendorStat,
+)
 from backend.schemas.billing import EmployeeTotal, VendorReceivable
 
 _WINDOW = "o.status <> 'cancelled' AND o.created_at::date BETWEEN %s AND %s"
@@ -163,6 +172,120 @@ class PostgresReportingRepository:
                       quantity_sold=int(r["quantity_sold"]))
             for r in rows
         ]
+
+    def vendor_today_item_stats(
+        self,
+        vendor_id: int,
+        day: date,
+        *,
+        facility_id: int | None = None,
+    ) -> list[VendorItemTodayAggregate]:
+        where = [
+            "o.status <> 'cancelled'",
+            "o.vendor_id = %s",
+            "COALESCE(o.meal_date, o.created_at::date) = %s",
+        ]
+        values: list[object] = [vendor_id, day]
+        if facility_id is not None:
+            where.append("o.facility_id = %s")
+            values.append(facility_id)
+        with get_connection() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT oi.item_id,
+                       COALESCE(SUM(oi.quantity), 0) AS sold_quantity,
+                       COALESCE(SUM(oi.total_price_cents), 0) AS revenue_cents
+                FROM orders o
+                JOIN order_items oi ON oi.order_id = o.id
+                WHERE {" AND ".join(where)}
+                GROUP BY oi.item_id
+                """,
+                values,
+            ).fetchall()
+        return [
+            VendorItemTodayAggregate(
+                item_id=int(r["item_id"]),
+                sold_quantity=int(r["sold_quantity"]),
+                revenue_cents=int(r["revenue_cents"]),
+            )
+            for r in rows
+        ]
+
+    def vendor_period_item_sales(
+        self,
+        vendor_id: int,
+        start: date,
+        end: date,
+        *,
+        facility_id: int | None = None,
+    ) -> list[VendorItemPeriodAggregate]:
+        where = [
+            "o.status <> 'cancelled'",
+            "o.vendor_id = %s",
+            "COALESCE(o.meal_date, o.created_at::date) BETWEEN %s AND %s",
+        ]
+        values: list[object] = [vendor_id, start, end]
+        if facility_id is not None:
+            where.append("o.facility_id = %s")
+            values.append(facility_id)
+        with get_connection() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT oi.item_id,
+                       COALESCE(SUM(oi.quantity), 0) AS quantity_sold,
+                       COALESCE(SUM(oi.total_price_cents), 0) AS revenue_cents,
+                       COUNT(DISTINCT o.id) AS order_count
+                FROM orders o
+                JOIN order_items oi ON oi.order_id = o.id
+                WHERE {" AND ".join(where)}
+                GROUP BY oi.item_id
+                """,
+                values,
+            ).fetchall()
+        return [
+            VendorItemPeriodAggregate(
+                item_id=int(r["item_id"]),
+                quantity_sold=int(r["quantity_sold"]),
+                revenue_cents=int(r["revenue_cents"]),
+                order_count=int(r["order_count"]),
+            )
+            for r in rows
+        ]
+
+    def vendor_period_summary(
+        self,
+        vendor_id: int,
+        start: date,
+        end: date,
+        *,
+        facility_id: int | None = None,
+    ) -> VendorRevenueWindowSummary:
+        where = [
+            "o.status <> 'cancelled'",
+            "o.vendor_id = %s",
+            "COALESCE(o.meal_date, o.created_at::date) BETWEEN %s AND %s",
+        ]
+        values: list[object] = [vendor_id, start, end]
+        if facility_id is not None:
+            where.append("o.facility_id = %s")
+            values.append(facility_id)
+        with get_connection() as conn:
+            row = conn.execute(
+                f"""
+                SELECT COUNT(DISTINCT o.id) AS order_count,
+                       COALESCE(SUM(oi.quantity), 0) AS quantity_sold,
+                       COALESCE(SUM(oi.total_price_cents), 0) AS revenue_cents
+                FROM orders o
+                JOIN order_items oi ON oi.order_id = o.id
+                WHERE {" AND ".join(where)}
+                """,
+                values,
+            ).fetchone()
+        return VendorRevenueWindowSummary(
+            order_count=int(row["order_count"]),
+            quantity_sold=int(row["quantity_sold"]),
+            revenue_cents=int(row["revenue_cents"]),
+        )
 
     def employee_monthly_totals(self, year: int, month: int) -> list[EmployeeTotal]:
         with get_connection() as conn:

--- a/backend/repositories/reporting_repository.py
+++ b/backend/repositories/reporting_repository.py
@@ -9,7 +9,16 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date, datetime
 
-from backend.schemas.admin_stats import DayPoint, FacilityStat, ItemSales, OrderSummary, VendorStat
+from backend.schemas.admin_stats import (
+    DayPoint,
+    FacilityStat,
+    ItemSales,
+    OrderSummary,
+    VendorItemPeriodAggregate,
+    VendorItemTodayAggregate,
+    VendorRevenueWindowSummary,
+    VendorStat,
+)
 from backend.schemas.billing import EmployeeTotal, VendorReceivable
 
 
@@ -190,6 +199,92 @@ class ReportingRepository:
         ]
         rows.sort(key=lambda r: r.quantity_sold, reverse=True)
         return rows[:limit]
+
+    @staticmethod
+    def _row_business_day(row: _OrderRow) -> date:
+        return row.meal_date or row.created_at.date()
+
+    def _vendor_rows_in_window(
+        self,
+        vendor_id: int,
+        start: date,
+        end: date,
+        facility_id: int | None,
+    ) -> list[_OrderRow]:
+        rows: list[_OrderRow] = []
+        for r in self._orders:
+            if r.status == "cancelled" or r.vendor_id != vendor_id:
+                continue
+            if facility_id is not None and r.facility_id != facility_id:
+                continue
+            if start <= self._row_business_day(r) <= end:
+                rows.append(r)
+        return rows
+
+    def vendor_today_item_stats(
+        self,
+        vendor_id: int,
+        day: date,
+        *,
+        facility_id: int | None = None,
+    ) -> list[VendorItemTodayAggregate]:
+        acc: dict[int, dict[str, int]] = {}
+        for r in self._vendor_rows_in_window(vendor_id, day, day, facility_id):
+            for item_id, qty, unit_price in r.items:
+                a = acc.setdefault(item_id, {"sold_quantity": 0, "revenue_cents": 0})
+                a["sold_quantity"] += qty
+                a["revenue_cents"] += qty * unit_price
+        return [
+            VendorItemTodayAggregate(
+                item_id=item_id,
+                sold_quantity=a["sold_quantity"],
+                revenue_cents=a["revenue_cents"],
+            )
+            for item_id, a in acc.items()
+        ]
+
+    def vendor_period_item_sales(
+        self,
+        vendor_id: int,
+        start: date,
+        end: date,
+        *,
+        facility_id: int | None = None,
+    ) -> list[VendorItemPeriodAggregate]:
+        acc: dict[int, dict] = {}
+        for r in self._vendor_rows_in_window(vendor_id, start, end, facility_id):
+            for item_id, qty, unit_price in r.items:
+                a = acc.setdefault(
+                    item_id,
+                    {"quantity_sold": 0, "revenue_cents": 0, "order_ids": set()},
+                )
+                a["quantity_sold"] += qty
+                a["revenue_cents"] += qty * unit_price
+                a["order_ids"].add(r.order_id)
+        return [
+            VendorItemPeriodAggregate(
+                item_id=item_id,
+                quantity_sold=a["quantity_sold"],
+                revenue_cents=a["revenue_cents"],
+                order_count=len(a["order_ids"]),
+            )
+            for item_id, a in acc.items()
+        ]
+
+    def vendor_period_summary(
+        self,
+        vendor_id: int,
+        start: date,
+        end: date,
+        *,
+        facility_id: int | None = None,
+    ) -> VendorRevenueWindowSummary:
+        rows = self._vendor_rows_in_window(vendor_id, start, end, facility_id)
+        return VendorRevenueWindowSummary(
+            order_count=len(rows),
+            quantity_sold=sum(self._row_quantity(r) for r in rows),
+            revenue_cents=sum(self._row_revenue(r) for r in rows),
+        )
 
     def employee_monthly_totals(self, year: int, month: int) -> list[EmployeeTotal]:
         acc: dict[int, dict] = {}

--- a/backend/routes/vendor_revenue.py
+++ b/backend/routes/vendor_revenue.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+
+from backend.core.reporting import get_reporting_repository
+from backend.core.vendor_identity import get_vendor_profile_repository, require_approved_vendor
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository
+from backend.routes.vendor_menu import get_menu_item_repository
+from backend.schemas.vendor_revenue import VendorRevenueDashboard
+from backend.services.vendor_revenue_service import VendorRevenueService
+
+router = APIRouter(prefix="/vendor/me/revenue", tags=["vendor-self"])
+
+
+def get_vendor_revenue_service(
+    item_repo: Annotated[MenuItemRepository, Depends(get_menu_item_repository)],
+    reporting_repo: Annotated[object, Depends(get_reporting_repository)],
+    vendor_repo: Annotated[VendorProfileRepository, Depends(get_vendor_profile_repository)],
+) -> VendorRevenueService:
+    return VendorRevenueService(item_repo, reporting_repo, vendor_repo)
+
+
+@router.get("")
+def get_vendor_revenue(
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorRevenueService, Depends(get_vendor_revenue_service)],
+    today: Annotated[date | None, Query()] = None,
+    start: Annotated[date | None, Query()] = None,
+    end: Annotated[date | None, Query()] = None,
+    facility_id: Annotated[int | None, Query()] = None,
+) -> VendorRevenueDashboard:
+    report_today = today or date.today()
+    report_end = end or report_today
+    report_start = start or (report_end - timedelta(days=29))
+    return service.dashboard(
+        vendor_id,
+        today=report_today,
+        start=report_start,
+        end=report_end,
+        facility_id=facility_id,
+    )

--- a/backend/schemas/admin_stats.py
+++ b/backend/schemas/admin_stats.py
@@ -46,3 +46,22 @@ class DashboardStats(BaseModel):
     vendor_ranking: list[VendorStat]
     facility_distribution: list[FacilityStat]
     daily_trend: list[DayPoint]
+
+
+class VendorItemTodayAggregate(BaseModel):
+    item_id: int
+    sold_quantity: int
+    revenue_cents: int
+
+
+class VendorItemPeriodAggregate(BaseModel):
+    item_id: int
+    quantity_sold: int
+    revenue_cents: int
+    order_count: int
+
+
+class VendorRevenueWindowSummary(BaseModel):
+    order_count: int
+    quantity_sold: int
+    revenue_cents: int

--- a/backend/schemas/vendor_revenue.py
+++ b/backend/schemas/vendor_revenue.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class VendorTodayItemStat(BaseModel):
+    item_id: int
+    item_name: str
+    daily_quota: int | None = None
+    sold_quantity: int
+    remaining_quantity: int | None = None
+    revenue_cents: int
+    available: bool
+
+
+class VendorItemSales(BaseModel):
+    item_id: int
+    item_name: str
+    quantity_sold: int
+    revenue_cents: int
+    order_count: int
+
+
+class VendorRevenueSummary(BaseModel):
+    order_count: int
+    quantity_sold: int
+    revenue_cents: int
+
+
+class VendorRevenueDashboard(BaseModel):
+    today: date
+    start: date
+    end: date
+    summary: VendorRevenueSummary
+    today_items: list[VendorTodayItemStat]
+    period_items: list[VendorItemSales]

--- a/backend/services/vendor_revenue_service.py
+++ b/backend/services/vendor_revenue_service.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import date
+
+from backend.core.errors import CodedHTTPException
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository
+from backend.schemas.vendor_revenue import (
+    VendorItemSales,
+    VendorRevenueDashboard,
+    VendorRevenueSummary,
+    VendorTodayItemStat,
+)
+
+
+class VendorRevenueService:
+    def __init__(
+        self,
+        menu_item_repository: MenuItemRepository,
+        reporting_repository,
+        vendor_repository: VendorProfileRepository,
+    ) -> None:
+        self._items = menu_item_repository
+        self._reporting = reporting_repository
+        self._vendors = vendor_repository
+
+    def dashboard(
+        self,
+        vendor_id: int,
+        *,
+        today: date,
+        start: date,
+        end: date,
+        facility_id: int | None = None,
+    ) -> VendorRevenueDashboard:
+        if start > end:
+            raise CodedHTTPException(
+                status_code=400,
+                code="validation_error",
+                detail="start must be on or before end",
+            )
+        self._assert_facility_access(vendor_id, facility_id)
+
+        menu_items = self._items.list(vendor_id=vendor_id)
+        today_stats = self._reporting.vendor_today_item_stats(
+            vendor_id, today, facility_id=facility_id
+        )
+        period_sales = self._reporting.vendor_period_item_sales(
+            vendor_id, start, end, facility_id=facility_id
+        )
+        summary = self._reporting.vendor_period_summary(
+            vendor_id, start, end, facility_id=facility_id
+        )
+
+        return VendorRevenueDashboard(
+            today=today,
+            start=start,
+            end=end,
+            summary=VendorRevenueSummary(
+                order_count=summary.order_count,
+                quantity_sold=summary.quantity_sold,
+                revenue_cents=summary.revenue_cents,
+            ),
+            today_items=self._today_items(menu_items, today_stats),
+            period_items=self._period_items(menu_items, period_sales),
+        )
+
+    def _assert_facility_access(self, vendor_id: int, facility_id: int | None) -> None:
+        if facility_id is None:
+            return
+        if not any(facility.id == facility_id for facility in self._vendors.list_facilities(vendor_id)):
+            raise CodedHTTPException(
+                status_code=403,
+                code="forbidden",
+                detail="vendor does not serve the selected facility",
+            )
+
+    @staticmethod
+    def _today_items(menu_items, today_stats) -> list[VendorTodayItemStat]:
+        sold_by_item = {stat.item_id: stat for stat in today_stats}
+        rows: list[VendorTodayItemStat] = []
+        for item in menu_items:
+            stat = sold_by_item.get(item.id)
+            sold_quantity = stat.sold_quantity if stat else 0
+            revenue_cents = stat.revenue_cents if stat else 0
+            remaining = None
+            if item.daily_quota is not None:
+                remaining = max(item.daily_quota - sold_quantity, 0)
+            rows.append(
+                VendorTodayItemStat(
+                    item_id=item.id,
+                    item_name=item.name,
+                    daily_quota=item.daily_quota,
+                    sold_quantity=sold_quantity,
+                    remaining_quantity=remaining,
+                    revenue_cents=revenue_cents,
+                    available=item.available,
+                )
+            )
+        return rows
+
+    @staticmethod
+    def _period_items(menu_items, period_sales) -> list[VendorItemSales]:
+        menu_names = {item.id: item.name for item in menu_items}
+        rows = [
+            VendorItemSales(
+                item_id=sale.item_id,
+                item_name=menu_names.get(sale.item_id, f"Item #{sale.item_id}"),
+                quantity_sold=sale.quantity_sold,
+                revenue_cents=sale.revenue_cents,
+                order_count=sale.order_count,
+            )
+            for sale in period_sales
+        ]
+        rows.sort(key=lambda row: (-row.quantity_sold, row.item_name))
+        return rows

--- a/backend/tests/test_vendor_revenue.py
+++ b/backend/tests/test_vendor_revenue.py
@@ -1,0 +1,109 @@
+"""Unit tests for GET /vendor/me/revenue."""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.core.reporting import get_reporting_repository
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.reporting_repository import ReportingRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.routes.vendor_menu import get_menu_item_repository
+
+
+@pytest.fixture()
+def client():
+    vendor_repo = VendorProfileRepository()
+    vendor_repo.seed(VendorRecord(id=1, name="Noodle House", status="approved"))
+    vendor_repo.assign_facility(1, facility_id=10, code="F10", name="Fab 10")
+
+    item_repo = MenuItemRepository()
+    rice = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=5)
+    soup = item_repo.create(vendor_id=1, name="Soup", price_cents=90, daily_quota=None)
+
+    today = date(2026, 5, 30)
+    yesterday = date(2026, 5, 29)
+    today_ts = datetime(2026, 5, 30, 12, 0, tzinfo=timezone.utc)
+    yesterday_ts = datetime(2026, 5, 29, 12, 0, tzinfo=timezone.utc)
+
+    reporting_repo = ReportingRepository()
+    reporting_repo.seed_order(
+        order_id=1, vendor_id=1, vendor_name="Noodle House",
+        facility_id=10, facility_name="Fab 10", status="pending",
+        created_at=today_ts, meal_date=today,
+        items=[(rice.id, 2, rice.price_cents), (soup.id, 1, soup.price_cents)],
+    )
+    reporting_repo.seed_order(
+        order_id=2, vendor_id=1, vendor_name="Noodle House",
+        facility_id=10, facility_name="Fab 10", status="pending",
+        created_at=yesterday_ts, meal_date=yesterday,
+        items=[(rice.id, 1, rice.price_cents)],
+    )
+    reporting_repo.seed_order(
+        order_id=3, vendor_id=1, vendor_name="Noodle House",
+        facility_id=10, facility_name="Fab 10", status="cancelled",
+        created_at=today_ts, meal_date=today,
+        items=[(rice.id, 3, rice.price_cents)],
+    )
+
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
+    app.dependency_overrides[get_menu_item_repository] = lambda: item_repo
+    app.dependency_overrides[get_reporting_repository] = lambda: reporting_repo
+    yield TestClient(app)
+    app.dependency_overrides.pop(get_vendor_profile_repository, None)
+    app.dependency_overrides.pop(get_menu_item_repository, None)
+    app.dependency_overrides.pop(get_reporting_repository, None)
+
+
+_VENDOR_HEADERS = {"x-user-role": "vendor_manager", "x-vendor-id": "1"}
+
+
+def test_vendor_revenue_dashboard_counts_today_stock_and_period_sales(client) -> None:
+    resp = client.get(
+        "/vendor/me/revenue?today=2026-05-30&start=2026-05-29&end=2026-05-30&facility_id=10",
+        headers=_VENDOR_HEADERS,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["summary"] == {
+        "order_count": 2,
+        "quantity_sold": 4,
+        "revenue_cents": 450,
+    }
+
+    today_by_name = {item["item_name"]: item for item in body["today_items"]}
+    assert today_by_name["Rice Bowl"]["sold_quantity"] == 2
+    assert today_by_name["Rice Bowl"]["remaining_quantity"] == 3
+    assert today_by_name["Rice Bowl"]["revenue_cents"] == 240
+    assert today_by_name["Soup"]["sold_quantity"] == 1
+    assert today_by_name["Soup"]["remaining_quantity"] is None
+
+    period_by_name = {item["item_name"]: item for item in body["period_items"]}
+    assert period_by_name["Rice Bowl"]["quantity_sold"] == 3
+    assert period_by_name["Rice Bowl"]["order_count"] == 2
+    assert period_by_name["Soup"]["quantity_sold"] == 1
+
+
+def test_vendor_revenue_rejects_unknown_facility(client) -> None:
+    resp = client.get(
+        "/vendor/me/revenue?today=2026-05-30&facility_id=99",
+        headers=_VENDOR_HEADERS,
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "forbidden"
+
+
+def test_vendor_revenue_rejects_invalid_range(client) -> None:
+    resp = client.get(
+        "/vendor/me/revenue?start=2026-05-31&end=2026-05-30",
+        headers=_VENDOR_HEADERS,
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"

--- a/frontend/src/api/vendor.js
+++ b/frontend/src/api/vendor.js
@@ -25,6 +25,16 @@ export function getMyOrders({ facilityId } = {}) {
   return apiFetch(appendFacilityParam("/vendor/me/orders", facilityId));
 }
 
+export function getVendorRevenue({ facilityId, today, start, end } = {}) {
+  const params = new URLSearchParams();
+  if (facilityId != null && facilityId !== "") params.set("facility_id", String(facilityId));
+  if (today) params.set("today", today);
+  if (start) params.set("start", start);
+  if (end) params.set("end", end);
+  const qs = params.toString();
+  return apiFetch(`/vendor/me/revenue${qs ? `?${qs}` : ""}`);
+}
+
 export function getMyOrder(orderId) {
   return apiFetch(`/vendor/me/orders/${orderId}`);
 }

--- a/frontend/src/pages/vendor/VendorRevenuePage.jsx
+++ b/frontend/src/pages/vendor/VendorRevenuePage.jsx
@@ -1,20 +1,241 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { getVendorRevenue } from "../../api/vendor";
+import { useFacility } from "../../facility/FacilityContext";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
+import { formatMoney } from "../../utils/format";
+
+const RANGES = [
+  { days: 7, label: "Last 7 days" },
+  { days: 30, label: "Last 30 days" },
+];
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function isoDaysBefore(base, days) {
+  const d = new Date(base);
+  d.setDate(d.getDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+function presetRange(days) {
+  const end = todayIso();
+  const start = isoDaysBefore(end, days - 1);
+  return { start, end };
+}
+
+function quotaText(value) {
+  if (value == null) return "Unlimited";
+  return String(value);
+}
+
+function remainingText(value) {
+  if (value == null) return "Unlimited";
+  if (value === 0) return "Sold out";
+  return String(value);
+}
+
+function numberText(value) {
+  return new Intl.NumberFormat("en-US").format(value ?? 0);
+}
 
 export default function VendorRevenuePage() {
+  const { selectedFacilityId } = useFacility();
+  const initialRange = useMemo(() => presetRange(30), []);
+  const [startDate, setStartDate] = useState(initialRange.start);
+  const [endDate, setEndDate] = useState(initialRange.end);
+  const [dashboard, setDashboard] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const activePresetDays = useMemo(() => {
+    for (const range of RANGES) {
+      const candidate = presetRange(range.days);
+      if (candidate.start === startDate && candidate.end === endDate) {
+        return range.days;
+      }
+    }
+    return null;
+  }, [startDate, endDate]);
+
+  const rangeInvalid = startDate > endDate;
+
+  useEffect(() => {
+    if (rangeInvalid) {
+      setError("Start date must be on or before end date.");
+      setLoading(false);
+      setDashboard(null);
+      return undefined;
+    }
+    let active = true;
+    setLoading(true);
+    setError(null);
+    getVendorRevenue({
+      facilityId: selectedFacilityId,
+      today: todayIso(),
+      start: startDate,
+      end: endDate,
+    })
+      .then((data) => {
+        if (active) setDashboard(data);
+      })
+      .catch((err) => {
+        if (active) setError(err.message ?? "Unable to load revenue data");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [startDate, endDate, selectedFacilityId, rangeInvalid]);
+
+  const applyPreset = (days) => {
+    const range = presetRange(days);
+    setStartDate(range.start);
+    setEndDate(range.end);
+  };
+
   return (
     <div>
       <div className="page-header">
         <FacilityScopeLabel label="Revenue facility" />
-        <p className="eyebrow">商家 · 營收</p>
-        <h2>收益總覽</h2>
+        <p className="eyebrow">Vendor / Revenue</p>
+        <h2>Sales dashboard</h2>
       </div>
 
-      <section className="panel" style={{ padding: "32px 24px", textAlign: "center" }}>
-        <p style={{ fontSize: 18, fontWeight: 600, marginBottom: 8 }}>營收報表即將推出</p>
-        <p className="panel-copy">
-          本月度帳款由福委會統一結算。詳細帳款資料請聯繫系統管理員或等待後續功能上線。
-        </p>
-      </section>
+      <div className="range-pills" role="group" aria-label="Revenue range" style={{ marginBottom: 12 }}>
+        {RANGES.map((range) => (
+          <button
+            key={range.days}
+            type="button"
+            className={`range-pill${activePresetDays === range.days ? " is-active" : ""}`}
+            onClick={() => applyPreset(range.days)}
+            aria-pressed={activePresetDays === range.days}
+          >
+            {range.label}
+          </button>
+        ))}
+      </div>
+
+      <div
+        className="range-custom"
+        role="group"
+        aria-label="Custom date range"
+        style={{ display: "flex", gap: 12, alignItems: "flex-end", flexWrap: "wrap", marginBottom: 20 }}
+      >
+        <label style={{ display: "flex", flexDirection: "column", fontSize: 12 }}>
+          <span>Start</span>
+          <input
+            type="date"
+            value={startDate}
+            max={endDate}
+            onChange={(event) => setStartDate(event.target.value)}
+          />
+        </label>
+        <label style={{ display: "flex", flexDirection: "column", fontSize: 12 }}>
+          <span>End</span>
+          <input
+            type="date"
+            value={endDate}
+            min={startDate}
+            max={todayIso()}
+            onChange={(event) => setEndDate(event.target.value)}
+          />
+        </label>
+      </div>
+
+      {loading && <p className="loading-state">Loading revenue data...</p>}
+      {error && <p className="error-state">{error}</p>}
+
+      {dashboard && !loading && !error && (
+        <section className="dashboard-grid">
+          <article className="panel stat-cards">
+            <div className="stat-card">
+              <span>Orders</span>
+              <strong>{numberText(dashboard.summary.order_count)}</strong>
+            </div>
+            <div className="stat-card">
+              <span>Items sold</span>
+              <strong>{numberText(dashboard.summary.quantity_sold)}</strong>
+            </div>
+            <div className="stat-card">
+              <span>Revenue</span>
+              <strong>{formatMoney(dashboard.summary.revenue_cents)}</strong>
+            </div>
+          </article>
+
+          <article className="panel">
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "baseline" }}>
+              <h3>Today stock</h3>
+              <p className="panel-copy" style={{ margin: 0 }}>{dashboard.today}</p>
+            </div>
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Item</th>
+                  <th>Quota</th>
+                  <th>Sold</th>
+                  <th>Remaining</th>
+                  <th>Revenue</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dashboard.today_items.map((item) => (
+                  <tr key={item.item_id}>
+                    <td>{item.item_name}</td>
+                    <td>{quotaText(item.daily_quota)}</td>
+                    <td>{numberText(item.sold_quantity)}</td>
+                    <td>{remainingText(item.remaining_quantity)}</td>
+                    <td>{formatMoney(item.revenue_cents)}</td>
+                  </tr>
+                ))}
+                {dashboard.today_items.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="table-empty">No menu items yet.</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </article>
+
+          <article className="panel">
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "baseline" }}>
+              <h3>Dish sales</h3>
+              <p className="panel-copy" style={{ margin: 0 }}>
+                {dashboard.start} to {dashboard.end}
+              </p>
+            </div>
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Item</th>
+                  <th>Orders</th>
+                  <th>Sold</th>
+                  <th>Revenue</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dashboard.period_items.map((item) => (
+                  <tr key={item.item_id}>
+                    <td>{item.item_name}</td>
+                    <td>{numberText(item.order_count)}</td>
+                    <td>{numberText(item.quantity_sold)}</td>
+                    <td>{formatMoney(item.revenue_cents)}</td>
+                  </tr>
+                ))}
+                {dashboard.period_items.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="table-empty">No sales in this range.</td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </article>
+        </section>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/vendor/VendorRevenuePage.jsx
+++ b/frontend/src/pages/vendor/VendorRevenuePage.jsx
@@ -151,7 +151,7 @@ export default function VendorRevenuePage() {
       {error && <p className="error-state">{error}</p>}
 
       {dashboard && !loading && !error && (
-        <section className="dashboard-grid">
+        <section style={{ display: "grid", gap: 18 }}>
           <article className="panel stat-cards">
             <div className="stat-card">
               <span>Orders</span>
@@ -167,73 +167,103 @@ export default function VendorRevenuePage() {
             </div>
           </article>
 
-          <article className="panel">
-            <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "baseline" }}>
-              <h3>Today stock</h3>
-              <p className="panel-copy" style={{ margin: 0 }}>{dashboard.today}</p>
-            </div>
-            <table className="data-table">
-              <thead>
-                <tr>
-                  <th>Item</th>
-                  <th>Quota</th>
-                  <th>Sold</th>
-                  <th>Remaining</th>
-                  <th>Revenue</th>
-                </tr>
-              </thead>
-              <tbody>
-                {dashboard.today_items.map((item) => (
-                  <tr key={item.item_id}>
-                    <td>{item.item_name}</td>
-                    <td>{quotaText(item.daily_quota)}</td>
-                    <td>{numberText(item.sold_quantity)}</td>
-                    <td>{remainingText(item.remaining_quantity)}</td>
-                    <td>{formatMoney(item.revenue_cents)}</td>
-                  </tr>
-                ))}
-                {dashboard.today_items.length === 0 && (
-                  <tr>
-                    <td colSpan={5} className="table-empty">No menu items yet.</td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </article>
+          <div
+            style={{
+              display: "grid",
+              gap: 18,
+              gridTemplateColumns: "repeat(auto-fit, minmax(420px, 1fr))",
+            }}
+          >
+            <article className="panel">
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  gap: 16,
+                  alignItems: "baseline",
+                  flexWrap: "wrap",
+                  marginBottom: 12,
+                }}
+              >
+                <h3 style={{ margin: 0 }}>Today stock</h3>
+                <p className="panel-copy" style={{ margin: 0 }}>{dashboard.today}</p>
+              </div>
+              <div style={{ overflowX: "auto" }}>
+                <table className="data-table">
+                  <thead>
+                    <tr>
+                      <th>Item</th>
+                      <th>Quota</th>
+                      <th>Sold</th>
+                      <th>Remaining</th>
+                      <th>Revenue</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dashboard.today_items.map((item) => (
+                      <tr key={item.item_id}>
+                        <td>{item.item_name}</td>
+                        <td>{quotaText(item.daily_quota)}</td>
+                        <td>{numberText(item.sold_quantity)}</td>
+                        <td>{remainingText(item.remaining_quantity)}</td>
+                        <td>{formatMoney(item.revenue_cents)}</td>
+                      </tr>
+                    ))}
+                    {dashboard.today_items.length === 0 && (
+                      <tr>
+                        <td colSpan={5} className="table-empty">No menu items yet.</td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </article>
 
-          <article className="panel">
-            <div style={{ display: "flex", justifyContent: "space-between", gap: 16, alignItems: "baseline" }}>
-              <h3>Dish sales</h3>
-              <p className="panel-copy" style={{ margin: 0 }}>
-                {dashboard.start} to {dashboard.end}
-              </p>
-            </div>
-            <table className="data-table">
-              <thead>
-                <tr>
-                  <th>Item</th>
-                  <th>Orders</th>
-                  <th>Sold</th>
-                  <th>Revenue</th>
-                </tr>
-              </thead>
-              <tbody>
-                {dashboard.period_items.map((item) => (
-                  <tr key={item.item_id}>
-                    <td>{item.item_name}</td>
-                    <td>{numberText(item.order_count)}</td>
-                    <td>{numberText(item.quantity_sold)}</td>
-                    <td>{formatMoney(item.revenue_cents)}</td>
-                  </tr>
-                ))}
-                {dashboard.period_items.length === 0 && (
-                  <tr>
-                    <td colSpan={4} className="table-empty">No sales in this range.</td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </article>
+            <article className="panel">
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  gap: 16,
+                  alignItems: "baseline",
+                  flexWrap: "wrap",
+                  marginBottom: 12,
+                }}
+              >
+                <h3 style={{ margin: 0 }}>Dish sales</h3>
+                <p className="panel-copy" style={{ margin: 0 }}>
+                  {dashboard.start} to {dashboard.end}
+                </p>
+              </div>
+              <div style={{ overflowX: "auto" }}>
+                <table className="data-table">
+                  <thead>
+                    <tr>
+                      <th>Item</th>
+                      <th>Orders</th>
+                      <th>Sold</th>
+                      <th>Revenue</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dashboard.period_items.map((item) => (
+                      <tr key={item.item_id}>
+                        <td>{item.item_name}</td>
+                        <td>{numberText(item.order_count)}</td>
+                        <td>{numberText(item.quantity_sold)}</td>
+                        <td>{formatMoney(item.revenue_cents)}</td>
+                      </tr>
+                    ))}
+                    {dashboard.period_items.length === 0 && (
+                      <tr>
+                        <td colSpan={4} className="table-empty">No sales in this range.</td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </article>
+          </div>
         </section>
       )}
     </div>


### PR DESCRIPTION
Closes #139

## Summary
- New `GET /vendor/me/revenue` endpoint returning today-stock per item (quota / sold / remaining) and per-item sales counts for a chosen window.
- Vendor revenue page on the frontend with preset (近 7 / 30 天) + custom start/end date pickers, and tables for today stock + dish sales.
- Aggregations go through `ReportingRepository` (in-memory + Postgres), reusing the shared reporting layer that already backs admin stats and recommendations.

## Implementation notes
- Added three vendor-scoped methods to `ReportingRepository` / `PostgresReportingRepository`:
  - `vendor_today_item_stats(vendor_id, day, *, facility_id=None)`
  - `vendor_period_item_sales(vendor_id, start, end, *, facility_id=None)`
  - `vendor_period_summary(vendor_id, start, end, *, facility_id=None)`
- Business day uses `COALESCE(meal_date, created_at::date)` so the dashboard reflects the day the meal is for (matches employee-facing semantics). Admin stats keep their existing `created_at::date` windowing — both are intentional.
- "Sold today / period" excludes cancelled orders (treats anything non-cancelled as ordered). See trade-off below.
- Facility scope: when a vendor selects a facility, both the access check (`vendor_repository.list_facilities`) and the SQL filter (`o.facility_id = …`) apply; cross-facility leakage is rejected with 403.

## Trade-offs / decisions
- **ordered vs delivered.** Issue mentions "ordered/delivered". I went with non-cancelled = ordered, because vendors need to see committed demand before pickup (to decide whether to prep more). Billing keeps using delivered-only. If reviewers want today-stock to count delivered only, the change is a one-line filter swap on the new ReportingRepository methods.
- **Aggregate schemas in `admin_stats.py`.** Followed the existing convention that reporting DTOs live there. New types are `VendorItem*Aggregate` to distinguish from user-facing `VendorItemSales` / `VendorTodayItemStat` in `vendor_revenue.py`.
- **Postgres integration test not added in this PR.** The in-memory ReportingRepository is fully covered by `test_vendor_revenue.py`; the SQL follows the same patterns as the existing `top_items` / `vendor_monthly_receivables` queries (which do have `_db.py` coverage). Happy to add one if reviewers want it.

## Test plan
- [x] `pytest backend/tests --ignore=backend/tests/integration` — 303 passed
- [x] New tests in `test_vendor_revenue.py` cover today stock, period sales, facility-access denial (403), inverted-range rejection (400)
- [ ] Manual: log in as approved vendor, switch facility, switch 7/30-day presets and custom date range, verify today stock + dish sales tables
- [ ] Manual: confirm cancelled orders do not appear in either today or period tables
