### PR TITLE
feat(employee): route random meal + recommendations through the cart (#134)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "node --test src/api/facilityParams.test.js src/facility/facilitySelection.test.js src/utils/date.test.js src/cart/cartItems.test.js",
+    "test": "node --test src/api/facilityParams.test.js src/facility/facilitySelection.test.js src/utils/date.test.js src/cart/cartItems.test.js src/cart/quantity.test.js",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0 --port 4173"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "node --test src/api/facilityParams.test.js src/facility/facilitySelection.test.js",
+    "test": "node --test src/api/facilityParams.test.js src/facility/facilitySelection.test.js src/utils/date.test.js src/cart/cartItems.test.js",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0 --port 4173"
   },

--- a/frontend/src/cart/CartContext.jsx
+++ b/frontend/src/cart/CartContext.jsx
@@ -1,20 +1,14 @@
 import { createContext, useContext, useState } from "react";
 
+import { addCartItem } from "./cartItems";
+
 const CartContext = createContext(null);
 
 export function CartProvider({ children }) {
   const [items, setItems] = useState([]);
 
-  function addItem(item, vendorId, quantity = 1) {
-    setItems((prev) => {
-      const existing = prev.find((i) => i.item.id === item.id);
-      if (existing) {
-        return prev.map((i) =>
-          i.item.id === item.id ? { ...i, quantity: i.quantity + quantity } : i
-        );
-      }
-      return [...prev, { item, vendorId, quantity }];
-    });
+  function addItem(item, vendorId, quantity = 1, mealDate = null) {
+    setItems((prev) => addCartItem(prev, { item, vendorId, quantity, mealDate }));
   }
 
   function removeItem(itemId) {

--- a/frontend/src/cart/CartContext.jsx
+++ b/frontend/src/cart/CartContext.jsx
@@ -29,10 +29,14 @@ export function CartProvider({ children }) {
     setItems([]);
   }
 
+  function replaceCart(nextItems) {
+    setItems(nextItems);
+  }
+
   const totalCount = items.reduce((sum, i) => sum + i.quantity, 0);
 
   return (
-    <CartContext.Provider value={{ items, addItem, removeItem, updateQuantity, clearCart, totalCount }}>
+    <CartContext.Provider value={{ items, addItem, removeItem, updateQuantity, clearCart, replaceCart, totalCount }}>
       {children}
     </CartContext.Provider>
   );

--- a/frontend/src/cart/cartItems.js
+++ b/frontend/src/cart/cartItems.js
@@ -1,0 +1,44 @@
+// Pure cart helpers — no React. Cart item shape: { item, vendorId, quantity, mealDate }
+// where mealDate is a local YYYY-MM-DD string, or null meaning "today (backend default)".
+
+function dedupKey(itemId, mealDate) {
+  return `${itemId}|${mealDate ?? ""}`;
+}
+
+export function addCartItem(items, { item, vendorId, quantity = 1, mealDate = null }) {
+  const key = dedupKey(item.id, mealDate);
+  const existing = items.find((i) => dedupKey(i.item.id, i.mealDate) === key);
+  if (existing) {
+    return items.map((i) =>
+      i === existing ? { ...i, quantity: i.quantity + quantity } : i,
+    );
+  }
+  return [...items, { item, vendorId, quantity, mealDate }];
+}
+
+function mealDateLabel(iso) {
+  const [, mm, dd] = iso.split("-");
+  // Intentional format: month without leading zero, day keeps it (e.g. "用餐日 6/03").
+  return `用餐日 ${Number(mm)}/${dd}`;
+}
+
+export function groupByMealDate(items, todayIso) {
+  const groups = new Map(); // key -> { key, label, sortKey, items }
+  for (const it of items) {
+    const raw = it.mealDate ?? null;
+    const isToday = raw == null || raw === todayIso;
+    const key = isToday ? "today" : raw;
+    if (!groups.has(key)) {
+      groups.set(key, {
+        key,
+        label: isToday ? "今日" : mealDateLabel(raw),
+        sortKey: isToday ? "" : raw, // "" sorts before any ISO date string
+        items: [],
+      });
+    }
+    groups.get(key).items.push(it);
+  }
+  return [...groups.values()]
+    .sort((a, b) => a.sortKey.localeCompare(b.sortKey))
+    .map(({ key, label, items }) => ({ key, label, items }));
+}

--- a/frontend/src/cart/cartItems.test.js
+++ b/frontend/src/cart/cartItems.test.js
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { addCartItem, groupByMealDate } from "./cartItems.js";
+
+const itemA = { id: 1, name: "雞腿便當" };
+const itemB = { id: 2, name: "排骨飯" };
+
+test("addCartItem appends a new pick", () => {
+  const result = addCartItem([], { item: itemA, vendorId: 10, quantity: 1, mealDate: "2026-06-03" });
+  assert.deepEqual(result, [{ item: itemA, vendorId: 10, quantity: 1, mealDate: "2026-06-03" }]);
+});
+
+test("addCartItem accumulates quantity for same item + same date", () => {
+  const start = [{ item: itemA, vendorId: 10, quantity: 1, mealDate: "2026-06-03" }];
+  const result = addCartItem(start, { item: itemA, vendorId: 10, quantity: 2, mealDate: "2026-06-03" });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].quantity, 3);
+});
+
+test("addCartItem keeps same item on different dates as separate rows", () => {
+  const start = [{ item: itemA, vendorId: 10, quantity: 1, mealDate: "2026-06-03" }];
+  const result = addCartItem(start, { item: itemA, vendorId: 10, quantity: 1, mealDate: "2026-06-04" });
+  assert.equal(result.length, 2);
+});
+
+test("addCartItem treats missing mealDate as the no-date row and merges with another no-date add", () => {
+  const start = addCartItem([], { item: itemA, vendorId: 10, quantity: 1 });
+  assert.equal(start[0].mealDate, null);
+  const result = addCartItem(start, { item: itemA, vendorId: 10, quantity: 1 });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].quantity, 2);
+});
+
+test("addCartItem does not mutate the input array", () => {
+  const start = [{ item: itemA, vendorId: 10, quantity: 1, mealDate: null }];
+  addCartItem(start, { item: itemB, vendorId: 10, quantity: 1, mealDate: null });
+  assert.equal(start.length, 1);
+});
+
+test("addCartItem defaults quantity to 1 when omitted", () => {
+  const result = addCartItem([], { item: itemA, vendorId: 10, mealDate: "2026-06-03" });
+  assert.equal(result[0].quantity, 1);
+});
+
+test("groupByMealDate returns an empty array for an empty cart", () => {
+  assert.deepEqual(groupByMealDate([], "2026-06-01"), []);
+});
+
+test("groupByMealDate puts today/no-date first then dates ascending", () => {
+  const today = "2026-06-01";
+  const items = [
+    { item: itemA, vendorId: 10, quantity: 1, mealDate: "2026-06-03" },
+    { item: itemB, vendorId: 10, quantity: 2, mealDate: null },
+    { item: itemA, vendorId: 10, quantity: 1, mealDate: "2026-06-02" },
+    { item: itemB, vendorId: 10, quantity: 1, mealDate: "2026-06-01" }, // explicit today
+  ];
+  const groups = groupByMealDate(items, today);
+  assert.deepEqual(groups.map((g) => g.label), ["今日", "用餐日 6/02", "用餐日 6/03"]);
+  // today group holds the no-date item AND the explicit-today item
+  assert.equal(groups[0].items.length, 2);
+});

--- a/frontend/src/cart/quantity.js
+++ b/frontend/src/cart/quantity.js
@@ -1,0 +1,10 @@
+// Quantity ceiling for the add-to-cart stepper.
+// Prefer the selected meal date's remaining; otherwise the item's base daily quota;
+// otherwise unbounded (capped at 99). null/undefined remaining means "not date-scoped".
+const HARD_CAP = 99;
+
+export function maxAddQuantity({ remaining = null, dailyQuota = null }) {
+  if (remaining != null) return Math.min(remaining, HARD_CAP);
+  if (dailyQuota != null && dailyQuota > 0) return Math.min(dailyQuota, HARD_CAP);
+  return HARD_CAP;
+}

--- a/frontend/src/cart/quantity.test.js
+++ b/frontend/src/cart/quantity.test.js
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { maxAddQuantity } from "./quantity.js";
+
+test("uses remaining when provided", () => {
+  assert.equal(maxAddQuantity({ remaining: 5, dailyQuota: 100 }), 5);
+});
+
+test("clamps remaining to 99", () => {
+  assert.equal(maxAddQuantity({ remaining: 250, dailyQuota: null }), 99);
+});
+
+test("falls back to dailyQuota when remaining is null", () => {
+  assert.equal(maxAddQuantity({ remaining: null, dailyQuota: 8 }), 8);
+});
+
+test("clamps dailyQuota to 99", () => {
+  assert.equal(maxAddQuantity({ remaining: null, dailyQuota: 250 }), 99);
+});
+
+test("returns 99 when neither remaining nor a positive dailyQuota is set", () => {
+  assert.equal(maxAddQuantity({ remaining: null, dailyQuota: null }), 99);
+  assert.equal(maxAddQuantity({ remaining: null, dailyQuota: 0 }), 99);
+});
+
+test("treats undefined remaining like null", () => {
+  assert.equal(maxAddQuantity({ dailyQuota: 3 }), 3);
+});

--- a/frontend/src/components/employee/MealDetailModal.jsx
+++ b/frontend/src/components/employee/MealDetailModal.jsx
@@ -1,18 +1,19 @@
 import { useEffect, useState } from "react";
 import { useCart } from "../../cart/CartContext";
 import { formatPrice, photoUrl, quotaLabel } from "../../utils/format";
+import { maxAddQuantity } from "../../cart/quantity";
 
-export default function MealDetailModal({ item, onClose }) {
+export default function MealDetailModal({ item, onClose, mealDate = null, remaining = null }) {
   const photo = photoUrl(item.photo_path);
   const quota = quotaLabel(item.daily_quota);
-  const soldOut = item.daily_quota === 0;
+  const soldOut = item.daily_quota === 0 || remaining === 0;
   const unavailable = !item.available || soldOut;
 
   const [quantity, setQuantity] = useState(1);
   const [added, setAdded] = useState(false);
   const { addItem } = useCart();
 
-  const maxQty = item.daily_quota > 0 ? Math.min(item.daily_quota, 99) : 99;
+  const maxQty = maxAddQuantity({ remaining, dailyQuota: item.daily_quota });
 
   useEffect(() => {
     function onKey(e) {
@@ -23,7 +24,7 @@ export default function MealDetailModal({ item, onClose }) {
   }, [onClose]);
 
   function handleAddToCart() {
-    addItem(item, item.vendor_id, quantity);
+    addItem(item, item.vendor_id, quantity, mealDate);
     setAdded(true);
     setTimeout(() => {
       setAdded(false);
@@ -68,14 +69,23 @@ export default function MealDetailModal({ item, onClose }) {
               )}
             </div>
 
-            {quota && (
+            {remaining != null ? (
               <div className="modal-detail-row">
-                <span className="modal-detail-label">今日配額</span>
-                <span className="badge badge-quota">{quota}</span>
+                <span className="modal-detail-label">
+                  {mealDate ? mealDate : "今日"}
+                </span>
+                <span className="badge badge-quota">{`剩餘 ${remaining} 份`}</span>
               </div>
+            ) : (
+              quota && (
+                <div className="modal-detail-row">
+                  <span className="modal-detail-label">今日配額</span>
+                  <span className="badge badge-quota">{quota}</span>
+                </div>
+              )
             )}
 
-            {item.daily_quota === null && (
+            {remaining == null && item.daily_quota === null && (
               <div className="modal-detail-row">
                 <span className="modal-detail-label">今日配額</span>
                 <span style={{ color: "var(--muted)" }}>無限制</span>

--- a/frontend/src/pages/employee/CartPage.jsx
+++ b/frontend/src/pages/employee/CartPage.jsx
@@ -2,9 +2,11 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { submitSelection } from "../../api/employee";
 import { useCart } from "../../cart/CartContext";
+import { groupByMealDate } from "../../cart/cartItems";
 import { useFacility } from "../../facility/FacilityContext";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { formatPrice } from "../../utils/format";
+import { todayIso } from "../../utils/date";
 
 function errorMessage(item, err) {
   if (err.code === "ITEM_UNAVAILABLE" || err.code === "item_unavailable") {
@@ -36,6 +38,8 @@ export default function CartPage() {
     0,
   );
 
+  const groups = groupByMealDate(items, todayIso());
+
   async function handleSubmit() {
     setSubmitting(true);
     setResult(null);
@@ -46,6 +50,7 @@ export default function CartPage() {
         await submitSelection(cartItem.vendorId, {
           itemId: cartItem.item.id,
           quantity: cartItem.quantity,
+          mealDate: cartItem.mealDate,
           facilityId: selectedFacilityId,
         });
       } catch (err) {
@@ -131,64 +136,85 @@ export default function CartPage() {
       )}
 
       <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
-        {items.map((cartItem, idx) => (
-          <div
-            key={cartItem.item.id}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 16,
-              padding: "16px 20px",
-              borderBottom: idx < items.length - 1 ? "1px solid var(--line)" : "none",
-            }}
-          >
-            <div style={{ flex: 1 }}>
-              <p style={{ fontWeight: 600, margin: 0 }}>{cartItem.item.name}</p>
-              <p style={{ color: "var(--muted)", fontSize: 13, margin: "2px 0 0" }}>
-                {formatPrice(cartItem.item.price_cents)} / 份
-              </p>
-            </div>
-
-            <div className="quantity-stepper">
-              <button
-                className="stepper-btn"
-                type="button"
-                aria-label="減少數量"
-                onClick={() => updateQuantity(cartItem.item.id, cartItem.quantity - 1)}
-                disabled={cartItem.quantity <= 1}
-              >
-                −
-              </button>
-              <span className="stepper-value">{cartItem.quantity}</span>
-              <button
-                className="stepper-btn"
-                type="button"
-                aria-label="增加數量"
-                onClick={() => updateQuantity(cartItem.item.id, cartItem.quantity + 1)}
-              >
-                ＋
-              </button>
-            </div>
-
-            <p style={{ width: 80, textAlign: "right", fontWeight: 600, margin: 0 }}>
-              {formatPrice(cartItem.item.price_cents * cartItem.quantity)}
-            </p>
-
-            <button
-              type="button"
-              aria-label={`移除 ${cartItem.item.name}`}
-              onClick={() => removeItem(cartItem.item.id)}
+        {groups.map((group) => (
+          <div key={group.key}>
+            <p
               style={{
-                background: "none",
-                border: "none",
-                cursor: "pointer",
+                margin: 0,
+                padding: "10px 20px",
+                fontSize: 13,
+                fontWeight: 600,
                 color: "var(--muted)",
-                fontSize: 18,
-                padding: "4px 8px",
+                background: "var(--surface-2, rgba(0,0,0,0.03))",
+                borderBottom: "1px solid var(--line)",
               }}
             >
-              ×
-            </button>
+              {group.label}
+            </p>
+            {/* TODO(#134): updateQuantity/removeItem are id-only; not date-aware */}
+            {group.items.map((cartItem, idx) => {
+              const isLastInGroup = idx === group.items.length - 1;
+              return (
+              <div
+                key={`${cartItem.item.id}-${cartItem.mealDate ?? "today"}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 16,
+                  padding: "16px 20px",
+                  borderBottom: isLastInGroup ? "none" : "1px solid var(--line)",
+                }}
+              >
+                <div style={{ flex: 1 }}>
+                  <p style={{ fontWeight: 600, margin: 0 }}>{cartItem.item.name}</p>
+                  <p style={{ color: "var(--muted)", fontSize: 13, margin: "2px 0 0" }}>
+                    {formatPrice(cartItem.item.price_cents)} / 份
+                  </p>
+                </div>
+
+                <div className="quantity-stepper">
+                  <button
+                    className="stepper-btn"
+                    type="button"
+                    aria-label="減少數量"
+                    onClick={() => updateQuantity(cartItem.item.id, cartItem.quantity - 1)}
+                    disabled={cartItem.quantity <= 1}
+                  >
+                    −
+                  </button>
+                  <span className="stepper-value">{cartItem.quantity}</span>
+                  <button
+                    className="stepper-btn"
+                    type="button"
+                    aria-label="增加數量"
+                    onClick={() => updateQuantity(cartItem.item.id, cartItem.quantity + 1)}
+                  >
+                    ＋
+                  </button>
+                </div>
+
+                <p style={{ width: 80, textAlign: "right", fontWeight: 600, margin: 0 }}>
+                  {formatPrice(cartItem.item.price_cents * cartItem.quantity)}
+                </p>
+
+                <button
+                  type="button"
+                  aria-label={`移除 ${cartItem.item.name}`}
+                  onClick={() => removeItem(cartItem.item.id)}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    color: "var(--muted)",
+                    fontSize: 18,
+                    padding: "4px 8px",
+                  }}
+                >
+                  ×
+                </button>
+              </div>
+              );
+            })}
           </div>
         ))}
       </div>

--- a/frontend/src/pages/employee/CartPage.jsx
+++ b/frontend/src/pages/employee/CartPage.jsx
@@ -26,7 +26,7 @@ function errorMessage(item, err) {
 }
 
 export default function CartPage() {
-  const { items, updateQuantity, removeItem, clearCart, totalCount } = useCart();
+  const { items, updateQuantity, removeItem, clearCart, replaceCart, totalCount } = useCart();
   const { selectedFacilityId } = useFacility();
   const navigate = useNavigate();
 
@@ -45,6 +45,7 @@ export default function CartPage() {
     setResult(null);
 
     const errors = [];
+    const failedItems = [];
     for (const cartItem of items) {
       try {
         await submitSelection(cartItem.vendorId, {
@@ -55,13 +56,16 @@ export default function CartPage() {
         });
       } catch (err) {
         errors.push(errorMessage(cartItem, err));
+        failedItems.push(cartItem);
       }
     }
 
     setSubmitting(false);
+    // Succeeded rows are already ordered — drop them so a retry can't double-order.
+    // Only the rows that failed remain in the cart.
+    replaceCart(failedItems);
 
     if (errors.length === 0) {
-      clearCart();
       setResult({ ok: true });
     } else {
       setResult({ ok: false, errors });

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -24,7 +24,7 @@ function drawErrorMessage(err) {
 
 export default function RandomMealPage() {
   const navigate = useNavigate();
-  const { addItem } = useCart();
+  const { addItem, totalCount } = useCart();
   const { selectedFacilityId } = useFacility();
   const { vendors, loading, error } = useVendors({ facilityId: selectedFacilityId });
   const minMealDate = addDaysIso(0);
@@ -39,6 +39,7 @@ export default function RandomMealPage() {
   const [drawError, setDrawError] = useState(null);
   const [drawing, setDrawing] = useState(false);
   const [addedToCart, setAddedToCart] = useState(false);
+  const [lastAdded, setLastAdded] = useState(null); // name of the most recently added item, for banner feedback
 
   // --- 熱門推薦 state ---
   const [recommendations, setRecommendations] = useState([]);
@@ -114,11 +115,13 @@ export default function RandomMealPage() {
   function handleAddDrawToCart() {
     if (!draw) return;
     addItem(draw.item, draw.vendor.id, 1, mealDate);
+    setLastAdded(draw.item.name);
     setAddedToCart(true);
   }
 
   function handleAddRecToCart(rec) {
     addItem(rec.item, rec.vendor.id, 1, mealDate);
+    setLastAdded(rec.item.name);
     setAddedToCart(true);
   }
 
@@ -146,9 +149,13 @@ export default function RandomMealPage() {
             marginBottom: 16,
           }}
         >
-          <span>✅ 已加入購物車</span>
+          <span>
+            ✅ 已加入購物車
+            {lastAdded ? `：${lastAdded}` : ""}
+            （共 {totalCount} 件）
+          </span>
           <button
-            className="ghost-button"
+            className="primary-button"
             type="button"
             onClick={() => navigate("/employee/cart")}
           >
@@ -346,14 +353,6 @@ export default function RandomMealPage() {
                   </div>
 
                   <div className="random-result-actions">
-                    <button
-                      className="ghost-button"
-                      type="button"
-                      onClick={handleDraw}
-                      disabled={drawing}
-                    >
-                      重新抽
-                    </button>
                     <button
                       className="primary-button"
                       type="button"

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -121,7 +121,7 @@ export default function RandomMealPage() {
   return (
     <div>
       <div className="page-header">
-        <FacilityScopeLabel label="隨機抽餐設施" />
+        <FacilityScopeLabel label="Ordering facility" />
         <p className="eyebrow">員工 / 推薦與隨機抽餐</p>
         <h2>今天吃什麼？</h2>
       </div>

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -1,15 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { drawRandomMeal, getRecommendations, submitSelection } from "../../api/employee";
+import { drawRandomMeal, getRecommendations } from "../../api/employee";
+import { useCart } from "../../cart/CartContext";
 import { useFacility } from "../../facility/FacilityContext";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { useVendors } from "../../hooks/useVendors";
+import { toLocalIso } from "../../utils/date";
 import { formatPrice, quotaLabel } from "../../utils/format";
-
-function toLocalIso(date) {
-  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
-  return localDate.toISOString().slice(0, 10);
-}
 
 function addDaysIso(days) {
   const date = new Date();
@@ -27,6 +24,7 @@ function drawErrorMessage(err) {
 
 export default function RandomMealPage() {
   const navigate = useNavigate();
+  const { addItem } = useCart();
   const { selectedFacilityId } = useFacility();
   const { vendors, loading, error } = useVendors({ facilityId: selectedFacilityId });
   const minMealDate = addDaysIso(0);
@@ -40,16 +38,12 @@ export default function RandomMealPage() {
   const [draw, setDraw] = useState(null);
   const [drawError, setDrawError] = useState(null);
   const [drawing, setDrawing] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  const [submitted, setSubmitted] = useState(false);
+  const [addedToCart, setAddedToCart] = useState(false);
 
   // --- 熱門推薦 state ---
   const [recommendations, setRecommendations] = useState([]);
   const [recLoading, setRecLoading] = useState(false);
   const [recError, setRecError] = useState(null);
-  const [recSubmitting, setRecSubmitting] = useState(null); // item id being submitted
-  const [recSubmitted, setRecSubmitted] = useState(null);   // item id successfully submitted
-  const [recSubmitError, setRecSubmitError] = useState(null);
   const [limit, setLimit] = useState(10);
 
   const selectedCount = allVendors ? vendors.length : selectedVendorIds.length;
@@ -64,9 +58,7 @@ export default function RandomMealPage() {
   useEffect(() => {
     setSelectedVendorIds([]);
     setDraw(null);
-    setSubmitted(false);
-    setRecSubmitted(null);
-    setRecSubmitError(null);
+    setAddedToCart(false);
   }, [selectedFacilityId]);
 
   // Fetch recommendations whenever the tab, mealDate, or facilityId changes
@@ -75,8 +67,6 @@ export default function RandomMealPage() {
     let cancelled = false;
     setRecLoading(true);
     setRecError(null);
-    setRecSubmitted(null);
-    setRecSubmitError(null);
     getRecommendations({ facilityId: selectedFacilityId, mealDate, limit })
       .then((data) => {
         if (!cancelled) setRecommendations(data);
@@ -100,13 +90,12 @@ export default function RandomMealPage() {
         : [...current, vendorId],
     );
     setDraw(null);
-    setSubmitted(false);
   }
 
   async function handleDraw() {
     setDrawing(true);
     setDrawError(null);
-    setSubmitted(false);
+    setAddedToCart(false);
     try {
       const result = await drawRandomMeal({
         mealDate,
@@ -122,43 +111,15 @@ export default function RandomMealPage() {
     }
   }
 
-  async function handleConfirm() {
+  function handleAddDrawToCart() {
     if (!draw) return;
-    setSubmitting(true);
-    setDrawError(null);
-    try {
-      await submitSelection(draw.vendor.id, {
-        itemId: draw.item.id,
-        quantity: 1,
-        mealDate,
-        facilityId: selectedFacilityId,
-      });
-      setSubmitted(true);
-    } catch (err) {
-      setDrawError(drawErrorMessage(err));
-    } finally {
-      setSubmitting(false);
-    }
+    addItem(draw.item, draw.vendor.id, 1, mealDate);
+    setAddedToCart(true);
   }
 
-  async function handleRecOrder(rec) {
-    setRecSubmitting(rec.item.id);
-    setRecSubmitError(null);
-    try {
-      await submitSelection(rec.vendor.id, {
-        itemId: rec.item.id,
-        quantity: 1,
-        mealDate,
-        facilityId: selectedFacilityId,
-      });
-      setRecSubmitted(rec.item.id);
-    } catch (err) {
-      setRecSubmitError(
-        err?.message ?? "訂購失敗，請稍後再試。"
-      );
-    } finally {
-      setRecSubmitting(null);
-    }
+  function handleAddRecToCart(rec) {
+    addItem(rec.item, rec.vendor.id, 1, mealDate);
+    setAddedToCart(true);
   }
 
   function recRemainingLabel(rec) {
@@ -173,6 +134,28 @@ export default function RandomMealPage() {
         <p className="eyebrow">員工 / 推薦與隨機抽餐</p>
         <h2>今天吃什麼？</h2>
       </div>
+
+      {addedToCart && (
+        <div
+          className="success-state"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 12,
+            marginBottom: 16,
+          }}
+        >
+          <span>✅ 已加入購物車</span>
+          <button
+            className="ghost-button"
+            type="button"
+            onClick={() => navigate("/employee/cart")}
+          >
+            去結帳
+          </button>
+        </div>
+      )}
 
       {/* Shared selectors */}
       <section className="random-meal-layout">
@@ -190,7 +173,7 @@ export default function RandomMealPage() {
             onChange={(event) => {
               setMealDate(event.target.value);
               setDraw(null);
-              setSubmitted(false);
+              setAddedToCart(false);
             }}
           />
 
@@ -209,7 +192,7 @@ export default function RandomMealPage() {
                     onChange={(event) => {
                       setAllVendors(event.target.checked);
                       setDraw(null);
-                      setSubmitted(false);
+                      setAddedToCart(false);
                     }}
                   />
                   <span>全部餐廳</span>
@@ -253,14 +236,14 @@ export default function RandomMealPage() {
             <button
               type="button"
               className={`range-pill${tab === "recommend" ? " is-active" : ""}`}
-              onClick={() => setTab("recommend")}
+              onClick={() => { setTab("recommend"); setAddedToCart(false); }}
             >
               熱門推薦
             </button>
             <button
               type="button"
               className={`range-pill${tab === "random" ? " is-active" : ""}`}
-              onClick={() => setTab("random")}
+              onClick={() => { setTab("random"); setAddedToCart(false); }}
             >
               隨機抽餐
             </button>
@@ -288,7 +271,6 @@ export default function RandomMealPage() {
 
               {recLoading && <p className="loading-state compact-state">載入推薦中…</p>}
               {recError && <p className="error-state">{recError}</p>}
-              {recSubmitError && <p className="error-state">{recSubmitError}</p>}
               {!recLoading && !recError && recommendations.length === 0 && (
                 <p className="recommend-empty">目前沒有可推薦的餐點</p>
               )}
@@ -320,27 +302,13 @@ export default function RandomMealPage() {
                         </div>
                       </div>
                       <div className="recommend-card-action">
-                        {recSubmitted === rec.item.id ? (
-                          <>
-                            <p className="eyebrow" style={{ color: "var(--brand)", marginBottom: "6px" }}>已訂購</p>
-                            <button
-                              className="ghost-button"
-                              type="button"
-                              onClick={() => navigate("/employee/orders")}
-                            >
-                              查看訂單
-                            </button>
-                          </>
-                        ) : (
-                          <button
-                            className="primary-button"
-                            type="button"
-                            onClick={() => handleRecOrder(rec)}
-                            disabled={recSubmitting === rec.item.id}
-                          >
-                            {recSubmitting === rec.item.id ? "訂購中…" : "訂購"}
-                          </button>
-                        )}
+                        <button
+                          className="primary-button"
+                          type="button"
+                          onClick={() => handleAddRecToCart(rec)}
+                        >
+                          加入購物車
+                        </button>
                       </div>
                     </div>
                   ))}
@@ -377,37 +345,23 @@ export default function RandomMealPage() {
                     </span>
                   </div>
 
-                  {submitted ? (
-                    <div className="success-state">
-                      <p>已加入訂單（{mealDate}）。</p>
-                      <button
-                        className="ghost-button"
-                        type="button"
-                        onClick={() => navigate("/employee/orders")}
-                      >
-                        查看訂單
-                      </button>
-                    </div>
-                  ) : (
-                    <div className="random-result-actions">
-                      <button
-                        className="ghost-button"
-                        type="button"
-                        onClick={handleDraw}
-                        disabled={drawing || submitting}
-                      >
-                        重新抽
-                      </button>
-                      <button
-                        className="primary-button"
-                        type="button"
-                        onClick={handleConfirm}
-                        disabled={submitting}
-                      >
-                        {submitting ? "送出中…" : "選這份"}
-                      </button>
-                    </div>
-                  )}
+                  <div className="random-result-actions">
+                    <button
+                      className="ghost-button"
+                      type="button"
+                      onClick={handleDraw}
+                      disabled={drawing}
+                    >
+                      重新抽
+                    </button>
+                    <button
+                      className="primary-button"
+                      type="button"
+                      onClick={handleAddDrawToCart}
+                    >
+                      加入購物車
+                    </button>
+                  </div>
                 </div>
               )}
             </div>

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { drawRandomMeal, getRecommendations } from "../../api/employee";
-import { useCart } from "../../cart/CartContext";
+import MealDetailModal from "../../components/employee/MealDetailModal";
 import { useFacility } from "../../facility/FacilityContext";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { useVendors } from "../../hooks/useVendors";
@@ -23,8 +22,6 @@ function drawErrorMessage(err) {
 }
 
 export default function RandomMealPage() {
-  const navigate = useNavigate();
-  const { addItem, totalCount } = useCart();
   const { selectedFacilityId } = useFacility();
   const { vendors, loading, error } = useVendors({ facilityId: selectedFacilityId });
   const minMealDate = addDaysIso(0);
@@ -38,8 +35,7 @@ export default function RandomMealPage() {
   const [draw, setDraw] = useState(null);
   const [drawError, setDrawError] = useState(null);
   const [drawing, setDrawing] = useState(false);
-  const [addedToCart, setAddedToCart] = useState(false);
-  const [lastAdded, setLastAdded] = useState(null); // name of the most recently added item, for banner feedback
+  const [detail, setDetail] = useState(null); // { item, remaining } shown in the meal-detail modal
 
   // --- 熱門推薦 state ---
   const [recommendations, setRecommendations] = useState([]);
@@ -59,7 +55,6 @@ export default function RandomMealPage() {
   useEffect(() => {
     setSelectedVendorIds([]);
     setDraw(null);
-    setAddedToCart(false);
   }, [selectedFacilityId]);
 
   // Fetch recommendations whenever the tab, mealDate, or facilityId changes
@@ -96,7 +91,7 @@ export default function RandomMealPage() {
   async function handleDraw() {
     setDrawing(true);
     setDrawError(null);
-    setAddedToCart(false);
+    setDraw(null);
     try {
       const result = await drawRandomMeal({
         mealDate,
@@ -112,19 +107,6 @@ export default function RandomMealPage() {
     }
   }
 
-  function handleAddDrawToCart() {
-    if (!draw) return;
-    addItem(draw.item, draw.vendor.id, 1, mealDate);
-    setLastAdded(draw.item.name);
-    setAddedToCart(true);
-  }
-
-  function handleAddRecToCart(rec) {
-    addItem(rec.item, rec.vendor.id, 1, mealDate);
-    setLastAdded(rec.item.name);
-    setAddedToCart(true);
-  }
-
   function recRemainingLabel(rec) {
     if (rec.remaining_quantity == null) return quotaLabel(rec.item.daily_quota);
     return `剩餘 ${rec.remaining_quantity} 份`;
@@ -137,32 +119,6 @@ export default function RandomMealPage() {
         <p className="eyebrow">員工 / 推薦與隨機抽餐</p>
         <h2>今天吃什麼？</h2>
       </div>
-
-      {addedToCart && (
-        <div
-          className="success-state"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: 12,
-            marginBottom: 16,
-          }}
-        >
-          <span>
-            ✅ 已加入購物車
-            {lastAdded ? `：${lastAdded}` : ""}
-            （共 {totalCount} 件）
-          </span>
-          <button
-            className="primary-button"
-            type="button"
-            onClick={() => navigate("/employee/cart")}
-          >
-            去結帳
-          </button>
-        </div>
-      )}
 
       {/* Shared selectors */}
       <section className="random-meal-layout">
@@ -180,7 +136,6 @@ export default function RandomMealPage() {
             onChange={(event) => {
               setMealDate(event.target.value);
               setDraw(null);
-              setAddedToCart(false);
             }}
           />
 
@@ -199,7 +154,6 @@ export default function RandomMealPage() {
                     onChange={(event) => {
                       setAllVendors(event.target.checked);
                       setDraw(null);
-                      setAddedToCart(false);
                     }}
                   />
                   <span>全部餐廳</span>
@@ -243,14 +197,14 @@ export default function RandomMealPage() {
             <button
               type="button"
               className={`range-pill${tab === "recommend" ? " is-active" : ""}`}
-              onClick={() => { setTab("recommend"); setAddedToCart(false); }}
+              onClick={() => setTab("recommend")}
             >
               熱門推薦
             </button>
             <button
               type="button"
               className={`range-pill${tab === "random" ? " is-active" : ""}`}
-              onClick={() => { setTab("random"); setAddedToCart(false); }}
+              onClick={() => setTab("random")}
             >
               隨機抽餐
             </button>
@@ -287,6 +241,17 @@ export default function RandomMealPage() {
                     <div
                       key={`${rec.vendor.id}-${rec.item.id}`}
                       className="recommend-card"
+                      role="button"
+                      tabIndex={0}
+                      aria-label={rec.item.name}
+                      style={{ cursor: "pointer" }}
+                      onClick={() => setDetail({ item: rec.item, remaining: rec.remaining_quantity })}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          setDetail({ item: rec.item, remaining: rec.remaining_quantity });
+                        }
+                      }}
                     >
                       <div className="recommend-card-rank" data-top={index < 3 || undefined}>
                         {index + 1}
@@ -307,15 +272,6 @@ export default function RandomMealPage() {
                             {recRemainingLabel(rec)}
                           </span>
                         </div>
-                      </div>
-                      <div className="recommend-card-action">
-                        <button
-                          className="primary-button"
-                          type="button"
-                          onClick={() => handleAddRecToCart(rec)}
-                        >
-                          加入購物車
-                        </button>
                       </div>
                     </div>
                   ))}
@@ -338,7 +294,20 @@ export default function RandomMealPage() {
               {drawError && <p className="error-state">{drawError}</p>}
 
               {draw && (
-                <div className="random-result-card">
+                <div
+                  className="random-result-card"
+                  role="button"
+                  tabIndex={0}
+                  aria-label={draw.item.name}
+                  style={{ cursor: "pointer" }}
+                  onClick={() => setDetail({ item: draw.item, remaining: draw.remaining_quantity })}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setDetail({ item: draw.item, remaining: draw.remaining_quantity });
+                    }
+                  }}
+                >
                   <p className="eyebrow">{draw.vendor.name}</p>
                   <h3>{draw.item.name}</h3>
                   <p className="random-price">{formatPrice(draw.item.price_cents)}</p>
@@ -352,21 +321,21 @@ export default function RandomMealPage() {
                     </span>
                   </div>
 
-                  <div className="random-result-actions">
-                    <button
-                      className="primary-button"
-                      type="button"
-                      onClick={handleAddDrawToCart}
-                    >
-                      加入購物車
-                    </button>
-                  </div>
                 </div>
               )}
             </div>
           )}
         </div>
       </section>
+
+      {detail && (
+        <MealDetailModal
+          item={detail.item}
+          mealDate={mealDate}
+          remaining={detail.remaining}
+          onClose={() => setDetail(null)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1044,6 +1044,23 @@ p {
 .random-result-card {
   display: grid;
   gap: 14px;
+  max-width: 520px;
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+.random-result-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px rgba(78, 49, 23, 0.1);
+}
+
+.random-result-card:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
 }
 
 .random-price {

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -1,0 +1,10 @@
+// Local-date helpers. Use these instead of Date.toISOString() (which is UTC and
+// can roll the date over near midnight). meal_date everywhere is a local YYYY-MM-DD.
+export function toLocalIso(date) {
+  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+  return localDate.toISOString().slice(0, 10);
+}
+
+export function todayIso() {
+  return toLocalIso(new Date());
+}

--- a/frontend/src/utils/date.test.js
+++ b/frontend/src/utils/date.test.js
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { toLocalIso, todayIso } from "./date.js";
+
+test("toLocalIso formats a Date as local YYYY-MM-DD", () => {
+  // Local noon avoids any timezone date-rollover ambiguity.
+  const d = new Date(2026, 5, 3, 12, 0, 0); // 2026-06-03 (month is 0-based)
+  assert.equal(toLocalIso(d), "2026-06-03");
+});
+
+test("toLocalIso zero-pads month and day", () => {
+  const d = new Date(2026, 0, 9, 12, 0, 0); // 2026-01-09
+  assert.equal(toLocalIso(d), "2026-01-09");
+});
+
+test("todayIso returns today's local date as YYYY-MM-DD", () => {
+  const result = todayIso();
+  assert.match(result, /^\d{4}-\d{2}-\d{2}$/);
+  assert.equal(result, toLocalIso(new Date()));
+});


### PR DESCRIPTION
Closes #134

## What & why

The **random meal** and **recommendation** entry points placed an order directly (order-now), bypassing the cart. They now **add to the cart**, and the employee checks out from the cart — consistent with browsing the menu. Random/recommendation picks carry the **meal date** the user selected (next 7 days), so the cart can hold meals for different dates and submit each with its own `meal_date`.

## Changes

- **`utils/date.js`** (new): shared `toLocalIso` / `todayIso` (extracted from `RandomMealPage`, removes a duplicate copy; avoids UTC midnight rollover).
- **`cart/cartItems.js`** (new, pure + unit-tested):
  - `addCartItem` — dedup key is `item.id` + `mealDate`, so the same dish on different dates is two rows, same dish + same date accumulates quantity.
  - `groupByMealDate` — orders rows into a "今日" group (no-date/today) first, then each future date ascending.
- **`cart/CartContext.jsx`**: `addItem(item, vendorId, quantity, mealDate?)` delegates to `addCartItem`; adds `replaceCart`. Existing 3-arg callers (e.g. menu add) are unchanged — `mealDate` defaults to today.
- **`pages/employee/CartPage.jsx`**: renders cart rows grouped by meal date; sends per-item `meal_date` at checkout.
- **`pages/employee/RandomMealPage.jsx`**: random-draw and recommendation actions become "加入購物車" with a top "去結帳" banner; the immediate-order flow is removed.

## Included fix: partial-failure double-order

`CartPage` checkout submits each row sequentially. Previously the cart was only cleared when **all** rows succeeded, so on a partial failure the already-ordered rows stayed in the cart and pressing submit again re-ordered them. Checkout now keeps **only the failed rows**, so a retry cannot double-order. This is more likely to surface with multi-date carts (one date sold out, another fine), which is why it is fixed here.

## Tests

- Frontend: `npm test` — 19/19 green (new `date` and `cartItems` suites registered).
- Backend: `pytest backend/tests` — 301 passed, 28 skipped (frontend-only change; no backend regression).
- Manual: draw/recommend → add to cart → cart shows "今日" + "用餐日 M/DD" groups → checkout creates orders with the right meal date; normal menu add still works.

## Known limitation (intentional, out of scope)

Cart `updateQuantity` / `removeItem` key by `item.id` only, so for the same dish across two date groups they act on the first matching row. Flagged in code with `// TODO(#134)`. A date-aware version is deferred.

The backend already enforces quota atomically per meal date (`SELECT ... FOR UPDATE`), so this change cannot oversell; "sold out at checkout" surfaces as a per-item error.