### PR TITLE
Scope vendor menu management by facility

### DIFF
--- a/backend/routes/vendor_menu.py
+++ b/backend/routes/vendor_menu.py
@@ -10,9 +10,10 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, File, Query, UploadFile, status
 from fastapi.responses import Response
 
-from backend.core.vendor_identity import require_approved_vendor
+from backend.core.vendor_identity import get_vendor_profile_repository, require_approved_vendor
 from backend.repositories.menu_category_repository import MenuCategoryRepository
 from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository
 from backend.routes.vendor_categories import get_menu_category_repository
 from backend.schemas.vendor_self import MenuItem, MenuItemCreate, MenuItemUpdate, PhotoUploadResponse
 from backend.services.vendor_menu_service import VendorMenuService
@@ -45,8 +46,9 @@ def get_vendor_menu_service(
     item_repo: Annotated[MenuItemRepository, Depends(get_menu_item_repository)],
     cat_repo: Annotated[MenuCategoryRepository, Depends(get_menu_category_repository)],
     storage: Annotated[PhotoStorage, Depends(get_photo_storage)],
+    vendor_repo: Annotated[VendorProfileRepository, Depends(get_vendor_profile_repository)],
 ) -> VendorMenuService:
-    return VendorMenuService(item_repo, cat_repo, storage)
+    return VendorMenuService(item_repo, cat_repo, storage, vendor_repo)
 
 
 @router.get("", response_model=list[MenuItem])
@@ -55,9 +57,15 @@ def list_menu(
     service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
     category_id: Annotated[int | None, Query()] = None,
     available: Annotated[bool | None, Query()] = None,
+    facility_id: Annotated[int | None, Query()] = None,
 ) -> list[MenuItem]:
     """列出商家菜單；可用 category_id / available 篩選。"""
-    return service.list(vendor_id, category_id=category_id, available=available)
+    return service.list(
+        vendor_id,
+        category_id=category_id,
+        available=available,
+        facility_id=facility_id,
+    )
 
 
 @router.post("", response_model=MenuItem, status_code=status.HTTP_201_CREATED)
@@ -65,9 +73,10 @@ def create_menu_item(
     payload: MenuItemCreate,
     vendor_id: Annotated[int, Depends(require_approved_vendor)],
     service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+    facility_id: Annotated[int | None, Query()] = None,
 ) -> MenuItem:
     """新增菜單項目。daily_quota: None=不限, 0=暫停供應。"""
-    return service.create(vendor_id, payload)
+    return service.create(vendor_id, payload, facility_id=facility_id)
 
 
 @router.get("/{item_id}", response_model=MenuItem)
@@ -75,8 +84,9 @@ def get_menu_item(
     item_id: int,
     vendor_id: Annotated[int, Depends(require_approved_vendor)],
     service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+    facility_id: Annotated[int | None, Query()] = None,
 ) -> MenuItem:
-    return service.get(vendor_id, item_id)
+    return service.get(vendor_id, item_id, facility_id=facility_id)
 
 
 @router.patch("/{item_id}", response_model=MenuItem)
@@ -85,9 +95,10 @@ def patch_menu_item(
     payload: MenuItemUpdate,
     vendor_id: Annotated[int, Depends(require_approved_vendor)],
     service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+    facility_id: Annotated[int | None, Query()] = None,
 ) -> MenuItem:
     """局部更新菜單項目。"""
-    return service.update(vendor_id, item_id, payload)
+    return service.update(vendor_id, item_id, payload, facility_id=facility_id)
 
 
 @router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -95,9 +106,10 @@ def delete_menu_item(
     item_id: int,
     vendor_id: Annotated[int, Depends(require_approved_vendor)],
     service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+    facility_id: Annotated[int | None, Query()] = None,
 ) -> Response:
     """刪除菜單項目；連帶刪除照片檔。"""
-    service.delete(vendor_id, item_id)
+    service.delete(vendor_id, item_id, facility_id=facility_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -106,6 +118,7 @@ async def put_menu_photo(
     item_id: int,
     vendor_id: Annotated[int, Depends(require_approved_vendor)],
     service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+    facility_id: Annotated[int | None, Query()] = None,
     file: UploadFile = File(...),
 ) -> PhotoUploadResponse:
     """上傳/覆蓋菜單項目照片 (multipart `file`)。
@@ -114,7 +127,12 @@ async def put_menu_photo(
     PUT 語意 — idempotent，多次呼叫覆蓋既有照片。
     """
     data = await file.read()
-    path = service.replace_photo(vendor_id=vendor_id, item_id=item_id, data=data)
+    path = service.replace_photo(
+        vendor_id=vendor_id,
+        item_id=item_id,
+        data=data,
+        facility_id=facility_id,
+    )
     return PhotoUploadResponse(photo_path=path)
 
 
@@ -123,7 +141,8 @@ def delete_menu_photo(
     item_id: int,
     vendor_id: Annotated[int, Depends(require_approved_vendor)],
     service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+    facility_id: Annotated[int | None, Query()] = None,
 ) -> Response:
     """刪除菜單項目照片 (檔案 + DB 路徑都清空)；不存在不算錯。"""
-    service.delete_photo(vendor_id=vendor_id, item_id=item_id)
+    service.delete_photo(vendor_id=vendor_id, item_id=item_id, facility_id=facility_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/services/vendor_menu_service.py
+++ b/backend/services/vendor_menu_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from backend.core.errors import CodedHTTPException
 from backend.repositories.menu_category_repository import MenuCategoryRepository
 from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository
 from backend.schemas.vendor_self import MenuItem, MenuItemCreate, MenuItemUpdate
 from backend.storage.photo_storage import PhotoStorage
 
@@ -20,21 +21,30 @@ class VendorMenuService:
         menu_item_repository: MenuItemRepository,
         category_repository: MenuCategoryRepository,
         photo_storage: PhotoStorage,
+        vendor_repository: VendorProfileRepository | None = None,
     ) -> None:
         self.menu_item_repository = menu_item_repository
         self.category_repository = category_repository
         self.photo_storage = photo_storage
+        self.vendor_repository = vendor_repository
 
     # --- query ---
 
     def list(
-        self, vendor_id: int, *, category_id: int | None = None, available: bool | None = None
+        self,
+        vendor_id: int,
+        *,
+        category_id: int | None = None,
+        available: bool | None = None,
+        facility_id: int | None = None,
     ) -> list[MenuItem]:
+        self._assert_facility_access(vendor_id, facility_id)
         return self.menu_item_repository.list(
             vendor_id=vendor_id, category_id=category_id, available=available
         )
 
-    def get(self, vendor_id: int, item_id: int) -> MenuItem:
+    def get(self, vendor_id: int, item_id: int, *, facility_id: int | None = None) -> MenuItem:
+        self._assert_facility_access(vendor_id, facility_id)
         item = self.menu_item_repository.get(vendor_id=vendor_id, item_id=item_id)
         if item is None:
             raise CodedHTTPException(status_code=404, code="not_found", detail="menu item not found")
@@ -42,7 +52,8 @@ class VendorMenuService:
 
     # --- mutate ---
 
-    def create(self, vendor_id: int, payload: MenuItemCreate) -> MenuItem:
+    def create(self, vendor_id: int, payload: MenuItemCreate, *, facility_id: int | None = None) -> MenuItem:
+        self._assert_facility_access(vendor_id, facility_id)
         if payload.category_id is not None:
             self._assert_category_belongs_to(vendor_id, payload.category_id)
         return self.menu_item_repository.create(
@@ -55,9 +66,16 @@ class VendorMenuService:
             daily_quota=payload.daily_quota,
         )
 
-    def update(self, vendor_id: int, item_id: int, payload: MenuItemUpdate) -> MenuItem:
+    def update(
+        self,
+        vendor_id: int,
+        item_id: int,
+        payload: MenuItemUpdate,
+        *,
+        facility_id: int | None = None,
+    ) -> MenuItem:
         # 確保 item 屬於 caller (避免讓 update 變成跨商家寫入)
-        self.get(vendor_id, item_id)
+        self.get(vendor_id, item_id, facility_id=facility_id)
         fields = payload.model_dump(exclude_unset=True)
         if "category_id" in fields and fields["category_id"] is not None:
             self._assert_category_belongs_to(vendor_id, fields["category_id"])
@@ -68,16 +86,23 @@ class VendorMenuService:
         assert updated is not None
         return updated
 
-    def delete(self, vendor_id: int, item_id: int) -> None:
+    def delete(self, vendor_id: int, item_id: int, *, facility_id: int | None = None) -> None:
         # 連帶刪除檔案 (best-effort)；先刪檔再刪 row 避免 row 沒了但檔還在。
-        self.get(vendor_id, item_id)
+        self.get(vendor_id, item_id, facility_id=facility_id)
         self.photo_storage.delete_menu_photo(vendor_id=vendor_id, item_id=item_id)
         self.menu_item_repository.delete(vendor_id=vendor_id, item_id=item_id)
 
     # --- photo sub-resource (used by Task 12) ---
 
-    def replace_photo(self, vendor_id: int, item_id: int, data: bytes) -> str:
-        self.get(vendor_id, item_id)  # ensure ownership before touching disk
+    def replace_photo(
+        self,
+        vendor_id: int,
+        item_id: int,
+        data: bytes,
+        *,
+        facility_id: int | None = None,
+    ) -> str:
+        self.get(vendor_id, item_id, facility_id=facility_id)  # ensure ownership before touching disk
         path = self.photo_storage.store_menu_photo(
             vendor_id=vendor_id, item_id=item_id, data=data
         )
@@ -86,8 +111,8 @@ class VendorMenuService:
         )
         return path
 
-    def delete_photo(self, vendor_id: int, item_id: int) -> None:
-        self.get(vendor_id, item_id)
+    def delete_photo(self, vendor_id: int, item_id: int, *, facility_id: int | None = None) -> None:
+        self.get(vendor_id, item_id, facility_id=facility_id)
         self.photo_storage.delete_menu_photo(vendor_id=vendor_id, item_id=item_id)
         self.menu_item_repository.clear_photo_path(vendor_id=vendor_id, item_id=item_id)
 
@@ -99,4 +124,14 @@ class VendorMenuService:
                 status_code=422,
                 code="validation_error",
                 detail="category_id does not belong to this vendor",
+            )
+
+    def _assert_facility_access(self, vendor_id: int, facility_id: int | None) -> None:
+        if facility_id is None or self.vendor_repository is None:
+            return
+        if not any(facility.id == facility_id for facility in self.vendor_repository.list_facilities(vendor_id)):
+            raise CodedHTTPException(
+                status_code=403,
+                code="forbidden",
+                detail="vendor does not serve the selected facility",
             )

--- a/backend/tests/test_vendor_menu.py
+++ b/backend/tests/test_vendor_menu.py
@@ -25,6 +25,8 @@ def _setup(tmp_path: Path) -> tuple[TestClient, MenuItemRepository, MenuCategory
     vendor_repo = VendorProfileRepository()
     vendor_repo.seed(VendorRecord(id=1, name="Alice", status="approved"))
     vendor_repo.seed(VendorRecord(id=2, name="Bob", status="approved"))
+    vendor_repo.assign_facility(1, facility_id=10, code="F10", name="Fab 10")
+    vendor_repo.assign_facility(2, facility_id=20, code="F20", name="Fab 20")
 
     cat_repo = MenuCategoryRepository()
     item_repo = MenuItemRepository()
@@ -84,6 +86,25 @@ def test_list_filters_by_category(tmp_path: Path) -> None:
     assert [i["name"] for i in listed] == ["Soup"]
 
 
+def test_list_accepts_served_facility_scope(tmp_path: Path) -> None:
+    client, item_repo, _ = _setup(tmp_path)
+    item_repo.create(vendor_id=1, name="Soup", price_cents=10)
+
+    resp = client.get("/vendor/me/menu?facility_id=10", headers=_h())
+
+    assert resp.status_code == 200
+    assert [item["name"] for item in resp.json()] == ["Soup"]
+
+
+def test_list_rejects_unserved_facility_scope(tmp_path: Path) -> None:
+    client, _, _ = _setup(tmp_path)
+
+    resp = client.get("/vendor/me/menu?facility_id=20", headers=_h())
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "forbidden"
+
+
 def test_cross_vendor_get_returns_404(tmp_path: Path) -> None:
     client, item_repo, _ = _setup(tmp_path)
     item = item_repo.create(vendor_id=1, name="A", price_cents=10)
@@ -99,6 +120,34 @@ def test_patch_partial_update(tmp_path: Path) -> None:
     body = resp.json()
     assert body["daily_quota"] == 0
     assert body["name"] == "A"
+
+
+def test_create_rejects_unserved_facility_scope(tmp_path: Path) -> None:
+    client, item_repo, _ = _setup(tmp_path)
+
+    resp = client.post(
+        "/vendor/me/menu?facility_id=20",
+        headers=_h(),
+        json={"name": "A", "price_cents": 10},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "forbidden"
+    assert item_repo.list(vendor_id=1) == []
+
+
+def test_patch_rejects_unserved_facility_scope(tmp_path: Path) -> None:
+    client, item_repo, _ = _setup(tmp_path)
+    item = item_repo.create(vendor_id=1, name="A", price_cents=10)
+
+    resp = client.patch(
+        f"/vendor/me/menu/{item.id}?facility_id=20",
+        headers=_h(),
+        json={"daily_quota": 0},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "forbidden"
 
 
 def test_delete_item(tmp_path: Path) -> None:
@@ -144,6 +193,21 @@ def test_put_photo_happy_path(tmp_path: Path) -> None:
     assert resp.json() == {"photo_path": f"vendors/1/menu/{item.id}.jpg"}
     assert (tmp_path / f"vendors/1/menu/{item.id}.jpg").exists()
     assert item_repo.get(vendor_id=1, item_id=item.id).photo_path == f"vendors/1/menu/{item.id}.jpg"
+
+
+def test_put_photo_rejects_unserved_facility_scope(tmp_path: Path) -> None:
+    client, item_repo, _ = _setup(tmp_path)
+    item = item_repo.create(vendor_id=1, name="A", price_cents=10)
+
+    resp = client.put(
+        f"/vendor/me/menu/{item.id}/photo?facility_id=20",
+        headers=_h(),
+        files={"file": ("photo.png", _png_bytes(), "image/png")},
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "forbidden"
+    assert item_repo.get(vendor_id=1, item_id=item.id).photo_path is None
 
 
 def test_put_photo_rejects_non_image(tmp_path: Path) -> None:

--- a/frontend/src/api/vendor.js
+++ b/frontend/src/api/vendor.js
@@ -6,9 +6,9 @@ function withMockFallback(apiCall, mockResult) {
   return apiCall().catch(() => mockResult);
 }
 
-export function getMyMenu() {
+export function getMyMenu({ facilityId } = {}) {
   return withMockFallback(
-    () => apiFetch("/vendor/me/menu"),
+    () => apiFetch(appendFacilityParam("/vendor/me/menu", facilityId)),
     (MOCK_MENU[1] ?? []).map((item) => ({
       ...item,
       created_at: new Date().toISOString(),
@@ -71,38 +71,38 @@ export function confirmPickup(orderId) {
   });
 }
 
-export function createMenuItem(data) {
-  return apiFetch("/vendor/me/menu", {
+export function createMenuItem(data, { facilityId } = {}) {
+  return apiFetch(appendFacilityParam("/vendor/me/menu", facilityId), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
 }
 
-export function updateMenuItem(itemId, data) {
-  return apiFetch(`/vendor/me/menu/${itemId}`, {
+export function updateMenuItem(itemId, data, { facilityId } = {}) {
+  return apiFetch(appendFacilityParam(`/vendor/me/menu/${itemId}`, facilityId), {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
 }
 
-export function deleteMenuItem(itemId) {
-  return apiFetch(`/vendor/me/menu/${itemId}`, { method: "DELETE" });
+export function deleteMenuItem(itemId, { facilityId } = {}) {
+  return apiFetch(appendFacilityParam(`/vendor/me/menu/${itemId}`, facilityId), { method: "DELETE" });
 }
 
-export function uploadMenuItemPhoto(itemId, file) {
+export function uploadMenuItemPhoto(itemId, file, { facilityId } = {}) {
   const form = new FormData();
   form.append("file", file);
   // Do NOT set Content-Type — browser sets multipart/form-data with boundary automatically.
-  return apiFetch(`/vendor/me/menu/${itemId}/photo`, {
+  return apiFetch(appendFacilityParam(`/vendor/me/menu/${itemId}/photo`, facilityId), {
     method: "PUT",
     body: form,
   });
 }
 
-export function deleteMenuItemPhoto(itemId) {
-  return apiFetch(`/vendor/me/menu/${itemId}/photo`, { method: "DELETE" });
+export function deleteMenuItemPhoto(itemId, { facilityId } = {}) {
+  return apiFetch(appendFacilityParam(`/vendor/me/menu/${itemId}/photo`, facilityId), { method: "DELETE" });
 }
 
 export function submitVendorApplication(data) {

--- a/frontend/src/vendor/VendorMenuContext.jsx
+++ b/frontend/src/vendor/VendorMenuContext.jsx
@@ -1,9 +1,11 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { createMenuItem, deleteMenuItem, deleteMenuItemPhoto, getMyMenu, updateMenuItem, uploadMenuItemPhoto } from "../api/vendor";
+import { useFacility } from "../facility/FacilityContext";
 
 const VendorMenuContext = createContext(null);
 
 export function VendorMenuProvider({ children }) {
+  const { selectedFacilityId } = useFacility();
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -12,27 +14,27 @@ export function VendorMenuProvider({ children }) {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getMyMenu()
+    getMyMenu({ facilityId: selectedFacilityId })
       .then((data) => { if (!cancelled) setItems(data); })
       .catch((err) => { if (!cancelled) setError(err); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, []);
+  }, [selectedFacilityId]);
 
   async function addItem(data) {
-    const newItem = await createMenuItem(data);
+    const newItem = await createMenuItem(data, { facilityId: selectedFacilityId });
     setItems((prev) => [...prev, newItem]);
     return newItem;
   }
 
   async function updateItem(id, data) {
-    const updated = await updateMenuItem(id, data);
+    const updated = await updateMenuItem(id, data, { facilityId: selectedFacilityId });
     setItems((prev) => prev.map((item) => (item.id === id ? updated : item)));
     return updated;
   }
 
   async function removeItem(id) {
-    await deleteMenuItem(id);
+    await deleteMenuItem(id, { facilityId: selectedFacilityId });
     setItems((prev) => prev.filter((item) => item.id !== id));
   }
 
@@ -41,7 +43,7 @@ export function VendorMenuProvider({ children }) {
   }
 
   async function uploadPhoto(id, file) {
-    const result = await uploadMenuItemPhoto(id, file);
+    const result = await uploadMenuItemPhoto(id, file, { facilityId: selectedFacilityId });
     setItems((prev) =>
       prev.map((item) =>
         item.id === id ? { ...item, photo_path: result.photo_path, _photo_v: Date.now() } : item,
@@ -51,7 +53,7 @@ export function VendorMenuProvider({ children }) {
   }
 
   async function removePhoto(id) {
-    await deleteMenuItemPhoto(id);
+    await deleteMenuItemPhoto(id, { facilityId: selectedFacilityId });
     setItems((prev) =>
       prev.map((item) => (item.id === id ? { ...item, photo_path: null } : item)),
     );


### PR DESCRIPTION
## Summary
- add `facility_id` query support to vendor menu list/create/get/update/delete and photo endpoints
- validate that the vendor serves the selected facility before allowing menu management operations
- pass the active topbar facility from `VendorMenuContext` through vendor menu API calls
- add regression coverage for served vs. unserved facility scopes on vendor menu operations

## Tests
- `pytest backend/tests/test_vendor_menu.py backend/tests/test_vendor_smoke.py --basetemp .tmp/pytest -o cache_dir=.tmp/pytest-cache`
- `pytest backend/tests/test_vendor_menu.py backend/tests/test_vendor_smoke.py backend/tests/test_vendor_orders.py backend/tests/test_vendor_revenue.py --basetemp .tmp/pytest -o cache_dir=.tmp/pytest-cache`
- `pytest backend/tests --basetemp .tmp/pytest -o cache_dir=.tmp/pytest-cache`
- `C:\Users\nol\.vscode-server\cli\servers\Stable-034f571df509819cc10b0c8129f66ef77a542f0e\server\node.exe --test src/api/facilityParams.test.js src/facility/facilitySelection.test.js`

Part of #70.