### PR TITLE
feat(auth): enforce is_active on employee routes + employee onboarding flow

### DIFF
--- a/backend/core/employee_identity.py
+++ b/backend/core/employee_identity.py
@@ -1,12 +1,38 @@
 """Employee identity dependencies for employee-facing ordering APIs."""
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Annotated
 
-from fastapi import Header, Request
+from fastapi import Depends, Header, Request
 
 from backend.core.errors import CodedHTTPException
 from backend.core.security import decode_access_token
+
+
+def _db_active_check(employee_id: int) -> None:
+    """Reject the request if the employee account is inactive in the database."""
+    from backend.db.connection import get_connection
+
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT is_active FROM users WHERE id = %s", (employee_id,)
+        ).fetchone()
+    if not row or not row["is_active"]:
+        raise CodedHTTPException(
+            status_code=403,
+            code="account_disabled",
+            detail="This account has been disabled",
+        )
+
+
+def get_employee_active_check() -> Callable[[int], None]:
+    """Injectable that returns the active-status checker.
+
+    Override via ``app.dependency_overrides`` in unit tests to avoid a live DB
+    connection while still exercising the route logic.
+    """
+    return _db_active_check
 
 
 def require_employee_role(
@@ -29,6 +55,7 @@ def require_employee(
     request: Request,
     x_user_role: Annotated[str | None, Header()] = None,
     x_user_id: Annotated[str | None, Header()] = None,
+    active_check: Annotated[Callable[[int], None], Depends(get_employee_active_check)] = ...,  # type: ignore[assignment]
 ) -> int:
     auth = request.headers.get("authorization", "")
     if auth.startswith("Bearer "):
@@ -36,7 +63,9 @@ def require_employee(
         if payload:
             if payload.get("role") != "employee":
                 raise CodedHTTPException(status_code=403, code="forbidden", detail="employee role required")
-            return int(payload["sub"])
+            employee_id = int(payload["sub"])
+            active_check(employee_id)
+            return employee_id
 
     # Header fallback (tests / mock login)
     if x_user_role != "employee":
@@ -44,6 +73,8 @@ def require_employee(
     if x_user_id is None:
         raise CodedHTTPException(status_code=400, code="validation_error", detail="x-user-id header missing")
     try:
-        return int(x_user_id)
+        employee_id = int(x_user_id)
     except ValueError as exc:
         raise CodedHTTPException(status_code=400, code="validation_error", detail="x-user-id must be integer") from exc
+    active_check(employee_id)
+    return employee_id

--- a/backend/routes/admin_users.py
+++ b/backend/routes/admin_users.py
@@ -11,7 +11,7 @@ from backend.schemas.admin import AdminUserItem, AdminUserListResponse
 router = APIRouter(prefix="/admin/users", tags=["admin-users"])
 
 
-def _fetch_users(search: str | None, role: str | None) -> list[dict]:
+def _fetch_users(search: str | None, role: str | None, is_active: bool | None) -> list[dict]:
     conditions = ["1=1"]
     params: list = []
 
@@ -23,6 +23,10 @@ def _fetch_users(search: str | None, role: str | None) -> list[dict]:
     if role:
         conditions.append("r.name = %s")
         params.append(role)
+
+    if is_active is not None:
+        conditions.append("u.is_active = %s")
+        params.append(is_active)
 
     where = " AND ".join(conditions)
     sql = f"""
@@ -42,8 +46,9 @@ def list_users(
     _role: Annotated[str, Depends(require_roles("admin"))],
     search: str | None = Query(default=None),
     role: str | None = Query(default=None),
+    is_active: bool | None = Query(default=None),
 ) -> AdminUserListResponse:
-    users = _fetch_users(search, role)
+    users = _fetch_users(search, role, is_active)
     return AdminUserListResponse(
         users=[AdminUserItem(**u) for u in users],
         total=len(users),

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -71,6 +71,7 @@ def login(payload: LoginRequest) -> TokenResponse:
         user_id=user["id"],
         role=user["role"],
         display_name=user["display_name"],
+        is_active=user["is_active"],
         vendor_id=user["vendor_id"],
     )
 
@@ -97,11 +98,14 @@ def register(payload: RegisterRequest) -> TokenResponse:
 
         row = conn.execute(
             """
-            INSERT INTO users (email, display_name, role_id, password_hash, badge_code)
+            INSERT INTO users (email, display_name, role_id, password_hash, badge_code, is_active)
             SELECT %s, %s, r.id, %s,
                    CASE WHEN r.name = 'employee'
                         THEN 'EMP-' || LPAD(nextval('employee_badge_seq')::text, 4, '0')
-                        ELSE NULL END
+                        ELSE NULL END,
+                   -- Employees start inactive and require admin approval before they can order.
+                   -- All other roles (vendor_manager, admin) are active immediately.
+                   CASE WHEN r.name = 'employee' THEN FALSE ELSE TRUE END
             FROM roles r
             WHERE r.name = %s
             RETURNING id, badge_code
@@ -116,6 +120,7 @@ def register(payload: RegisterRequest) -> TokenResponse:
         user_id=user["id"],
         role=user["role"],
         display_name=user["display_name"],
+        is_active=user["is_active"],
         vendor_id=None,
         badge_code=row["badge_code"],
     )

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -26,5 +26,6 @@ class TokenResponse(BaseModel):
     user_id: int
     role: str
     display_name: str
+    is_active: bool = True
     vendor_id: int | None = None
     badge_code: str | None = None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from prometheus_client import REGISTRY
 
 from backend.core.audit import get_audit_log_repository
+from backend.core.employee_identity import get_employee_active_check
 from backend.main import app
 from backend.repositories.audit_log_repository import AuditLogRepository
 
@@ -31,3 +32,18 @@ def _in_memory_audit_repo() -> Generator[None, None, None]:
     app.dependency_overrides.setdefault(get_audit_log_repository, lambda: AuditLogRepository())
     yield
     app.dependency_overrides.pop(get_audit_log_repository, None)
+
+
+@pytest.fixture(autouse=True)
+def _bypass_employee_active_check(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+    """Unit tests run without a DB — bypass the is_active DB check in require_employee.
+
+    Integration tests (marked with ``pytest.mark.integration``) skip this so
+    the real check runs against Postgres.
+    """
+    if request.node.get_closest_marker("integration"):
+        yield
+        return
+    app.dependency_overrides.setdefault(get_employee_active_check, lambda: (lambda _: None))
+    yield
+    app.dependency_overrides.pop(get_employee_active_check, None)

--- a/backend/tests/integration/test_employee_active_db.py
+++ b/backend/tests/integration/test_employee_active_db.py
@@ -1,0 +1,113 @@
+"""Integration test: disabled employee is rejected by /employee/* endpoints.
+
+Requires a live PostgreSQL database (DATABASE_URL env var).
+
+    DATABASE_URL=postgresql://... pytest backend/tests/integration/test_employee_active_db.py -v
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.core.security import create_access_token, hash_password
+from backend.db.connection import get_connection
+from backend.main import app
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def client():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("DATABASE_URL not set")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def disabled_employee_id():
+    """Insert a disabled employee, yield their id, then clean up."""
+    with get_connection() as conn:
+        row = conn.execute(
+            """
+            INSERT INTO users (email, display_name, role_id, password_hash, is_active)
+            SELECT 'disabled.emp@test.local', 'Disabled Emp', r.id, %s, FALSE
+            FROM roles r WHERE r.name = 'employee'
+            RETURNING id
+            """,
+            (hash_password("testpass123"),),
+        ).fetchone()
+        conn.commit()
+        user_id = row["id"]
+
+    yield user_id
+
+    with get_connection() as conn:
+        conn.execute("DELETE FROM users WHERE id = %s", (user_id,))
+        conn.commit()
+
+
+@pytest.fixture()
+def active_employee_id():
+    """Insert an active employee, yield their id, then clean up."""
+    with get_connection() as conn:
+        row = conn.execute(
+            """
+            INSERT INTO users (email, display_name, role_id, password_hash, is_active)
+            SELECT 'active.emp@test.local', 'Active Emp', r.id, %s, TRUE
+            FROM roles r WHERE r.name = 'employee'
+            RETURNING id
+            """,
+            (hash_password("testpass123"),),
+        ).fetchone()
+        conn.commit()
+        user_id = row["id"]
+
+    yield user_id
+
+    with get_connection() as conn:
+        conn.execute("DELETE FROM users WHERE id = %s", (user_id,))
+        conn.commit()
+
+
+def _jwt_headers(user_id: int) -> dict[str, str]:
+    token = create_access_token({"sub": str(user_id), "role": "employee"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Disabled employee is rejected
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_employee_cannot_browse_vendors(client, disabled_employee_id):
+    resp = client.get("/employee/vendors", headers=_jwt_headers(disabled_employee_id))
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["code"] == "account_disabled"
+
+
+def test_disabled_employee_cannot_place_order(client, disabled_employee_id):
+    resp = client.post(
+        "/employee/vendors/1/orders",
+        json={"meal_date": "2099-01-01", "items": [{"menu_item_id": 1, "quantity": 1}]},
+        headers=_jwt_headers(disabled_employee_id),
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "account_disabled"
+
+
+# ---------------------------------------------------------------------------
+# Active employee still works (regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_active_employee_can_browse_vendors(client, active_employee_id):
+    resp = client.get("/employee/vendors", headers=_jwt_headers(active_employee_id))
+
+    # 200 OK (list may be empty in test DB — that's fine)
+    assert resp.status_code == 200

--- a/backend/tests/integration/test_employee_onboarding_db.py
+++ b/backend/tests/integration/test_employee_onboarding_db.py
@@ -1,0 +1,150 @@
+"""Integration test: employee onboarding flow against a real PostgreSQL database.
+
+Flow: register → is_active=False → login blocked → admin enables → login works → employee routes work.
+
+    DATABASE_URL=postgresql://... pytest backend/tests/integration/test_employee_onboarding_db.py -v
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.core.security import create_access_token, hash_password
+from backend.db.connection import get_connection
+from backend.main import app
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def client():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("DATABASE_URL not set")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def admin_headers():
+    """JWT for the seeded admin account."""
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT id FROM users WHERE email = 'admin@corpmeal.local'"
+        ).fetchone()
+    assert row, "admin@corpmeal.local not found — did migrations run?"
+    token = create_access_token({"sub": str(row["id"]), "role": "admin"})
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def registered_employee(client):
+    """Register a new employee and yield their (user_id, jwt_headers). Clean up after test."""
+    resp = client.post(
+        "/auth/register",
+        json={
+            "email": "onboarding.test@corpmeal.local",
+            "password": "testpass123",
+            "display_name": "Onboarding Test",
+            "role": "employee",
+        },
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    user_id = body["user_id"]
+    token = body["access_token"]
+
+    yield user_id, {"Authorization": f"Bearer {token}"}
+
+    with get_connection() as conn:
+        conn.execute("DELETE FROM users WHERE id = %s", (user_id,))
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_employee_register_returns_is_active_false(client):
+    """Newly registered employee should have is_active=False in the response."""
+    resp = client.post(
+        "/auth/register",
+        json={
+            "email": "onboarding.check@corpmeal.local",
+            "password": "testpass123",
+            "display_name": "Check User",
+            "role": "employee",
+        },
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["is_active"] is False
+
+    # cleanup
+    with get_connection() as conn:
+        conn.execute("DELETE FROM users WHERE id = %s", (body["user_id"],))
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Pre-approval: employee is blocked
+# ---------------------------------------------------------------------------
+
+
+def test_pending_employee_login_is_blocked(client, registered_employee):
+    user_id, _ = registered_employee
+    resp = client.post(
+        "/auth/login",
+        json={"email": "onboarding.test@corpmeal.local", "password": "testpass123"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "account_disabled"
+
+
+def test_pending_employee_cannot_browse_vendors(client, registered_employee):
+    _, headers = registered_employee
+    resp = client.get("/employee/vendors", headers=headers)
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "account_disabled"
+
+
+# ---------------------------------------------------------------------------
+# Admin approves the employee
+# ---------------------------------------------------------------------------
+
+
+def test_admin_can_see_pending_employee(client, admin_headers, registered_employee):
+    user_id, _ = registered_employee
+    resp = client.get("/admin/users?role=employee&is_active=false", headers=admin_headers)
+    assert resp.status_code == 200
+    ids = [u["id"] for u in resp.json()["users"]]
+    assert user_id in ids
+
+
+def test_full_onboarding_flow(client, admin_headers, registered_employee):
+    """register → blocked → admin enables → can login and browse."""
+    user_id, headers = registered_employee
+
+    # Step 1: blocked before approval
+    resp = client.get("/employee/vendors", headers=headers)
+    assert resp.status_code == 403
+
+    # Step 2: admin enables
+    resp = client.patch(f"/admin/users/{user_id}/enable", headers=admin_headers)
+    assert resp.status_code == 200
+    assert resp.json()["is_active"] is True
+
+    # Step 3: employee can now login
+    resp = client.post(
+        "/auth/login",
+        json={"email": "onboarding.test@corpmeal.local", "password": "testpass123"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["is_active"] is True
+
+    # Step 4: employee can access ordering routes
+    new_token = resp.json()["access_token"]
+    resp = client.get("/employee/vendors", headers={"Authorization": f"Bearer {new_token}"})
+    assert resp.status_code == 200

--- a/backend/tests/test_admin_users.py
+++ b/backend/tests/test_admin_users.py
@@ -126,6 +126,32 @@ def test_list_users_role_filter_param_is_forwarded() -> None:
     assert resp.json()["users"][0]["role"] == "vendor_manager"
 
 
+def test_list_users_is_active_false_filter_returns_pending_employees() -> None:
+    """?is_active=false should surface employees awaiting admin approval."""
+    rows = [_make_user_row(is_active=False)]
+    with patch("backend.routes.admin_users.get_connection", return_value=_list_conn(rows)) as mock_conn:
+        resp = client.get("/admin/users?is_active=false", headers=_ADMIN_HEADERS)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["users"][0]["is_active"] is False
+    execute_call = mock_conn.return_value.__enter__.return_value.execute.call_args
+    assert "u.is_active = %s" in execute_call.args[0]
+    assert False in execute_call.args[1]
+
+
+def test_list_users_is_active_true_filter_excludes_pending() -> None:
+    rows = [_make_user_row(is_active=True)]
+    with patch("backend.routes.admin_users.get_connection", return_value=_list_conn(rows)) as mock_conn:
+        resp = client.get("/admin/users?is_active=true", headers=_ADMIN_HEADERS)
+
+    assert resp.status_code == 200
+    execute_call = mock_conn.return_value.__enter__.return_value.execute.call_args
+    assert "u.is_active = %s" in execute_call.args[0]
+    assert True in execute_call.args[1]
+
+
 # ---------------------------------------------------------------------------
 # PATCH /admin/users/{id}/disable
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -103,7 +103,10 @@ def test_login_unknown_email_returns_401_invalid_credentials() -> None:
 
 @pytest.mark.parametrize("role", ["employee", "vendor_manager"])
 def test_register_new_user_returns_201_with_token(role: str) -> None:
-    registered_user = _user(role=role)
+    # _fetch_user returns what was actually written to the DB:
+    # employee → is_active=False (pending approval); vendor_manager → is_active=True
+    is_active = role != "employee"
+    registered_user = _user(role=role, is_active=is_active)
     with (
         patch("backend.routes.auth.get_connection", return_value=_conn_ctx()),
         patch("backend.routes.auth._fetch_user", return_value=registered_user),
@@ -118,6 +121,41 @@ def test_register_new_user_returns_201_with_token(role: str) -> None:
     assert "access_token" in body
     assert body["role"] == role
     assert body["user_id"] == 1
+    assert body["is_active"] is is_active
+
+
+def test_register_employee_starts_inactive() -> None:
+    """Newly registered employees must be inactive until an admin enables them."""
+    registered_user = _user(role="employee", is_active=False)
+    with (
+        patch("backend.routes.auth.get_connection", return_value=_conn_ctx(badge_code="EMP-0001")),
+        patch("backend.routes.auth._fetch_user", return_value=registered_user),
+    ):
+        resp = client.post(
+            "/auth/register",
+            json={"email": "new.emp@example.com", "password": _PASSWORD, "display_name": "New Emp", "role": "employee"},
+        )
+
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["is_active"] is False
+    assert body["badge_code"] == "EMP-0001"
+
+
+def test_register_vendor_manager_starts_active() -> None:
+    """Vendor managers are active on registration (vendor approval is a separate step)."""
+    registered_user = _user(role="vendor_manager", is_active=True)
+    with (
+        patch("backend.routes.auth.get_connection", return_value=_conn_ctx()),
+        patch("backend.routes.auth._fetch_user", return_value=registered_user),
+    ):
+        resp = client.post(
+            "/auth/register",
+            json={"email": "new.vendor@example.com", "password": _PASSWORD, "display_name": "New Vendor", "role": "vendor_manager"},
+        )
+
+    assert resp.status_code == 201
+    assert resp.json()["is_active"] is True
 
 
 def test_register_existing_email_returns_409_email_taken() -> None:

--- a/backend/tests/test_employee_active.py
+++ b/backend/tests/test_employee_active.py
@@ -1,0 +1,117 @@
+"""Unit tests for the is_active enforcement in require_employee.
+
+These tests override ``get_employee_active_check`` explicitly (instead of relying
+on the autouse bypass) to verify the guard itself — simulating both active and
+disabled employees without a real database connection.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from backend.core.employee_identity import get_employee_active_check
+from backend.core.errors import CodedHTTPException
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+
+
+def _setup_vendor_repo() -> None:
+    vendor_repo = VendorProfileRepository()
+    vendor_repo.seed(
+        VendorRecord(
+            id=1,
+            name="Test Bento",
+            status="approved",
+            address="No. 1",
+            business_hours="11:00-14:00",
+            contact_phone="0912-000-000",
+            contact_email="test@example.com",
+        )
+    )
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
+
+
+def _h(user_id: int = 42) -> dict[str, str]:
+    return {"x-user-role": "employee", "x-user-id": str(user_id)}
+
+
+def teardown_function() -> None:
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Active employee passes through
+# ---------------------------------------------------------------------------
+
+
+def test_active_employee_can_access_endpoint() -> None:
+    _setup_vendor_repo()
+    # Override: simulate an active employee (no-op check)
+    app.dependency_overrides[get_employee_active_check] = lambda: (lambda _: None)
+
+    client = TestClient(app)
+    resp = client.get("/employee/vendors", headers=_h())
+
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Disabled employee is rejected
+# ---------------------------------------------------------------------------
+
+
+def _raise_disabled(employee_id: int) -> None:
+    raise CodedHTTPException(
+        status_code=403,
+        code="account_disabled",
+        detail="This account has been disabled",
+    )
+
+
+def test_disabled_employee_gets_403_on_browse() -> None:
+    _setup_vendor_repo()
+    app.dependency_overrides[get_employee_active_check] = lambda: _raise_disabled
+
+    client = TestClient(app)
+    resp = client.get("/employee/vendors", headers=_h())
+
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body["code"] == "account_disabled"
+
+
+def test_disabled_employee_gets_403_on_order() -> None:
+    from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+    from backend.repositories.menu_item_repository import MenuItemRepository
+    from backend.routes.employee_ordering import get_employee_selection_repository
+    from backend.routes.vendor_menu import get_menu_item_repository
+
+    _setup_vendor_repo()
+    app.dependency_overrides[get_menu_item_repository] = lambda: MenuItemRepository()
+    app.dependency_overrides[get_employee_selection_repository] = lambda: EmployeeSelectionRepository()
+    app.dependency_overrides[get_employee_active_check] = lambda: _raise_disabled
+
+    client = TestClient(app)
+    resp = client.post(
+        "/employee/vendors/1/orders",
+        json={"meal_date": "2099-01-01", "items": [{"menu_item_id": 1, "quantity": 1}]},
+        headers=_h(),
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["code"] == "account_disabled"
+
+
+# ---------------------------------------------------------------------------
+# Non-employee role is still rejected (regression)
+# ---------------------------------------------------------------------------
+
+
+def test_non_employee_role_still_rejected() -> None:
+    _setup_vendor_repo()
+    app.dependency_overrides[get_employee_active_check] = lambda: (lambda _: None)
+
+    client = TestClient(app)
+    resp = client.get("/employee/vendors", headers={"x-user-role": "vendor_manager", "x-user-id": "1"})
+
+    assert resp.status_code == 403

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -1,9 +1,10 @@
 import { apiFetch } from "./client";
 
-export function getUsers({ search, role } = {}) {
+export function getUsers({ search, role, is_active } = {}) {
   const params = new URLSearchParams();
   if (search) params.set("search", search);
   if (role) params.set("role", role);
+  if (is_active !== undefined && is_active !== null) params.set("is_active", String(is_active));
   const qs = params.toString();
   return apiFetch(`/admin/users${qs ? `?${qs}` : ""}`);
 }

--- a/frontend/src/auth/AuthContext.jsx
+++ b/frontend/src/auth/AuthContext.jsx
@@ -59,10 +59,15 @@ export function AuthProvider({ children }) {
           title: mockRef?.title ?? data.role,
           email,
           vendorId: data.vendor_id ?? null,
+          isActive: data.is_active ?? true,
         };
-        const nextSession = { user, token: data.access_token };
-        writeStoredSession(nextSession);
-        setSession(nextSession);
+        // Inactive employees (pending admin approval) must not receive a session —
+        // all /employee/* routes would 403 anyway.
+        if (user.isActive) {
+          const nextSession = { user, token: data.access_token };
+          writeStoredSession(nextSession);
+          setSession(nextSession);
+        }
         return user;
       },
 

--- a/frontend/src/layout/navigation.js
+++ b/frontend/src/layout/navigation.js
@@ -23,6 +23,7 @@ export const navigationByRole = {
   ],
   admin: [
     { label: "統計儀表板", to: "/admin/stats" },
+    { label: "員工審核", to: "/admin/employees" },
     { label: "商家審核", to: "/admin/vendors" },
     { label: "廠區管理", to: "/admin/facilities" },
     { label: "權限管理", to: "/admin/permissions" },

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -31,6 +31,8 @@ export default function LoginPage() {
       setError(
         err.code === "invalid_credentials"
           ? "Invalid email or password."
+          : err.code === "account_disabled"
+          ? "Your account is pending admin approval. Please contact your administrator."
           : "Login failed. Please try again.",
       );
     } finally {

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -8,6 +8,86 @@ const ROLE_OPTIONS = [
   { value: "vendor_manager", label: "Vendor Manager", desc: "Manage your restaurant and menu" },
 ];
 
+function PendingApprovalScreen({ displayName }) {
+  return (
+    <div className="login-shell">
+      <section className="hero-panel">
+        <p className="eyebrow">Corporate Meal Ordering System</p>
+        <h1>Account created — one step away.</h1>
+        <p className="hero-copy">
+          Employee accounts require admin approval before you can browse
+          menus and place orders. Your administrator will review your
+          request shortly.
+        </p>
+        <div className="hero-grid">
+          <article className="metric-card">
+            <strong>Step 1 ✓</strong>
+            <span>Account registered</span>
+          </article>
+          <article className="metric-card">
+            <strong>Step 2 ⏳</strong>
+            <span>Admin approval pending</span>
+          </article>
+        </div>
+      </section>
+
+      <section className="login-panel">
+        <div>
+          <p className="eyebrow">Pending Approval</p>
+          <h2>Hi {displayName}, you're almost in!</h2>
+        </div>
+
+        <div style={{ display: "grid", gap: 16 }}>
+          <div
+            style={{
+              padding: "20px 24px",
+              borderRadius: "var(--radius-md)",
+              background: "rgba(47, 125, 74, 0.08)",
+              border: "1px solid rgba(47, 125, 74, 0.25)",
+              display: "grid",
+              gap: 8,
+            }}
+          >
+            <p style={{ margin: 0, fontWeight: 700, color: "var(--success)", fontSize: 15 }}>
+              ✓ Account created successfully
+            </p>
+            <p style={{ margin: 0, fontSize: 13, color: "var(--text)", lineHeight: 1.6 }}>
+              Your employee account has been registered and is now awaiting
+              admin activation. You won't be able to sign in until an
+              administrator approves your account.
+            </p>
+          </div>
+
+          <div
+            style={{
+              padding: "16px 20px",
+              borderRadius: "var(--radius-md)",
+              background: "var(--surface-alt, rgba(0,0,0,0.04))",
+              fontSize: 13,
+              color: "var(--muted)",
+              lineHeight: 1.7,
+            }}
+          >
+            <strong style={{ color: "var(--text)", display: "block", marginBottom: 4 }}>
+              What happens next?
+            </strong>
+            An admin will review your registration and activate your account.
+            Once approved, you can sign in with the email and password you
+            just set.
+          </div>
+        </div>
+
+        <p style={{ marginTop: 24, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
+          Already approved?{" "}
+          <Link to="/login" style={{ color: "var(--accent)", fontWeight: 600 }}>
+            Sign in
+          </Link>
+        </p>
+      </section>
+    </div>
+  );
+}
+
 export default function RegisterPage() {
   const navigate = useNavigate();
   const { isAuthenticated, user, register } = useAuth();
@@ -19,9 +99,14 @@ export default function RegisterPage() {
   const [confirm, setConfirm]         = useState("");
   const [error, setError]             = useState(null);
   const [loading, setLoading]         = useState(false);
+  const [pendingName, setPendingName] = useState(null);  // non-null → show pending screen
 
   if (isAuthenticated && user) {
     return <Navigate replace to={roleHomePath[user.role] ?? "/"} />;
+  }
+
+  if (pendingName !== null) {
+    return <PendingApprovalScreen displayName={pendingName} />;
   }
 
   async function handleSubmit(e) {
@@ -40,7 +125,13 @@ export default function RegisterPage() {
     setLoading(true);
     try {
       const u = await register(email, password, displayName, role);
-      navigate(roleHomePath[u.role] ?? "/", { replace: true });
+      if (!u.isActive) {
+        // Employee accounts start inactive — show the pending approval screen
+        // instead of navigating into the app (all API calls would 403 anyway).
+        setPendingName(u.name);
+      } else {
+        navigate(roleHomePath[u.role] ?? "/", { replace: true });
+      }
     } catch (err) {
       setError(
         err.code === "email_taken"

--- a/frontend/src/pages/admin/AdminEmployeeReviewPage.jsx
+++ b/frontend/src/pages/admin/AdminEmployeeReviewPage.jsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from "react";
+import { deleteUser, enableUser, getUsers } from "../../api/admin";
+
+const TABS = [
+  { label: "待審核", is_active: false },
+  { label: "已啟用", is_active: true },
+];
+
+function formatDate(iso) {
+  return new Date(iso).toLocaleDateString("zh-TW");
+}
+
+function btnStyle(variant) {
+  const base = {
+    padding: "5px 14px",
+    borderRadius: "var(--radius-md)",
+    border: "none",
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: "pointer",
+  };
+  if (variant === "approve") {
+    return { ...base, background: "rgba(47,125,74,0.15)", color: "var(--success)" };
+  }
+  if (variant === "reject") {
+    return { ...base, background: "rgba(200,92,44,0.12)", color: "var(--brand)" };
+  }
+  return { ...base, background: "var(--line)", color: "var(--text)" };
+}
+
+const GRID_COLS = "1fr 200px 110px 110px 180px";
+
+export default function AdminEmployeeReviewPage() {
+  const [tab, setTab]           = useState(0);   // 0 = 待審核, 1 = 已啟用
+  const [employees, setEmployees] = useState([]);
+  const [loading, setLoading]   = useState(true);
+  const [error, setError]       = useState(null);
+  const [actionError, setActionError] = useState(null);
+  const [busy, setBusy]         = useState(null);  // user_id of in-flight action
+
+  const isActive = TABS[tab].is_active;
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setEmployees([]);
+    getUsers({ role: "employee", is_active: isActive })
+      .then((data) => setEmployees(data.users))
+      .catch((err) => setError(err.message ?? "無法載入員工列表"))
+      .finally(() => setLoading(false));
+  }, [isActive]);
+
+  async function handleApprove(userId) {
+    setBusy(userId);
+    setActionError(null);
+    try {
+      await enableUser(userId);
+      setEmployees((prev) => prev.filter((u) => u.id !== userId));
+    } catch (err) {
+      setActionError(err.message ?? "核准失敗");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleReject(userId, displayName) {
+    if (!window.confirm(`確定要拒絕並刪除「${displayName}」的申請？此操作無法復原。`)) return;
+    setBusy(userId);
+    setActionError(null);
+    try {
+      await deleteUser(userId);
+      setEmployees((prev) => prev.filter((u) => u.id !== userId));
+    } catch (err) {
+      setActionError(err.message ?? "拒絕失敗");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div>
+      <div className="page-header">
+        <p className="eyebrow">Admin · Employee Review</p>
+        <h2>員工帳號審核</h2>
+      </div>
+
+      <div className="filter-bar" style={{ marginBottom: 20 }}>
+        {TABS.map((t, i) => (
+          <button
+            key={t.label}
+            type="button"
+            className={`filter-pill${tab === i ? " filter-pill-active" : ""}`}
+            onClick={() => { setTab(i); setActionError(null); }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {actionError && (
+        <p style={{ color: "var(--brand)", marginBottom: 12, fontSize: 14 }}>{actionError}</p>
+      )}
+
+      {loading && <p className="loading-state">載入中...</p>}
+      {error   && <p className="error-state">{error}</p>}
+
+      {!loading && !error && employees.length === 0 && (
+        <p className="empty-state">
+          {isActive ? "目前沒有已啟用的員工帳號。" : "目前沒有待審核的員工申請。"}
+        </p>
+      )}
+
+      {!loading && !error && employees.length > 0 && (
+        <div className="panel" style={{ padding: 0, overflowX: "auto" }}>
+          {/* Header */}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: GRID_COLS,
+              minWidth: 700,
+              padding: "10px 20px",
+              borderBottom: "1px solid var(--line)",
+              color: "var(--muted)",
+              fontSize: 12,
+              fontWeight: 600,
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+            }}
+          >
+            <span>員工</span>
+            <span>Email</span>
+            <span style={{ textAlign: "center" }}>工牌代碼</span>
+            <span style={{ textAlign: "center" }}>申請日期</span>
+            <span style={{ textAlign: "right" }}>操作</span>
+          </div>
+
+          {employees.map((emp, idx) => (
+            <div
+              key={emp.id}
+              style={{
+                display: "grid",
+                gridTemplateColumns: GRID_COLS,
+                minWidth: 700,
+                alignItems: "center",
+                padding: "14px 20px",
+                borderBottom: idx < employees.length - 1 ? "1px solid var(--line)" : "none",
+              }}
+            >
+              <div>
+                <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>{emp.display_name}</p>
+                <p style={{ margin: "2px 0 0", fontSize: 12, color: "var(--muted)" }}>
+                  ID #{emp.id}
+                </p>
+              </div>
+
+              <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>{emp.email}</p>
+
+              <p style={{ margin: 0, fontSize: 13, textAlign: "center", fontFamily: "monospace" }}>
+                {emp.badge_code ?? "—"}
+              </p>
+
+              <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
+                {formatDate(emp.created_at)}
+              </p>
+
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+                {!isActive && (
+                  <>
+                    <button
+                      type="button"
+                      disabled={busy === emp.id}
+                      onClick={() => handleApprove(emp.id)}
+                      style={btnStyle("approve")}
+                    >
+                      核准
+                    </button>
+                    <button
+                      type="button"
+                      disabled={busy === emp.id}
+                      onClick={() => handleReject(emp.id, emp.display_name)}
+                      style={btnStyle("reject")}
+                    >
+                      拒絕
+                    </button>
+                  </>
+                )}
+                {isActive && (
+                  <span style={{ fontSize: 12, color: "var(--success)", fontWeight: 600 }}>
+                    ✓ 已啟用
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -7,6 +7,7 @@ import AdminFacilitiesPage from "../pages/admin/AdminFacilitiesPage";
 import AdminBillingPage from "../pages/admin/AdminBillingPage";
 import AdminStatsPage from "../pages/admin/AdminStatsPage";
 import AdminPermissionsPage from "../pages/admin/AdminPermissionsPage";
+import AdminEmployeeReviewPage from "../pages/admin/AdminEmployeeReviewPage";
 import AdminVendorReviewDetailPage from "../pages/admin/AdminVendorReviewDetailPage";
 import AdminVendorReviewListPage from "../pages/admin/AdminVendorReviewListPage";
 import AccountPage from "../pages/employee/AccountPage";
@@ -102,6 +103,7 @@ export function AppRouter() {
 
           <Route element={<RoleRoute allowedRoles={["admin"]} />}>
             <Route element={<Navigate replace to="/admin/stats" />} path="/admin" />
+            <Route element={<AdminEmployeeReviewPage />} path="/admin/employees" />
             <Route element={<AdminVendorReviewListPage />} path="/admin/vendors" />
             <Route element={<AdminVendorReviewDetailPage />} path="/admin/vendors/:applicationId" />
             <Route element={<AdminPermissionsPage />} path="/admin/permissions" />


### PR DESCRIPTION
## Problem

`require_employee` only checked the role claim, never `is_active`. After an admin disabled an employee account, only `/auth/login` blocked them — any existing JWT or session headers still granted full access to every `/employee/*` ordering API.

Additionally, after registering, employee accounts had no clear indication that they were pending admin approval — the frontend silently dropped them onto the employee home page (which would 403 on every API call).

Relates to #129.

## Changes

### Backend

#### `backend/core/employee_identity.py`
- Add `_db_active_check(employee_id)`: queries `users.is_active` and raises `403 account_disabled` when false
- Add `get_employee_active_check()`: injectable dependency so tests can swap it out via `app.dependency_overrides` without a live DB
- Update `require_employee`: both the JWT path and the header fallback now call `active_check(employee_id)` after extracting the user id

#### `backend/routes/auth.py`
- `register`: employees now inserted with `is_active = FALSE`; all other roles remain `TRUE`
- `login` / `register`: `TokenResponse` now includes `is_active`

#### `backend/tests/conftest.py`
- Add autouse fixture `_bypass_employee_active_check`
  - Unit tests: installs a no-op bypass — all existing tests continue to pass
  - Tests marked `pytest.mark.integration`: skip the bypass so the real DB check runs

#### New tests
- `test_employee_active.py` (unit): active employee passes / disabled employee gets 403 on browse and order / non-employee role still rejected (regression)
- `tests/integration/test_employee_active_db.py` (integration): creates a disabled employee in a real DB, asserts 403 on browse and order; active employee still gets 200
- `tests/integration/test_employee_onboarding_db.py` (integration): register → inactive → admin enables → login succeeds

### Frontend

#### Registration UX (`RegisterPage.jsx`, `AuthContext.jsx`)
- `AuthContext.register()`: stores `is_active` on the user object; skips `writeStoredSession` / `setSession` for inactive users (no point holding a session that 403s everywhere)
- `RegisterPage`: after registration, checks `u.isActive`; if `false`, renders an inline `<PendingApprovalScreen>` with a two-step progress card instead of navigating into the app

#### Login UX (`LoginPage.jsx`)
- Handles `account_disabled` error code with an explicit message — _"Your account is pending admin approval. Please contact your administrator."_ — instead of the generic fallback

#### Admin employee review (`AdminEmployeeReviewPage.jsx`)
- New page at `/admin/employees`, mirroring the vendor review workflow
- Two-tab layout: **待審核** (`is_active=false`) / **已啟用** (`is_active=true`)
- **核准** → `PATCH /admin/users/{id}/enable`; **拒絕** → `DELETE /admin/users/{id}` (with confirm dialog)
- `api/admin.js`: `getUsers()` extended with `is_active` filter
- `router/index.jsx`: `/admin/employees` registered under the admin `RoleRoute`
- `navigation.js`: _員工審核_ added to the admin nav (before _商家審核_)

## Acceptance Criteria (from #129)

- [x] Disabled employee is rejected by `/employee/*` endpoints (not only by login)
- [x] Employee registration creates an inactive account pending admin approval
- [x] Employee sees a clear "pending approval" screen immediately after registration
- [x] Inactive employee attempting login gets a descriptive error message
- [x] Admin has a dedicated review page to approve or reject pending employee accounts
