### PR TITLE
feat(employee): add order history range

### DIFF
--- a/backend/repositories/employee_selection_repository.py
+++ b/backend/repositories/employee_selection_repository.py
@@ -118,8 +118,18 @@ class EmployeeSelectionRepository:
 
         return self._order_to_schema(order)
 
-    def list_orders(self, *, employee_id: int) -> list[EmployeeOrder]:
+    def list_orders(
+        self,
+        *,
+        employee_id: int,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> list[EmployeeOrder]:
         rows = [r for r in self._orders.values() if r.employee_id == employee_id]
+        if start_date is not None:
+            rows = [r for r in rows if (r.meal_date or r.created_at.date()) >= start_date]
+        if end_date is not None:
+            rows = [r for r in rows if (r.meal_date or r.created_at.date()) <= end_date]
         rows.sort(key=lambda r: r.id)
         return [self._order_to_schema(r) for r in rows]
 

--- a/backend/repositories/postgres_employee_selection_repository.py
+++ b/backend/repositories/postgres_employee_selection_repository.py
@@ -401,18 +401,33 @@ class PostgresEmployeeSelectionRepository:
             ).fetchall()
         return [_selection_to_schema(r) for r in rows]
 
-    def list_orders(self, *, employee_id: int) -> list[EmployeeOrder]:
+    def list_orders(
+        self,
+        *,
+        employee_id: int,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> list[EmployeeOrder]:
+        where = ["employee_id = %s"]
+        values: list[object] = [employee_id]
+        if start_date is not None:
+            where.append("COALESCE(meal_date, created_at::date) >= %s")
+            values.append(start_date)
+        if end_date is not None:
+            where.append("COALESCE(meal_date, created_at::date) <= %s")
+            values.append(end_date)
+
         with get_connection() as conn:
             order_rows = conn.execute(
-                """
+                f"""
                 SELECT id, employee_id, vendor_id, facility_id, meal_date, status,
                        total_price_cents, pickup_code, pickup_confirmed_at,
                        pickup_confirmed_by_user_id, created_at, updated_at, cancelled_at
                 FROM orders
-                WHERE employee_id = %s
+                WHERE {" AND ".join(where)}
                 ORDER BY id
                 """,
-                (employee_id,),
+                values,
             ).fetchall()
             return [self._hydrate_order(conn, row) for row in order_rows]
 

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -179,8 +179,10 @@ def list_my_selections(
 def list_my_orders(
     employee_id: Annotated[int, Depends(require_employee)],
     service: Annotated[EmployeeOrderingService, Depends(get_employee_ordering_service)],
+    start_date: Annotated[date | None, Query()] = None,
+    end_date: Annotated[date | None, Query()] = None,
 ) -> list[EmployeeOrder]:
-    return service.list_my_orders(employee_id)
+    return service.list_my_orders(employee_id, start_date=start_date, end_date=end_date)
 
 
 @router.get("/me/orders/{order_id}", response_model=EmployeeOrder)

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -29,6 +29,7 @@ from backend.schemas.employee import (
 from backend.schemas.vendor_self import Facility, MenuItem as VendorMenuItem
 
 MEAL_DATE_WINDOW_DAYS = 7
+ORDER_HISTORY_PAST_DAYS = 30
 
 
 class EmployeeOrderingService:
@@ -308,8 +309,34 @@ class EmployeeOrderingService:
 
         return results
 
-    def list_my_orders(self, employee_id: int) -> list[EmployeeOrder]:
-        return self.selection_repository.list_orders(employee_id=employee_id)
+    def list_my_orders(
+        self,
+        employee_id: int,
+        *,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> list[EmployeeOrder]:
+        today = date.today()
+        min_date = today - timedelta(days=ORDER_HISTORY_PAST_DAYS)
+        max_date = today + timedelta(days=MEAL_DATE_WINDOW_DAYS - 1)
+
+        if start_date is not None and end_date is not None and start_date > end_date:
+            raise CodedHTTPException(
+                status_code=400,
+                code="validation_error",
+                detail="start_date must be on or before end_date",
+            )
+
+        effective_start = max(start_date or min_date, min_date)
+        effective_end = min(end_date or max_date, max_date)
+        if effective_start > effective_end:
+            return []
+
+        return self.selection_repository.list_orders(
+            employee_id=employee_id,
+            start_date=effective_start,
+            end_date=effective_end,
+        )
 
     def get_my_order(self, employee_id: int, order_id: int) -> EmployeeOrder:
         order = self.selection_repository.get_order(employee_id=employee_id, order_id=order_id)

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -274,6 +274,24 @@ def test_my_orders_rejects_inverted_date_range() -> None:
     assert resp.json()["code"] == "validation_error"
 
 
+def test_my_orders_returns_empty_when_requested_range_is_outside_allowed_window() -> None:
+    client, _, selection_repo = _setup()
+    today = date.today()
+    selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=today)
+
+    resp = client.get(
+        "/employee/me/orders",
+        headers=_h(100),
+        params={
+            "start_date": (today + timedelta(days=7)).isoformat(),
+            "end_date": (today + timedelta(days=7)).isoformat(),
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
 def test_cancel_pending_order_marks_order_cancelled() -> None:
     client, item_repo, _ = _setup()
     item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -213,6 +213,67 @@ def test_my_orders_are_scoped_by_employee() -> None:
     assert resp.json() == []
 
 
+def test_my_orders_default_to_recent_history_and_next_seven_days() -> None:
+    client, _, selection_repo = _setup()
+    today = date.today()
+    too_old = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=today - timedelta(days=31))
+    first_history_day = selection_repo.create_order(
+        employee_id=100,
+        vendor_id=1,
+        items=[],
+        meal_date=today - timedelta(days=30),
+    )
+    last_order_day = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=today + timedelta(days=6))
+    too_far = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=today + timedelta(days=7))
+    selection_repo.create_order(employee_id=200, vendor_id=1, items=[], meal_date=today)
+
+    resp = client.get("/employee/me/orders", headers=_h(100))
+
+    assert resp.status_code == 200
+    assert [order["id"] for order in resp.json()] == [first_history_day.id, last_order_day.id]
+    assert too_old.id not in [order["id"] for order in resp.json()]
+    assert too_far.id not in [order["id"] for order in resp.json()]
+
+
+def test_my_orders_filters_by_requested_date_range() -> None:
+    client, _, selection_repo = _setup()
+    today = date.today()
+    before = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=today - timedelta(days=2))
+    inside = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=today - timedelta(days=1))
+    after = selection_repo.create_order(employee_id=100, vendor_id=1, items=[], meal_date=today)
+
+    resp = client.get(
+        "/employee/me/orders",
+        headers=_h(100),
+        params={
+            "start_date": (today - timedelta(days=1)).isoformat(),
+            "end_date": (today - timedelta(days=1)).isoformat(),
+        },
+    )
+
+    assert resp.status_code == 200
+    assert [order["id"] for order in resp.json()] == [inside.id]
+    assert before.id not in [order["id"] for order in resp.json()]
+    assert after.id not in [order["id"] for order in resp.json()]
+
+
+def test_my_orders_rejects_inverted_date_range() -> None:
+    client, _, _ = _setup()
+    today = date.today()
+
+    resp = client.get(
+        "/employee/me/orders",
+        headers=_h(100),
+        params={
+            "start_date": today.isoformat(),
+            "end_date": (today - timedelta(days=1)).isoformat(),
+        },
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"
+
+
 def test_cancel_pending_order_marks_order_cancelled() -> None:
     client, item_repo, _ = _setup()
     item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120)

--- a/backend/tests/test_postgres_quota.py
+++ b/backend/tests/test_postgres_quota.py
@@ -113,6 +113,38 @@ def test_create_order_uses_for_update_lock() -> None:
     assert "FOR UPDATE" in sql.upper()
 
 
+def test_list_orders_filters_by_employee_and_date_range() -> None:
+    order_rows = [
+        {
+            **_order_row(),
+            "pickup_code": "0601-0099",
+            "pickup_confirmed_at": None,
+            "pickup_confirmed_by_user_id": None,
+            "facility_id": None,
+        }
+    ]
+    ctx = _conn_with_side_effects(order_rows)
+
+    with patch(
+        "backend.repositories.postgres_employee_selection_repository.get_connection",
+        return_value=ctx,
+    ):
+        repo = PostgresEmployeeSelectionRepository()
+        with patch.object(repo, "_hydrate_order", side_effect=lambda _conn, row: row):
+            rows = repo.list_orders(
+                employee_id=1,
+                start_date=date(2026, 5, 1),
+                end_date=date(2026, 6, 7),
+            )
+
+    sql, values = ctx.__enter__.return_value.execute.call_args.args
+    assert "employee_id = %s" in sql
+    assert "COALESCE(meal_date, created_at::date) >= %s" in sql
+    assert "COALESCE(meal_date, created_at::date) <= %s" in sql
+    assert values == [1, date(2026, 5, 1), date(2026, 6, 7)]
+    assert rows == order_rows
+
+
 # ---------------------------------------------------------------------------
 # Quota exhausted
 # ---------------------------------------------------------------------------

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "test": "node --test src/api/facilityParams.test.js src/facility/facilitySelection.test.js",
+    "test": "node --test src/api/facilityParams.test.js src/facility/facilitySelection.test.js src/utils/orderHistoryRange.test.js",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0 --port 4173"
   },

--- a/frontend/src/api/employee.js
+++ b/frontend/src/api/employee.js
@@ -66,8 +66,12 @@ export function getMySelections() {
   return withMockFallback(() => apiFetch("/employee/me/selections"), []);
 }
 
-export function getMyOrders() {
-  return withMockFallback(() => apiFetch("/employee/me/orders"), []);
+export function getMyOrders({ startDate, endDate } = {}) {
+  const params = new URLSearchParams();
+  if (startDate) params.set("start_date", startDate);
+  if (endDate) params.set("end_date", endDate);
+  const qs = params.toString();
+  return withMockFallback(() => apiFetch(`/employee/me/orders${qs ? `?${qs}` : ""}`), []);
 }
 
 export function getMyBilling({ year, month } = {}) {

--- a/frontend/src/hooks/useMyOrders.js
+++ b/frontend/src/hooks/useMyOrders.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { getMyOrders } from "../api/employee";
 
-export function useMyOrders() {
+export function useMyOrders(range = {}) {
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -10,12 +10,12 @@ export function useMyOrders() {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getMyOrders()
+    getMyOrders(range)
       .then((data) => { if (!cancelled) setOrders(data); })
       .catch((err) => { if (!cancelled) setError(err); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, []);
+  }, [range.startDate, range.endDate]);
 
   return { orders, setOrders, loading, error };
 }

--- a/frontend/src/pages/employee/OrdersPage.jsx
+++ b/frontend/src/pages/employee/OrdersPage.jsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { deleteMyOrder, getMyBilling, updateMyOrder } from "../../api/employee";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { useMyOrders } from "../../hooks/useMyOrders";
 import { formatMoney, formatPrice } from "../../utils/format";
+import { datesWithoutOrders, getDefaultOrderHistoryRange, getFutureMealDates } from "../../utils/orderHistoryRange";
 
 const STATUS_LABELS = {
   pending: "待確認",
@@ -46,7 +48,10 @@ function currentPeriod() {
 }
 
 export default function OrdersPage() {
-  const { orders, setOrders, loading, error } = useMyOrders();
+  const navigate = useNavigate();
+  const orderRange = useMemo(() => getDefaultOrderHistoryRange(), []);
+  const futureMealDates = useMemo(() => getFutureMealDates(), []);
+  const { orders, setOrders, loading, error } = useMyOrders(orderRange);
   const [billing, setBilling] = useState(null);
   const [billingError, setBillingError] = useState(false);
   const [editingOrderId, setEditingOrderId] = useState(null);
@@ -55,6 +60,7 @@ export default function OrdersPage() {
   const [actionError, setActionError] = useState(null);
 
   const visibleOrders = orders.filter((order) => order.status !== "cancelled");
+  const missingFutureOrderDates = datesWithoutOrders(orders, futureMealDates);
 
   useEffect(() => {
     let alive = true;
@@ -141,6 +147,25 @@ export default function OrdersPage() {
 
       {error && <p className="error-state">無法載入訂單，請稍後再試。</p>}
       {actionError && <p className="error-state" style={{ marginBottom: 20 }}>{actionError}</p>}
+
+      {!loading && !error && missingFutureOrderDates.length > 0 && (
+        <div className="panel" style={{ padding: "14px 18px", marginBottom: 20 }}>
+          <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>未來 7 天尚未訂餐</p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginTop: 12 }}>
+            {missingFutureOrderDates.map((mealDate) => (
+              <button
+                key={mealDate}
+                className="ghost-button"
+                type="button"
+                onClick={() => navigate(`/employee/random-meal?meal_date=${mealDate}`)}
+                style={{ color: "var(--text)", borderColor: "var(--line)", background: "var(--surface)" }}
+              >
+                {mealDate} 去點餐
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {!loading && !error && visibleOrders.length === 0 && (
         <p className="empty-state">尚無目前訂單。</p>

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { drawRandomMeal, getRecommendations, submitSelection } from "../../api/employee";
 import { useFacility } from "../../facility/FacilityContext";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
@@ -27,11 +27,16 @@ function drawErrorMessage(err) {
 
 export default function RandomMealPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { selectedFacilityId } = useFacility();
   const { vendors, loading, error } = useVendors({ facilityId: selectedFacilityId });
   const minMealDate = addDaysIso(0);
   const maxMealDate = addDaysIso(6);
-  const [mealDate, setMealDate] = useState(minMealDate);
+  const requestedMealDate = new URLSearchParams(location.search).get("meal_date");
+  const initialMealDate = requestedMealDate && requestedMealDate >= minMealDate && requestedMealDate <= maxMealDate
+    ? requestedMealDate
+    : minMealDate;
+  const [mealDate, setMealDate] = useState(initialMealDate);
   const [tab, setTab] = useState("recommend");
 
   // --- 隨機抽餐 state ---

--- a/frontend/src/utils/orderHistoryRange.js
+++ b/frontend/src/utils/orderHistoryRange.js
@@ -1,0 +1,37 @@
+const HISTORY_PAST_DAYS = 30;
+const ORDER_WINDOW_DAYS = 7;
+
+function toLocalIso(date) {
+  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+  return localDate.toISOString().slice(0, 10);
+}
+
+function addDays(baseDate, days) {
+  const date = new Date(baseDate);
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() + days);
+  return date;
+}
+
+export function getDefaultOrderHistoryRange(baseDate = new Date()) {
+  return {
+    startDate: toLocalIso(addDays(baseDate, -HISTORY_PAST_DAYS)),
+    endDate: toLocalIso(addDays(baseDate, ORDER_WINDOW_DAYS - 1)),
+  };
+}
+
+export function getFutureMealDates(baseDate = new Date()) {
+  return Array.from({ length: ORDER_WINDOW_DAYS }, (_, index) => (
+    toLocalIso(addDays(baseDate, index))
+  ));
+}
+
+export function datesWithoutOrders(orders, futureDates = getFutureMealDates()) {
+  const orderedDates = new Set(
+    orders
+      .filter((order) => order.status !== "cancelled")
+      .map((order) => order.meal_date)
+      .filter(Boolean),
+  );
+  return futureDates.filter((mealDate) => !orderedDates.has(mealDate));
+}

--- a/frontend/src/utils/orderHistoryRange.test.js
+++ b/frontend/src/utils/orderHistoryRange.test.js
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  datesWithoutOrders,
+  getDefaultOrderHistoryRange,
+  getFutureMealDates,
+} from "./orderHistoryRange.js";
+
+test("getDefaultOrderHistoryRange covers the last 30 days and next 7 days including today", () => {
+  const range = getDefaultOrderHistoryRange(new Date(2026, 5, 1));
+
+  assert.deepEqual(range, {
+    startDate: "2026-05-02",
+    endDate: "2026-06-07",
+  });
+});
+
+test("getFutureMealDates returns today through the next six days", () => {
+  assert.deepEqual(getFutureMealDates(new Date(2026, 5, 1)), [
+    "2026-06-01",
+    "2026-06-02",
+    "2026-06-03",
+    "2026-06-04",
+    "2026-06-05",
+    "2026-06-06",
+    "2026-06-07",
+  ]);
+});
+
+test("datesWithoutOrders ignores cancelled orders when building go-order dates", () => {
+  const missing = datesWithoutOrders(
+    [
+      { meal_date: "2026-06-01", status: "pending" },
+      { meal_date: "2026-06-02", status: "cancelled" },
+    ],
+    ["2026-06-01", "2026-06-02", "2026-06-03"],
+  );
+
+  assert.deepEqual(missing, ["2026-06-02", "2026-06-03"]);
+});


### PR DESCRIPTION
## Summary
- add `start_date` / `end_date` support for `GET /employee/me/orders`
- default employee order history to the last 30 days through the next 7 days including today
- show go-order buttons for future meal dates without an active order and deep-link the selected date into random meal ordering
- add backend range-filter tests and frontend date-range utility tests

## Tests
- `pytest backend/tests/test_employee_ordering.py -q` ✅ 35 passed
- `pytest backend/tests -q --basetemp=.tmp_pytest` ✅ 326 passed, 28 skipped
- `npm test` / frontend build not run locally because this shell has no `node`/`npm` on PATH

Closes #120