### PR TITLE
feat(employee): add meal date picker to menu ordering

### DIFF
--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -86,6 +86,7 @@ def list_menu(
     category_id: Annotated[int | None, Query()] = None,
     available: Annotated[bool | None, Query()] = True,
     facility_id: Annotated[int | None, Query()] = None,
+    meal_date: Annotated[date | None, Query()] = None,
 ) -> list[EmployeeMenuItem]:
     return service.list_menu(
         vendor_id,
@@ -93,6 +94,7 @@ def list_menu(
         available=available,
         employee_id=employee_id,
         facility_id=facility_id,
+        meal_date=meal_date,
     )
 
 

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -76,15 +76,18 @@ class EmployeeOrderingService:
         available: bool | None = True,
         employee_id: int | None = None,
         facility_id: int | None = None,
+        meal_date: date | None = None,
     ) -> list[EmployeeMenuItem]:
         vendor = self._vendor_to_schema(self._get_approved_vendor(vendor_id))
         if employee_id is not None:
             self._assert_facility_access(vendor, employee_id, facility_id=facility_id)
+        target_date = meal_date or date.today()
+        self._ensure_meal_date_in_window(target_date)
         items = self.menu_item_repository.list(
             vendor_id=vendor_id, category_id=category_id, available=available
         )
         used_by_item = self.selection_repository.item_quantities_for_date(
-            meal_date=date.today(), vendor_ids=[vendor_id]
+            meal_date=target_date, vendor_ids=[vendor_id]
         )
         return [
             self._menu_item_to_schema(item, remaining=self._remaining_quantity(item, used_by_item.get(item.id, 0)))

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -692,6 +692,49 @@ def test_list_menu_includes_remaining_quantity_when_quota_set() -> None:
     assert body[0]["remaining_quantity"] == 3  # 5 - 2 = 3
 
 
+def test_list_menu_remaining_quantity_uses_requested_meal_date() -> None:
+    client, item_repo, selection_repo = _setup()
+    item = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=5)
+    today = date.today()
+    future = today + timedelta(days=2)
+    selection_repo.create_order(
+        employee_id=100,
+        vendor_id=1,
+        meal_date=future,
+        items=[OrderItemSnapshot(item_id=item.id, item_name="Rice Bowl", quantity=4, unit_price_cents=120)],
+    )
+
+    today_resp = client.get(
+        "/employee/vendors/1/menu",
+        headers=_browse_h(),
+        params={"meal_date": today.isoformat()},
+    )
+    future_resp = client.get(
+        "/employee/vendors/1/menu",
+        headers=_browse_h(),
+        params={"meal_date": future.isoformat()},
+    )
+
+    assert today_resp.status_code == 200
+    assert future_resp.status_code == 200
+    assert today_resp.json()[0]["remaining_quantity"] == 5
+    assert future_resp.json()[0]["remaining_quantity"] == 1
+
+
+def test_list_menu_rejects_meal_date_outside_next_seven_days() -> None:
+    client, item_repo, _ = _setup()
+    item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=5)
+
+    resp = client.get(
+        "/employee/vendors/1/menu",
+        headers=_browse_h(),
+        params={"meal_date": _meal_date(7)},
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"
+
+
 def test_list_menu_remaining_quantity_is_null_when_no_quota() -> None:
     client, item_repo, _ = _setup()
     item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=120, daily_quota=None)

--- a/frontend/src/api/employee.js
+++ b/frontend/src/api/employee.js
@@ -102,9 +102,10 @@ export function deleteMyOrder(orderId) {
   });
 }
 
-export function getVendorMenu(vendorId, { available, facilityId } = {}) {
+export function getVendorMenu(vendorId, { available, facilityId, mealDate } = {}) {
   const params = new URLSearchParams();
   if (available != null) params.set("available", String(available));
+  if (mealDate) params.set("meal_date", mealDate);
   const qs = params.toString();
   return withMockFallback(
     () => apiFetch(appendFacilityParam(`/employee/vendors/${vendorId}/menu${qs ? `?${qs}` : ""}`, facilityId)),

--- a/frontend/src/cart/CartContext.jsx
+++ b/frontend/src/cart/CartContext.jsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState } from "react";
 
-import { addCartItem } from "./cartItems";
+import { addCartItem, removeCartItem, updateCartItemQuantity } from "./cartItems";
 
 const CartContext = createContext(null);
 
@@ -11,17 +11,18 @@ export function CartProvider({ children }) {
     setItems((prev) => addCartItem(prev, { item, vendorId, quantity, mealDate }));
   }
 
-  function removeItem(itemId) {
-    setItems((prev) => prev.filter((i) => i.item.id !== itemId));
+  function removeItem(itemId, mealDate = null) {
+    setItems((prev) => removeCartItem(prev, { itemId, mealDate }));
   }
 
-  function updateQuantity(itemId, quantity) {
+  function updateQuantity(itemId, mealDateOrQuantity = null, maybeQuantity = undefined) {
+    const hasMealDateArg = maybeQuantity !== undefined;
+    const mealDate = hasMealDateArg ? mealDateOrQuantity : null;
+    const quantity = hasMealDateArg ? maybeQuantity : mealDateOrQuantity;
     if (quantity <= 0) {
-      removeItem(itemId);
+      removeItem(itemId, mealDate);
     } else {
-      setItems((prev) =>
-        prev.map((i) => (i.item.id === itemId ? { ...i, quantity } : i))
-      );
+      setItems((prev) => updateCartItemQuantity(prev, { itemId, mealDate, quantity }));
     }
   }
 

--- a/frontend/src/cart/cartItems.js
+++ b/frontend/src/cart/cartItems.js
@@ -16,6 +16,21 @@ export function addCartItem(items, { item, vendorId, quantity = 1, mealDate = nu
   return [...items, { item, vendorId, quantity, mealDate }];
 }
 
+export function removeCartItem(items, { itemId, mealDate = null }) {
+  const key = dedupKey(itemId, mealDate);
+  return items.filter((i) => dedupKey(i.item.id, i.mealDate) !== key);
+}
+
+export function updateCartItemQuantity(items, { itemId, mealDate = null, quantity }) {
+  if (quantity <= 0) {
+    return removeCartItem(items, { itemId, mealDate });
+  }
+  const key = dedupKey(itemId, mealDate);
+  return items.map((i) =>
+    dedupKey(i.item.id, i.mealDate) === key ? { ...i, quantity } : i,
+  );
+}
+
 function mealDateLabel(iso) {
   const [, mm, dd] = iso.split("-");
   // Intentional format: month without leading zero, day keeps it (e.g. "用餐日 6/03").

--- a/frontend/src/cart/cartItems.test.js
+++ b/frontend/src/cart/cartItems.test.js
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { addCartItem, groupByMealDate } from "./cartItems.js";
+import { addCartItem, groupByMealDate, removeCartItem, updateCartItemQuantity } from "./cartItems.js";
 
 const itemA = { id: 1, name: "雞腿便當" };
 const itemB = { id: 2, name: "排骨飯" };
@@ -41,6 +41,31 @@ test("addCartItem does not mutate the input array", () => {
 test("addCartItem defaults quantity to 1 when omitted", () => {
   const result = addCartItem([], { item: itemA, vendorId: 10, mealDate: "2026-06-03" });
   assert.equal(result[0].quantity, 1);
+});
+
+test("updateCartItemQuantity updates only the matching item + date row", () => {
+  const start = [
+    { item: itemA, vendorId: 10, quantity: 1, mealDate: "2026-06-03" },
+    { item: itemA, vendorId: 10, quantity: 2, mealDate: "2026-06-04" },
+  ];
+  const result = updateCartItemQuantity(start, {
+    itemId: itemA.id,
+    mealDate: "2026-06-04",
+    quantity: 4,
+  });
+  assert.equal(result[0].quantity, 1);
+  assert.equal(result[1].quantity, 4);
+});
+
+test("removeCartItem removes only the matching item + date row", () => {
+  const start = [
+    { item: itemA, vendorId: 10, quantity: 1, mealDate: "2026-06-03" },
+    { item: itemA, vendorId: 10, quantity: 2, mealDate: "2026-06-04" },
+  ];
+  const result = removeCartItem(start, { itemId: itemA.id, mealDate: "2026-06-03" });
+  assert.deepEqual(result, [
+    { item: itemA, vendorId: 10, quantity: 2, mealDate: "2026-06-04" },
+  ]);
 });
 
 test("groupByMealDate returns an empty array for an empty cart", () => {

--- a/frontend/src/hooks/useVendorMenu.js
+++ b/frontend/src/hooks/useVendorMenu.js
@@ -6,19 +6,19 @@ export function useVendorMenu(vendorId, filters = {}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const { available, facilityId } = filters;
+  const { available, facilityId, mealDate } = filters;
 
   useEffect(() => {
     if (!vendorId) return;
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getVendorMenu(vendorId, { available, facilityId })
+    getVendorMenu(vendorId, { available, facilityId, mealDate })
       .then((data) => { if (!cancelled) setItems(data); })
       .catch((err) => { if (!cancelled) setError(err); })
       .finally(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [vendorId, available, facilityId]);
+  }, [vendorId, available, facilityId, mealDate]);
 
   return { items, loading, error };
 }

--- a/frontend/src/pages/employee/CartPage.jsx
+++ b/frontend/src/pages/employee/CartPage.jsx
@@ -181,7 +181,7 @@ export default function CartPage() {
                     className="stepper-btn"
                     type="button"
                     aria-label="減少數量"
-                    onClick={() => updateQuantity(cartItem.item.id, cartItem.quantity - 1)}
+                    onClick={() => updateQuantity(cartItem.item.id, cartItem.mealDate, cartItem.quantity - 1)}
                     disabled={cartItem.quantity <= 1}
                   >
                     −
@@ -191,7 +191,7 @@ export default function CartPage() {
                     className="stepper-btn"
                     type="button"
                     aria-label="增加數量"
-                    onClick={() => updateQuantity(cartItem.item.id, cartItem.quantity + 1)}
+                    onClick={() => updateQuantity(cartItem.item.id, cartItem.mealDate, cartItem.quantity + 1)}
                   >
                     ＋
                   </button>
@@ -204,7 +204,7 @@ export default function CartPage() {
                 <button
                   type="button"
                   aria-label={`移除 ${cartItem.item.name}`}
-                  onClick={() => removeItem(cartItem.item.id)}
+                  onClick={() => removeItem(cartItem.item.id, cartItem.mealDate)}
                   style={{
                     background: "none",
                     border: "none",

--- a/frontend/src/pages/employee/VendorMenuPage.jsx
+++ b/frontend/src/pages/employee/VendorMenuPage.jsx
@@ -6,16 +6,26 @@ import { useFacility } from "../../facility/FacilityContext";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { useVendor } from "../../hooks/useVendor";
 import { useVendorMenu } from "../../hooks/useVendorMenu";
+import { todayIso, toLocalIso } from "../../utils/date";
 
 const FILTERS = [
   { label: "全部菜單", value: undefined },
   { label: "供應中", value: true },
 ];
 
+function addDaysIso(days) {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return toLocalIso(date);
+}
+
 export default function VendorMenuPage() {
   const { vendorId } = useParams();
   const navigate = useNavigate();
 
+  const minMealDate = todayIso();
+  const maxMealDate = addDaysIso(6);
+  const [mealDate, setMealDate] = useState(minMealDate);
   const [availableFilter, setAvailableFilter] = useState(undefined);
   const [selectedItem, setSelectedItem] = useState(null);
   const { selectedFacilityId } = useFacility();
@@ -24,6 +34,7 @@ export default function VendorMenuPage() {
   const { items, loading: menuLoading, error } = useVendorMenu(vendorId, {
     available: availableFilter,
     facilityId: selectedFacilityId,
+    mealDate,
   });
 
   const loading = vendorLoading || menuLoading;
@@ -51,6 +62,26 @@ export default function VendorMenuPage() {
           {vendor.business_hours && <span> &nbsp;·&nbsp; 🕐 {vendor.business_hours}</span>}
         </p>
       )}
+
+      <div className="menu-toolbar">
+        <div className="menu-date-control">
+          <label className="field-label" htmlFor="vendor-menu-meal-date">
+            Meal date
+          </label>
+          <input
+            className="date-input"
+            id="vendor-menu-meal-date"
+            max={maxMealDate}
+            min={minMealDate}
+            type="date"
+            value={mealDate}
+            onChange={(event) => {
+              setMealDate(event.target.value);
+              setSelectedItem(null);
+            }}
+          />
+        </div>
+      </div>
 
       <div className="filter-bar">
         {FILTERS.map((f) => (
@@ -92,6 +123,7 @@ export default function VendorMenuPage() {
       {selectedItem && (
         <MealDetailModal
           item={selectedItem}
+          mealDate={mealDate}
           onClose={() => setSelectedItem(null)}
         />
       )}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -473,6 +473,20 @@ p {
   margin-bottom: 24px;
 }
 
+.menu-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: end;
+  margin-bottom: 18px;
+}
+
+.menu-date-control {
+  display: grid;
+  gap: 8px;
+  width: min(100%, 260px);
+}
+
 .filter-pill {
   padding: 8px 18px;
   border: 1px solid var(--line);


### PR DESCRIPTION
## Summary
- Add a meal-date picker to the regular employee vendor menu flow.
- Pass `meal_date` through menu fetching and `MealDetailModal` cart additions.
- Make menu remaining quantity reflect the selected meal date.
- Make cart quantity/remove operations target item + meal date rows.

## Tests
- `python -m pytest backend/tests/test_employee_ordering.py -q -p no:cacheprovider`
- `python -m compileall -q backend`
- `node --test src/cart/cartItems.test.js src/cart/quantity.test.js`
- `npm test`
- `npm run build`

Closes #157
