### PR TITLE
feat(vendor): batch confirm/advance orders on orders list (#133)

### DIFF
--- a/backend/routes/vendor_orders.py
+++ b/backend/routes/vendor_orders.py
@@ -16,7 +16,14 @@ from backend.repositories.employee_selection_repository import EmployeeSelection
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
 from backend.routes.employee_ordering import get_employee_selection_repository
 from backend.routes.notifications import get_notification_service
-from backend.schemas.employee import EmployeeOrder, OrderStatus, PickupLabel, VendorOrderStatusUpdate
+from backend.schemas.employee import (
+    BatchOrderStatusUpdate,
+    BatchOrderStatusResponse,
+    EmployeeOrder,
+    OrderStatus,
+    PickupLabel,
+    VendorOrderStatusUpdate,
+)
 from backend.services.notification_service import NotificationService
 from backend.services.vendor_order_service import VendorOrderService
 
@@ -77,6 +84,21 @@ def get_vendor_pickup_label(
     service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
 ) -> PickupLabel:
     return service.get_pickup_label(vendor_id, order_id)
+
+
+@router.post("/batch-status", response_model=BatchOrderStatusResponse)
+def batch_update_order_status(
+    payload: BatchOrderStatusUpdate,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    actor_user_id: Annotated[int | None, Depends(get_current_user_id)],
+    service: Annotated[VendorOrderService, Depends(get_vendor_order_service)],
+) -> BatchOrderStatusResponse:
+    return service.batch_update_status(
+        vendor_id,
+        payload.order_ids,
+        payload.status,
+        actor_user_id=actor_user_id,
+    )
 
 
 @router.get("/by-badge/{badge_code}", response_model=list[EmployeeOrder])

--- a/backend/schemas/employee.py
+++ b/backend/schemas/employee.py
@@ -107,6 +107,25 @@ class EmployeeOrder(BaseModel):
     cancelled_at: datetime | None = None
 
 
+class BatchOrderStatusUpdate(BaseModel):
+    order_ids: list[int] = Field(min_length=1)
+    status: OrderStatus
+
+
+class BatchOrderResult(BaseModel):
+    order_id: int
+    success: bool
+    order: EmployeeOrder | None = None
+    error: str | None = None
+    code: str | None = None
+
+
+class BatchOrderStatusResponse(BaseModel):
+    results: list[BatchOrderResult]
+    succeeded: int
+    failed: int
+
+
 class PickupLabelItem(BaseModel):
     item_name: str
     quantity: int

--- a/backend/services/vendor_order_service.py
+++ b/backend/services/vendor_order_service.py
@@ -8,7 +8,14 @@ from backend.core.masking import mask_name
 from backend.repositories.audit_log_repository import AuditLogRepository
 from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
-from backend.schemas.employee import EmployeeOrder, OrderStatus, PickupLabel, PickupLabelItem
+from backend.schemas.employee import (
+    BatchOrderResult,
+    BatchOrderStatusResponse,
+    EmployeeOrder,
+    OrderStatus,
+    PickupLabel,
+    PickupLabelItem,
+)
 
 ALLOWED_TRANSITIONS: dict[str, set[str]] = {
     "pending": {"confirmed", "cancelled"},
@@ -133,6 +140,43 @@ class VendorOrderService:
             metadata={"from": old_status, "to": new_status},
         )
         return self._deidentify_order(updated)
+
+    def batch_update_status(
+        self,
+        vendor_id: int,
+        order_ids: list[int],
+        new_status: str,
+        *,
+        actor_user_id: int | None = None,
+    ) -> BatchOrderStatusResponse:
+        """Apply a status transition to multiple orders at once.
+
+        Each order is processed independently: invalid transitions or orders not
+        belonging to this vendor are reported as per-order failures rather than
+        aborting the whole batch.
+        """
+        results: list[BatchOrderResult] = []
+        for order_id in order_ids:
+            try:
+                order = self.update_status(
+                    vendor_id, order_id, new_status, actor_user_id=actor_user_id
+                )
+                results.append(BatchOrderResult(order_id=order_id, success=True, order=order))
+            except CodedHTTPException as exc:
+                results.append(
+                    BatchOrderResult(
+                        order_id=order_id,
+                        success=False,
+                        error=exc.detail,
+                        code=exc.code,
+                    )
+                )
+        succeeded = sum(1 for r in results if r.success)
+        return BatchOrderStatusResponse(
+            results=results,
+            succeeded=succeeded,
+            failed=len(results) - succeeded,
+        )
 
     def list_ready_orders_by_badge(self, vendor_id, badge_code, *, meal_date=None):
         if self._user_repo is None:

--- a/backend/tests/integration/test_vendor_orders_db.py
+++ b/backend/tests/integration/test_vendor_orders_db.py
@@ -252,3 +252,85 @@ def test_patch_status_404_for_other_vendors_order(client, seeded_ids):
     )
     assert resp.status_code == 404
     assert resp.json()["code"] == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# POST /vendor/me/orders/batch-status
+# ---------------------------------------------------------------------------
+
+
+def test_batch_status_advances_multiple_orders(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+    id1 = _insert_order(vendor_id, employee_id)
+    id2 = _insert_order(vendor_id, employee_id)
+
+    resp = client.post(
+        "/vendor/me/orders/batch-status",
+        headers=_vh(vendor_id),
+        json={"order_ids": [id1, id2], "status": "confirmed"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["succeeded"] == 2
+    assert body["failed"] == 0
+
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT id, status FROM orders WHERE id = ANY(%s)", ([id1, id2],)
+        ).fetchall()
+    statuses = {row["id"]: row["status"] for row in rows}
+    assert statuses[id1] == "confirmed"
+    assert statuses[id2] == "confirmed"
+
+
+def test_batch_status_partial_failure_other_vendor(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+
+    with get_connection() as conn:
+        other = conn.execute(
+            "INSERT INTO vendors (name, status) VALUES ('IntTest BatchOther', 'approved') RETURNING id"
+        ).fetchone()
+        conn.commit()
+    own_id = _insert_order(vendor_id, employee_id)
+    other_id = _insert_order(other["id"], employee_id)
+
+    resp = client.post(
+        "/vendor/me/orders/batch-status",
+        headers=_vh(vendor_id),
+        json={"order_ids": [own_id, other_id], "status": "confirmed"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["succeeded"] == 1
+    assert body["failed"] == 1
+    results = {r["order_id"]: r for r in body["results"]}
+    assert results[own_id]["success"] is True
+    assert results[other_id]["success"] is False
+    assert results[other_id]["code"] == "not_found"
+
+
+def test_batch_status_partial_failure_invalid_transition(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+    id1 = _insert_order(vendor_id, employee_id)
+    id2 = _insert_order(vendor_id, employee_id)
+
+    # advance id2 to confirmed first
+    client.patch(
+        f"/vendor/me/orders/{id2}/status",
+        headers=_vh(vendor_id),
+        json={"status": "confirmed"},
+    )
+
+    resp = client.post(
+        "/vendor/me/orders/batch-status",
+        headers=_vh(vendor_id),
+        json={"order_ids": [id1, id2], "status": "confirmed"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["succeeded"] == 1
+    assert body["failed"] == 1
+    results = {r["order_id"]: r for r in body["results"]}
+    assert results[id1]["success"] is True
+    assert results[id2]["success"] is False
+    assert results[id2]["code"] == "invalid_status_transition"

--- a/backend/tests/test_vendor_orders.py
+++ b/backend/tests/test_vendor_orders.py
@@ -264,3 +264,102 @@ def test_patch_status_404_for_other_vendors_order() -> None:
     )
     assert resp.status_code == 404
     assert resp.json()["code"] == "not_found"
+
+
+# --- batch-status ---
+
+
+def test_batch_status_advances_all_valid_orders() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    o1 = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+    o2 = selection_repo.create_order(employee_id=11, vendor_id=1, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).post(
+        "/vendor/me/orders/batch-status",
+        headers=_vh(1),
+        json={"order_ids": [o1.id, o2.id], "status": "confirmed"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["succeeded"] == 2
+    assert body["failed"] == 0
+    results = {r["order_id"]: r for r in body["results"]}
+    assert results[o1.id]["success"] is True
+    assert results[o1.id]["order"]["status"] == "confirmed"
+    assert results[o2.id]["success"] is True
+
+
+def test_batch_status_skips_orders_not_owned_by_vendor() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    own = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+    other = selection_repo.create_order(employee_id=20, vendor_id=2, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).post(
+        "/vendor/me/orders/batch-status",
+        headers=_vh(1),
+        json={"order_ids": [own.id, other.id], "status": "confirmed"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["succeeded"] == 1
+    assert body["failed"] == 1
+    results = {r["order_id"]: r for r in body["results"]}
+    assert results[own.id]["success"] is True
+    assert results[other.id]["success"] is False
+    assert results[other.id]["code"] == "not_found"
+
+
+def test_batch_status_reports_invalid_transition_per_order() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    o1 = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+    o2 = selection_repo.create_order(employee_id=11, vendor_id=1, items=[], meal_date=None)
+    # advance o2 to confirmed so it cannot be confirmed again
+    selection_repo.update_order_status(vendor_id=1, order_id=o2.id, new_status="confirmed")
+
+    resp = _client(vendor_repo, selection_repo).post(
+        "/vendor/me/orders/batch-status",
+        headers=_vh(1),
+        json={"order_ids": [o1.id, o2.id], "status": "confirmed"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["succeeded"] == 1
+    assert body["failed"] == 1
+    results = {r["order_id"]: r for r in body["results"]}
+    assert results[o1.id]["success"] is True
+    assert results[o2.id]["success"] is False
+    assert results[o2.id]["code"] == "invalid_status_transition"
+
+
+def test_batch_status_deidentifies_returned_orders() -> None:
+    """Batch responses must not leak employee_id / badge / masked_name."""
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    o1 = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).post(
+        "/vendor/me/orders/batch-status",
+        headers=_vh(1),
+        json={"order_ids": [o1.id], "status": "confirmed"},
+    )
+    assert resp.status_code == 200
+    order = resp.json()["results"][0]["order"]
+    assert order.get("employee_id") is None
+    assert order.get("employee_badge_code") is None
+    assert order.get("masked_name") is None
+
+
+def test_batch_status_requires_vendor_manager_role() -> None:
+    vendor_repo = _seed_vendor_repo()
+    selection_repo = EmployeeSelectionRepository()
+    o1 = selection_repo.create_order(employee_id=10, vendor_id=1, items=[], meal_date=None)
+
+    resp = _client(vendor_repo, selection_repo).post(
+        "/vendor/me/orders/batch-status",
+        headers={"x-user-role": "employee", "x-vendor-id": "1"},
+        json={"order_ids": [o1.id], "status": "confirmed"},
+    )
+    assert resp.status_code == 403

--- a/frontend/src/api/vendor.js
+++ b/frontend/src/api/vendor.js
@@ -58,6 +58,14 @@ export function updateOrderStatus(orderId, status) {
   });
 }
 
+export function batchUpdateOrderStatus(orderIds, status) {
+  return apiFetch("/vendor/me/orders/batch-status", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ order_ids: orderIds, status }),
+  });
+}
+
 // Look up a badge's ready orders for the vendor's own shop (quick-pickup flow).
 // No mock fallback: errors (404 badge_not_found) must reach the page so it can
 // distinguish "查無此員工編號" from "no ready orders" ([]).

--- a/frontend/src/pages/vendor/VendorOrdersPage.jsx
+++ b/frontend/src/pages/vendor/VendorOrdersPage.jsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { getMyOrders } from "../../api/vendor";
+import { batchUpdateOrderStatus, getMyOrders } from "../../api/vendor";
 import { useFacility } from "../../facility/FacilityContext";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { formatMoney } from "../../utils/format";
@@ -22,6 +22,15 @@ const STATUS_COLOR = {
   delivered: { background: "rgba(23,33,43,0.07)", color: "var(--muted)" },
   cancelled: { background: "rgba(200,92,44,0.08)", color: "var(--brand-deep)" },
 };
+
+/** Target statuses available in the batch action dropdown (terminal states excluded). */
+const BATCH_STATUS_OPTIONS = [
+  { value: "confirmed", label: "確認訂單" },
+  { value: "preparing", label: "開始備餐" },
+  { value: "ready", label: "可取餐" },
+  { value: "delivered", label: "已完成" },
+  { value: "cancelled", label: "取消訂單" },
+];
 
 function StatusBadge({ status }) {
   return (
@@ -47,6 +56,23 @@ function itemsSummary(items) {
   return items.length > 1 ? `${first} 等 ${items.length} 項` : first;
 }
 
+/** Indeterminate checkbox that reflects partial selection state. */
+function SelectAllCheckbox({ checked, indeterminate, onChange }) {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = indeterminate;
+  }, [indeterminate]);
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      checked={checked}
+      onChange={onChange}
+      style={{ width: 16, height: 16, cursor: "pointer" }}
+    />
+  );
+}
+
 export default function VendorOrdersPage() {
   const navigate = useNavigate();
   const { selectedFacilityId } = useFacility();
@@ -54,9 +80,17 @@ export default function VendorOrdersPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
+  // multi-select state
+  const [selectedIds, setSelectedIds] = useState(new Set());
+  const [batchStatus, setBatchStatus] = useState("confirmed");
+  const [batchLoading, setBatchLoading] = useState(false);
+  const [batchResult, setBatchResult] = useState(null); // { succeeded, failed, failures: [{order_id, error}] }
+
   useEffect(() => {
     setLoading(true);
     setError(null);
+    setSelectedIds(new Set());
+    setBatchResult(null);
     getMyOrders({ facilityId: selectedFacilityId })
       .then(setOrders)
       .catch((err) => setError(err.message ?? "無法載入訂單"))
@@ -68,6 +102,55 @@ export default function VendorOrdersPage() {
     (sum, o) => sum + o.items.reduce((s, item) => s + item.quantity, 0),
     0,
   );
+
+  // --- selection helpers ---
+  const allSelected = orders.length > 0 && selectedIds.size === orders.length;
+  const someSelected = selectedIds.size > 0 && selectedIds.size < orders.length;
+
+  function toggleSelectAll() {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(orders.map((o) => o.id)));
+    }
+    setBatchResult(null);
+  }
+
+  function toggleSelect(id) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+    setBatchResult(null);
+  }
+
+  // --- batch action ---
+  async function handleBatchAction() {
+    if (selectedIds.size === 0) return;
+    setBatchLoading(true);
+    setBatchResult(null);
+    try {
+      const res = await batchUpdateOrderStatus([...selectedIds], batchStatus);
+      setBatchResult({
+        succeeded: res.succeeded,
+        failed: res.failed,
+        failures: res.results.filter((r) => !r.success),
+      });
+      // Refresh order list so statuses are up-to-date
+      const fresh = await getMyOrders({ facilityId: selectedFacilityId });
+      setOrders(fresh);
+      // Deselect successfully updated orders
+      const failedIds = new Set(res.results.filter((r) => !r.success).map((r) => r.order_id));
+      setSelectedIds(failedIds);
+    } catch (err) {
+      setBatchResult({ error: err.message ?? "批量操作失敗" });
+    } finally {
+      setBatchLoading(false);
+    }
+  }
+
+  const GRID = "36px 150px 110px 1fr 110px 100px 36px";
 
   return (
     <div>
@@ -86,6 +169,7 @@ export default function VendorOrdersPage() {
 
       {!loading && !error && orders.length > 0 && (
         <>
+          {/* ── Summary cards ── */}
           <div style={{ display: "flex", gap: 16, marginBottom: 24 }}>
             <div className="panel" style={{ flex: 1, padding: "16px 20px" }}>
               <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>訂單數</p>
@@ -101,11 +185,114 @@ export default function VendorOrdersPage() {
             </div>
           </div>
 
+          {/* ── Batch action bar ── */}
+          {selectedIds.size > 0 && (
+            <div
+              className="panel"
+              style={{
+                padding: "12px 20px",
+                marginBottom: 16,
+                display: "flex",
+                alignItems: "center",
+                gap: 12,
+                flexWrap: "wrap",
+                background: "rgba(47,100,200,0.05)",
+                borderColor: "rgba(47,100,200,0.2)",
+              }}
+            >
+              <span style={{ fontWeight: 600, fontSize: 14 }}>
+                已選取 {selectedIds.size} 筆訂單
+              </span>
+              <span style={{ color: "var(--muted)", fontSize: 13 }}>→ 批量更新為</span>
+              <select
+                value={batchStatus}
+                onChange={(e) => setBatchStatus(e.target.value)}
+                disabled={batchLoading}
+                style={{
+                  padding: "5px 10px",
+                  borderRadius: 6,
+                  border: "1px solid var(--line)",
+                  fontSize: 13,
+                  cursor: "pointer",
+                }}
+              >
+                {BATCH_STATUS_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={handleBatchAction}
+                disabled={batchLoading}
+                style={{
+                  padding: "6px 16px",
+                  borderRadius: 6,
+                  border: "none",
+                  background: "var(--brand)",
+                  color: "#fff",
+                  fontWeight: 600,
+                  fontSize: 13,
+                  cursor: batchLoading ? "not-allowed" : "pointer",
+                  opacity: batchLoading ? 0.6 : 1,
+                }}
+              >
+                {batchLoading ? "套用中..." : "套用"}
+              </button>
+              <button
+                onClick={() => { setSelectedIds(new Set()); setBatchResult(null); }}
+                disabled={batchLoading}
+                style={{
+                  padding: "6px 12px",
+                  borderRadius: 6,
+                  border: "1px solid var(--line)",
+                  background: "transparent",
+                  fontSize: 13,
+                  cursor: "pointer",
+                  color: "var(--muted)",
+                }}
+              >
+                取消選取
+              </button>
+
+              {/* Result feedback */}
+              {batchResult && !batchResult.error && (
+                <span style={{ marginLeft: "auto", fontSize: 13 }}>
+                  {batchResult.succeeded > 0 && (
+                    <span style={{ color: "var(--success)", fontWeight: 600, marginRight: 8 }}>
+                      ✓ {batchResult.succeeded} 筆成功
+                    </span>
+                  )}
+                  {batchResult.failed > 0 && (
+                    <span style={{ color: "var(--brand-deep)", fontWeight: 600 }}>
+                      ✗ {batchResult.failed} 筆失敗
+                      {batchResult.failures.length > 0 && (
+                        <span style={{ fontWeight: 400, marginLeft: 4 }}>
+                          (訂單 #{batchResult.failures.map((f) => f.order_id).join(", #")}
+                          {" — "}
+                          {batchResult.failures[0].error})
+                        </span>
+                      )}
+                    </span>
+                  )}
+                </span>
+              )}
+              {batchResult?.error && (
+                <span style={{ marginLeft: "auto", fontSize: 13, color: "var(--brand-deep)" }}>
+                  ✗ {batchResult.error}
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* ── Orders table ── */}
           <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
+            {/* Header */}
             <div
               style={{
                 display: "grid",
-                gridTemplateColumns: "150px 110px 1fr 110px 100px 36px",
+                gridTemplateColumns: GRID,
+                alignItems: "center",
                 padding: "10px 20px",
                 borderBottom: "1px solid var(--line)",
                 color: "var(--muted)",
@@ -115,6 +302,11 @@ export default function VendorOrdersPage() {
                 letterSpacing: "0.05em",
               }}
             >
+              <SelectAllCheckbox
+                checked={allSelected}
+                indeterminate={someSelected}
+                onChange={toggleSelectAll}
+              />
               <span>日期 · 訂單</span>
               <span>取餐碼</span>
               <span>品項</span>
@@ -123,46 +315,62 @@ export default function VendorOrdersPage() {
               <span />
             </div>
 
-            {orders.map((order, idx) => (
-              <button
-                key={order.id}
-                type="button"
-                onClick={() => navigate(`/vendor/orders/${order.id}`)}
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "150px 110px 1fr 110px 100px 36px",
-                  alignItems: "center",
-                  width: "100%",
-                  padding: "14px 20px",
-                  border: "none",
-                  borderBottom: idx < orders.length - 1 ? "1px solid var(--line)" : "none",
-                  background: "transparent",
-                  cursor: "pointer",
-                  textAlign: "left",
-                  transition: "background 120ms ease",
-                }}
-                onMouseEnter={(e) => (e.currentTarget.style.background = "rgba(23,33,43,0.03)")}
-                onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
-              >
-                <div>
-                  <p style={{ margin: 0, fontSize: 13, fontWeight: 600 }}>{order.meal_date ?? "—"}</p>
-                  <p style={{ margin: "2px 0 0", fontSize: 11, color: "var(--muted)" }}>#{order.id}</p>
+            {/* Rows */}
+            {orders.map((order, idx) => {
+              const isSelected = selectedIds.has(order.id);
+              return (
+                <div
+                  key={order.id}
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns: GRID,
+                    alignItems: "center",
+                    width: "100%",
+                    padding: "14px 20px",
+                    borderBottom: idx < orders.length - 1 ? "1px solid var(--line)" : "none",
+                    background: isSelected ? "rgba(47,100,200,0.05)" : "transparent",
+                    cursor: "pointer",
+                    transition: "background 120ms ease",
+                    boxSizing: "border-box",
+                  }}
+                  onClick={() => navigate(`/vendor/orders/${order.id}`)}
+                  onMouseEnter={(e) => {
+                    if (!isSelected) e.currentTarget.style.background = "rgba(23,33,43,0.03)";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.background = isSelected
+                      ? "rgba(47,100,200,0.05)"
+                      : "transparent";
+                  }}
+                >
+                  {/* Checkbox — stops propagation so click doesn't navigate */}
+                  <input
+                    type="checkbox"
+                    checked={isSelected}
+                    onChange={() => toggleSelect(order.id)}
+                    onClick={(e) => e.stopPropagation()}
+                    style={{ width: 16, height: 16, cursor: "pointer" }}
+                  />
+                  <div>
+                    <p style={{ margin: 0, fontSize: 13, fontWeight: 600 }}>{order.meal_date ?? "—"}</p>
+                    <p style={{ margin: "2px 0 0", fontSize: 11, color: "var(--muted)" }}>#{order.id}</p>
+                  </div>
+                  <p style={{ margin: 0, fontWeight: 700, fontSize: 13 }}>
+                    {order.pickup_code ?? "—"}
+                  </p>
+                  <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>
+                    {itemsSummary(order.items)}
+                  </p>
+                  <p style={{ margin: 0, textAlign: "right", fontWeight: 600 }}>
+                    {formatMoney(order.total_price_cents)}
+                  </p>
+                  <div style={{ textAlign: "right" }}>
+                    <StatusBadge status={order.status} />
+                  </div>
+                  <p style={{ margin: 0, textAlign: "right", color: "var(--muted)", fontSize: 16 }}>›</p>
                 </div>
-                <p style={{ margin: 0, fontWeight: 700, fontSize: 13 }}>
-                  {order.pickup_code ?? "—"}
-                </p>
-                <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>
-                  {itemsSummary(order.items)}
-                </p>
-                <p style={{ margin: 0, textAlign: "right", fontWeight: 600 }}>
-                  {formatMoney(order.total_price_cents)}
-                </p>
-                <div style={{ textAlign: "right" }}>
-                  <StatusBadge status={order.status} />
-                </div>
-                <p style={{ margin: 0, textAlign: "right", color: "var(--muted)", fontSize: 16 }}>›</p>
-              </button>
-            ))}
+              );
+            })}
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary

Implements [#133](https://github.com/mizu5555/Corporate-Meal-Ordering-System/issues/133) — vendors can now select multiple orders and advance/confirm them in one operation instead of one-by-one.

## Changes

### Backend
- **`POST /vendor/me/orders/batch-status`** — accepts a list of order IDs and a target status; processes each independently and returns per-order success/failure so partial failures are visible
- Orders not belonging to the calling vendor → `not_found` per-order (no abort)
- Invalid status transitions → `invalid_status_transition` per-order (no abort)
- Existing single-order endpoints untouched

### Frontend
- Multi-select checkboxes on every row of `VendorOrdersPage`
- Indeterminate select-all checkbox in table header
- Batch action bar appears when ≥ 1 orders selected: status dropdown + Apply button + inline success/failure feedback
- Single-order row click still navigates to order detail

## Tests
- **Unit (5 new):** valid batch advance, cross-vendor rejection, invalid transition per-order, de-identification of returned orders, role guard
- **Integration (3 new):** batch advance persists to DB, partial failure cross-vendor, partial failure invalid transition