### PR TITLE
feat(menu): add dietary tags to meal flows

### DIFF
--- a/backend/db/migrations/012_menu_item_dietary_tags.sql
+++ b/backend/db/migrations/012_menu_item_dietary_tags.sql
@@ -1,0 +1,2 @@
+ALTER TABLE menu_items
+  ADD COLUMN IF NOT EXISTS dietary_tags TEXT[] NOT NULL DEFAULT '{}'::TEXT[];

--- a/backend/repositories/menu_item_repository.py
+++ b/backend/repositories/menu_item_repository.py
@@ -23,6 +23,7 @@ class _ItemRecord:
     price_cents: int
     available: bool
     daily_quota: int | None
+    dietary_tags: list[str]
     photo_path: str | None
     created_at: datetime
     updated_at: datetime
@@ -38,6 +39,7 @@ def _to_schema(rec: _ItemRecord) -> MenuItem:
         price_cents=rec.price_cents,
         available=rec.available,
         daily_quota=rec.daily_quota,
+        dietary_tags=list(rec.dietary_tags),
         photo_path=rec.photo_path,
         created_at=rec.created_at,
         updated_at=rec.updated_at,
@@ -59,6 +61,7 @@ class MenuItemRepository:
         category_id: int | None = None,
         available: bool = True,
         daily_quota: int | None = None,
+        dietary_tags: list[str] | None = None,
     ) -> MenuItem:
         now = datetime.now(timezone.utc)
         rec = _ItemRecord(
@@ -70,6 +73,7 @@ class MenuItemRepository:
             price_cents=price_cents,
             available=available,
             daily_quota=daily_quota,
+            dietary_tags=list(dietary_tags or []),
             photo_path=None,
             created_at=now,
             updated_at=now,

--- a/backend/repositories/postgres_menu_item_repository.py
+++ b/backend/repositories/postgres_menu_item_repository.py
@@ -17,18 +17,19 @@ class PostgresMenuItemRepository:
         category_id: int | None = None,
         available: bool = True,
         daily_quota: int | None = None,
+        dietary_tags: list[str] | None = None,
     ) -> MenuItem:
         with get_connection() as conn:
             row = conn.execute(
                 """
                 INSERT INTO menu_items (
                     vendor_id, category_id, name, description,
-                    price_cents, available, daily_quota
+                    price_cents, available, daily_quota, dietary_tags
                 )
-                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
                 RETURNING
                     id, vendor_id, category_id, name, description,
-                    price_cents, available, daily_quota, photo_path,
+                    price_cents, available, daily_quota, dietary_tags, photo_path,
                     created_at, updated_at
                 """,
                 (
@@ -39,6 +40,7 @@ class PostgresMenuItemRepository:
                     price_cents,
                     available,
                     daily_quota,
+                    dietary_tags or [],
                 ),
             ).fetchone()
 
@@ -66,7 +68,7 @@ class PostgresMenuItemRepository:
                 f"""
                 SELECT
                     id, vendor_id, category_id, name, description,
-                    price_cents, available, daily_quota, photo_path,
+                    price_cents, available, daily_quota, dietary_tags, photo_path,
                     created_at, updated_at
                 FROM menu_items
                 WHERE {" AND ".join(where)}
@@ -83,7 +85,7 @@ class PostgresMenuItemRepository:
                 """
                 SELECT
                     id, vendor_id, category_id, name, description,
-                    price_cents, available, daily_quota, photo_path,
+                    price_cents, available, daily_quota, dietary_tags, photo_path,
                     created_at, updated_at
                 FROM menu_items
                 WHERE vendor_id = %s AND id = %s
@@ -105,6 +107,7 @@ class PostgresMenuItemRepository:
             "price_cents": "price_cents",
             "available": "available",
             "daily_quota": "daily_quota",
+            "dietary_tags": "dietary_tags",
         }
         updates = [
             (allowed_columns[key], value)
@@ -126,7 +129,7 @@ class PostgresMenuItemRepository:
                 WHERE vendor_id = %s AND id = %s
                 RETURNING
                     id, vendor_id, category_id, name, description,
-                    price_cents, available, daily_quota, photo_path,
+                    price_cents, available, daily_quota, dietary_tags, photo_path,
                     created_at, updated_at
                 """,
                 values,

--- a/backend/routes/employee_ordering.py
+++ b/backend/routes/employee_ordering.py
@@ -34,7 +34,7 @@ from backend.schemas.employee import (
     RecommendedItem,
 )
 from backend.schemas.badge import EmployeeBadge
-from backend.schemas.vendor_self import Facility
+from backend.schemas.vendor_self import DietaryTag, Facility, normalize_dietary_tags
 from backend.services.employee_ordering_service import EmployeeOrderingService
 from backend.services.notification_service import NotificationService
 
@@ -57,6 +57,21 @@ def get_employee_ordering_service(
     audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
 ) -> EmployeeOrderingService:
     return EmployeeOrderingService(vendor_repo, item_repo, selection_repo, audit_repo)
+
+
+def _parse_dietary_query(values: list[str] | None) -> list[DietaryTag]:
+    if not values:
+        return []
+    tags = [
+        part.strip()
+        for value in values
+        for part in value.split(",")
+        if part.strip()
+    ]
+    try:
+        return normalize_dietary_tags(tags)
+    except ValueError as exc:
+        raise CodedHTTPException(status_code=422, code="validation_error", detail=str(exc)) from exc
 
 
 @router.get("/vendors", response_model=list[EmployeeVendor])
@@ -128,8 +143,17 @@ def list_recommendations(
     facility_id: int | None = None,
     meal_date: date | None = None,
     limit: Annotated[int, Query(ge=1, le=50)] = 8,
+    include_tags: Annotated[list[str] | None, Query()] = None,
+    exclude_tags: Annotated[list[str] | None, Query()] = None,
 ) -> list[RecommendedItem]:
-    return service.recommend(employee_id=employee_id, facility_id=facility_id, meal_date=meal_date, limit=limit)
+    return service.recommend(
+        employee_id=employee_id,
+        facility_id=facility_id,
+        meal_date=meal_date,
+        limit=limit,
+        include_tags=_parse_dietary_query(include_tags),
+        exclude_tags=_parse_dietary_query(exclude_tags),
+    )
 
 
 @router.post("/random-meals/draw", response_model=RandomMealDraw)

--- a/backend/schemas/employee.py
+++ b/backend/schemas/employee.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
-from backend.schemas.vendor_self import Facility
+from backend.schemas.vendor_self import DietaryTag, Facility, normalize_dietary_tags
 
 
 class EmployeeVendor(BaseModel):
@@ -30,6 +30,12 @@ class EmployeeMenuItem(BaseModel):
     daily_quota: int | None
     remaining_quantity: int | None = None
     photo_path: str | None
+    dietary_tags: list[DietaryTag] = Field(default_factory=list)
+
+    @field_validator("dietary_tags", mode="before")
+    @classmethod
+    def _normalize_dietary_tags(cls, value: object) -> list[DietaryTag]:
+        return normalize_dietary_tags(value)
 
 
 class MealSelectionCreate(BaseModel):
@@ -154,6 +160,13 @@ class RandomMealDrawRequest(BaseModel):
     meal_date: date
     vendor_ids: list[int] | None = None
     facility_id: int | None = None
+    include_tags: list[DietaryTag] = Field(default_factory=list)
+    exclude_tags: list[DietaryTag] = Field(default_factory=list)
+
+    @field_validator("include_tags", "exclude_tags", mode="before")
+    @classmethod
+    def _normalize_dietary_tags(cls, value: object) -> list[DietaryTag]:
+        return normalize_dietary_tags(value)
 
 
 class RandomMealDraw(BaseModel):

--- a/backend/schemas/vendor_self.py
+++ b/backend/schemas/vendor_self.py
@@ -6,13 +6,38 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, Literal, get_args
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
 
 
 # 所有 user-input 字串型欄位共用：去頭尾空白 + 至少 1 字元（避免純空白）。
 NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+DietaryTag = Literal["contains_beef", "contains_pork", "vegetarian", "ovo_lacto_vegetarian"]
+SUPPORTED_DIETARY_TAGS = set(get_args(DietaryTag))
+MEAT_DIETARY_TAGS = {"contains_beef", "contains_pork"}
+VEGETARIAN_DIETARY_TAGS = {"vegetarian", "ovo_lacto_vegetarian"}
+
+
+def normalize_dietary_tags(value: object) -> list[DietaryTag]:
+    if value is None:
+        return []
+    if isinstance(value, str) or not isinstance(value, list):
+        raise ValueError("dietary_tags must be a list")
+
+    normalized: list[DietaryTag] = []
+    seen: set[str] = set()
+    for raw_tag in value:
+        if raw_tag not in SUPPORTED_DIETARY_TAGS:
+            raise ValueError(f"unsupported dietary tag: {raw_tag}")
+        if raw_tag not in seen:
+            normalized.append(raw_tag)
+            seen.add(raw_tag)
+
+    if seen & VEGETARIAN_DIETARY_TAGS and seen & MEAT_DIETARY_TAGS:
+        raise ValueError("vegetarian tags cannot be combined with beef or pork tags")
+    return normalized
 
 
 class Facility(BaseModel):
@@ -93,9 +118,15 @@ class MenuItem(BaseModel):
     price_cents: int
     available: bool
     daily_quota: int | None
+    dietary_tags: list[DietaryTag] = Field(default_factory=list)
     photo_path: str | None
     created_at: datetime
     updated_at: datetime
+
+    @field_validator("dietary_tags", mode="before")
+    @classmethod
+    def _normalize_dietary_tags(cls, value: object) -> list[DietaryTag]:
+        return normalize_dietary_tags(value)
 
 
 class MenuItemCreate(BaseModel):
@@ -110,6 +141,12 @@ class MenuItemCreate(BaseModel):
     category_id: int | None = None
     available: bool = True
     daily_quota: int | None = Field(default=None, ge=0)
+    dietary_tags: list[DietaryTag] = Field(default_factory=list)
+
+    @field_validator("dietary_tags", mode="before")
+    @classmethod
+    def _normalize_dietary_tags(cls, value: object) -> list[DietaryTag]:
+        return normalize_dietary_tags(value)
 
 
 class MenuItemUpdate(BaseModel):
@@ -121,6 +158,12 @@ class MenuItemUpdate(BaseModel):
     category_id: int | None = None
     available: bool | None = None
     daily_quota: int | None = Field(default=None, ge=0)
+    dietary_tags: list[DietaryTag] | None = None
+
+    @field_validator("dietary_tags", mode="before")
+    @classmethod
+    def _normalize_dietary_tags(cls, value: object) -> list[DietaryTag]:
+        return normalize_dietary_tags(value)
 
 
 class PhotoUploadResponse(BaseModel):

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -207,6 +207,12 @@ class EmployeeOrderingService:
         for vendor_id in vendor_ids:
             vendor = approved_vendors[vendor_id]
             for item in self.menu_item_repository.list(vendor_id=vendor_id, available=True):
+                if not self._matches_dietary_tags(
+                    item,
+                    include_tags=payload.include_tags,
+                    exclude_tags=payload.exclude_tags,
+                ):
+                    continue
                 remaining = self._remaining_quantity(item, used_by_item.get(item.id, 0))
                 if remaining is None or remaining > 0:
                     candidates.append((vendor, item, remaining))
@@ -233,6 +239,8 @@ class EmployeeOrderingService:
         facility_id: int | None = None,
         meal_date: date | None = None,
         limit: int = 8,
+        include_tags: list[str] | None = None,
+        exclude_tags: list[str] | None = None,
     ) -> list[RecommendedItem]:
         target_date = meal_date or date.today()
 
@@ -259,9 +267,15 @@ class EmployeeOrderingService:
         )
 
         # Build item_by_id: {item_id: (vendor_id, raw_item)}
-        item_by_id: dict[int, tuple[int, object]] = {}
+        item_by_id: dict[int, tuple[int, VendorMenuItem]] = {}
         for vid in visible_ids:
             for it in self.menu_item_repository.list(vendor_id=vid, available=True):
+                if not self._matches_dietary_tags(
+                    it,
+                    include_tags=include_tags,
+                    exclude_tags=exclude_tags,
+                ):
+                    continue
                 item_by_id[it.id] = (vid, it)
 
         # Sales window: past 30 days up to today
@@ -530,7 +544,22 @@ class EmployeeOrderingService:
             daily_quota=item.daily_quota,
             remaining_quantity=remaining,
             photo_path=item.photo_path,
+            dietary_tags=item.dietary_tags,
         )
+
+    @staticmethod
+    def _matches_dietary_tags(
+        item: VendorMenuItem,
+        *,
+        include_tags: list[str] | None = None,
+        exclude_tags: list[str] | None = None,
+    ) -> bool:
+        tags = set(item.dietary_tags)
+        if include_tags and not set(include_tags).issubset(tags):
+            return False
+        if exclude_tags and tags.intersection(exclude_tags):
+            return False
+        return True
 
     def _order_to_pickup_label(self, order: EmployeeOrder) -> PickupLabel:
         vendor = self.vendor_repository.get(order.vendor_id)

--- a/backend/services/vendor_menu_service.py
+++ b/backend/services/vendor_menu_service.py
@@ -64,6 +64,7 @@ class VendorMenuService:
             category_id=payload.category_id,
             available=payload.available,
             daily_quota=payload.daily_quota,
+            dietary_tags=payload.dietary_tags,
         )
 
     def update(

--- a/backend/tests/test_employee_ordering.py
+++ b/backend/tests/test_employee_ordering.py
@@ -105,7 +105,14 @@ def test_pending_vendor_is_hidden_from_employee() -> None:
 
 def test_list_menu_defaults_to_available_items() -> None:
     client, item_repo, _ = _setup()
-    item_repo.create(vendor_id=1, category_id=7, name="Rice Bowl", price_cents=120, available=True)
+    item_repo.create(
+        vendor_id=1,
+        category_id=7,
+        name="Rice Bowl",
+        price_cents=120,
+        available=True,
+        dietary_tags=["vegetarian"],
+    )
     item_repo.create(vendor_id=1, category_id=7, name="Sold Out Soup", price_cents=80, available=False)
     item_repo.create(vendor_id=1, category_id=8, name="Tea", price_cents=40, available=True)
 
@@ -113,6 +120,7 @@ def test_list_menu_defaults_to_available_items() -> None:
 
     assert resp.status_code == 200
     assert [item["name"] for item in resp.json()] == ["Rice Bowl"]
+    assert resp.json()[0]["dietary_tags"] == ["vegetarian"]
 
 
 def test_select_meal_records_quantity_and_total_price() -> None:
@@ -515,6 +523,61 @@ def test_draw_random_meal_returns_409_when_no_meals_remain() -> None:
         "/employee/random-meals/draw",
         headers=_browse_h(),
         json={"meal_date": meal_date, "vendor_ids": [1]},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "no_random_meal_available"
+
+
+def test_draw_random_meal_excludes_disallowed_dietary_tags() -> None:
+    client, item_repo, _ = _setup()
+    beef = item_repo.create(
+        vendor_id=1,
+        name="Beef Bowl",
+        price_cents=120,
+        dietary_tags=["contains_beef"],
+    )
+    vegetarian = item_repo.create(
+        vendor_id=1,
+        name="Vegetarian Bowl",
+        price_cents=120,
+        dietary_tags=["vegetarian"],
+    )
+
+    resp = client.post(
+        "/employee/random-meals/draw",
+        headers=_browse_h(),
+        json={
+            "meal_date": _meal_date(),
+            "vendor_ids": [1],
+            "exclude_tags": ["contains_beef", "contains_pork"],
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["item"]["id"] == vegetarian.id
+    assert resp.json()["item"]["id"] != beef.id
+    assert resp.json()["item"]["dietary_tags"] == ["vegetarian"]
+
+
+def test_draw_random_meal_returns_409_when_dietary_filters_remove_all_candidates() -> None:
+    client, item_repo, _ = _setup()
+    item_repo.create(
+        vendor_id=1,
+        name="Beef Bowl",
+        price_cents=120,
+        dietary_tags=["contains_beef"],
+    )
+
+    resp = client.post(
+        "/employee/random-meals/draw",
+        headers=_browse_h(),
+        json={
+            "meal_date": _meal_date(),
+            "vendor_ids": [1],
+            "include_tags": ["vegetarian"],
+            "exclude_tags": ["contains_beef"],
+        },
     )
 
     assert resp.status_code == 409

--- a/backend/tests/test_menu_item_repository.py
+++ b/backend/tests/test_menu_item_repository.py
@@ -8,6 +8,7 @@ def test_create_assigns_id_and_defaults() -> None:
     assert item.id > 0
     assert item.available is True
     assert item.daily_quota is None
+    assert item.dietary_tags == []
     assert item.photo_path is None
 
 
@@ -47,6 +48,27 @@ def test_update_partial_fields() -> None:
     assert updated is not None
     assert updated.daily_quota == 0
     assert updated.name == "A"
+
+
+def test_create_update_and_list_round_trip_dietary_tags() -> None:
+    repo = MenuItemRepository()
+    item = repo.create(
+        vendor_id=1,
+        name="Vegetarian Rice",
+        price_cents=100,
+        dietary_tags=["vegetarian"],
+    )
+    assert item.dietary_tags == ["vegetarian"]
+
+    updated = repo.update(
+        vendor_id=1,
+        item_id=item.id,
+        fields={"dietary_tags": ["ovo_lacto_vegetarian"]},
+    )
+
+    assert updated is not None
+    assert updated.dietary_tags == ["ovo_lacto_vegetarian"]
+    assert repo.list(vendor_id=1)[0].dietary_tags == ["ovo_lacto_vegetarian"]
 
 
 def test_delete_removes_record() -> None:

--- a/backend/tests/test_recommendation.py
+++ b/backend/tests/test_recommendation.py
@@ -182,3 +182,57 @@ def test_no_vendors_returns_empty() -> None:
     results = svc.recommend(limit=8)
 
     assert results == []
+
+
+def test_include_tag_filters_recommendations_before_ranking() -> None:
+    vendor_repo = _base_vendor_repo()
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+    reporting_repo = ReportingRepository()
+
+    beef = item_repo.create(
+        vendor_id=1,
+        name="Popular Beef Bowl",
+        price_cents=120,
+        daily_quota=50,
+        dietary_tags=["contains_beef"],
+    )
+    vegetarian = item_repo.create(
+        vendor_id=1,
+        name="Vegetarian Bowl",
+        price_cents=100,
+        daily_quota=50,
+        dietary_tags=["vegetarian"],
+    )
+
+    _seed_sale(reporting_repo, order_id=1, vendor_id=1, items=[(beef.id, 20, 120)])
+    _seed_sale(reporting_repo, order_id=2, vendor_id=1, items=[(vegetarian.id, 2, 100)])
+
+    svc = _make_service(vendor_repo, item_repo, selection_repo, reporting_repo)
+    results = svc.recommend(limit=8, include_tags=["vegetarian"])
+
+    assert [r.item.id for r in results] == [vegetarian.id]
+
+
+def test_exclude_tags_filter_recommendations_before_ranking() -> None:
+    vendor_repo = _base_vendor_repo()
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+    reporting_repo = ReportingRepository()
+
+    pork = item_repo.create(
+        vendor_id=1,
+        name="Popular Pork Bowl",
+        price_cents=120,
+        daily_quota=50,
+        dietary_tags=["contains_pork"],
+    )
+    rice = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=100, daily_quota=50)
+
+    _seed_sale(reporting_repo, order_id=1, vendor_id=1, items=[(pork.id, 20, 120)])
+    _seed_sale(reporting_repo, order_id=2, vendor_id=1, items=[(rice.id, 2, 100)])
+
+    svc = _make_service(vendor_repo, item_repo, selection_repo, reporting_repo)
+    results = svc.recommend(limit=8, exclude_tags=["contains_beef", "contains_pork"])
+
+    assert [r.item.id for r in results] == [rice.id]

--- a/backend/tests/test_recommendation_route.py
+++ b/backend/tests/test_recommendation_route.py
@@ -149,3 +149,30 @@ def test_recommendations_items_have_from_sales_field() -> None:
     for rec in body:
         assert "from_sales" in rec
     assert body[0]["from_sales"] is True
+
+
+def test_recommendations_accepts_comma_separated_dietary_filters() -> None:
+    reporting_repo = ReportingRepository()
+    svc, item_repo = _make_service_with_reporting(reporting_repo)
+
+    beef = item_repo.create(
+        vendor_id=1,
+        name="Beef Bowl",
+        price_cents=120,
+        daily_quota=10,
+        dietary_tags=["contains_beef"],
+    )
+    rice = item_repo.create(vendor_id=1, name="Rice Bowl", price_cents=100, daily_quota=10)
+    _seed_sale(reporting_repo, order_id=1, vendor_id=1, items=[(beef.id, 10, 120)])
+    _seed_sale(reporting_repo, order_id=2, vendor_id=1, items=[(rice.id, 1, 100)])
+
+    app.dependency_overrides[get_employee_ordering_service] = lambda: svc
+    client = TestClient(app)
+
+    resp = client.get(
+        "/employee/recommendations?exclude_tags=contains_beef,contains_pork",
+        headers=_h(100),
+    )
+
+    assert resp.status_code == 200
+    assert [rec["item"]["id"] for rec in resp.json()] == [rice.id]

--- a/backend/tests/test_vendor_menu.py
+++ b/backend/tests/test_vendor_menu.py
@@ -53,7 +53,12 @@ def test_create_menu_item_and_get(tmp_path: Path) -> None:
     resp = client.post(
         "/vendor/me/menu",
         headers=_h(),
-        json={"name": "Rice Bowl", "price_cents": 120, "daily_quota": 50},
+        json={
+            "name": "Rice Bowl",
+            "price_cents": 120,
+            "daily_quota": 50,
+            "dietary_tags": ["contains_beef"],
+        },
     )
     assert resp.status_code == 201
     item_id = resp.json()["id"]
@@ -61,6 +66,61 @@ def test_create_menu_item_and_get(tmp_path: Path) -> None:
     got = client.get(f"/vendor/me/menu/{item_id}", headers=_h()).json()
     assert got["name"] == "Rice Bowl"
     assert got["daily_quota"] == 50
+    assert got["dietary_tags"] == ["contains_beef"]
+
+
+def test_create_patch_and_list_round_trip_dietary_tags(tmp_path: Path) -> None:
+    client, _, _ = _setup(tmp_path)
+    created = client.post(
+        "/vendor/me/menu",
+        headers=_h(),
+        json={
+            "name": "Veggie Bowl",
+            "price_cents": 120,
+            "dietary_tags": ["vegetarian"],
+        },
+    )
+    assert created.status_code == 201
+    item_id = created.json()["id"]
+
+    patched = client.patch(
+        f"/vendor/me/menu/{item_id}",
+        headers=_h(),
+        json={"dietary_tags": ["ovo_lacto_vegetarian"]},
+    )
+
+    assert patched.status_code == 200
+    assert patched.json()["dietary_tags"] == ["ovo_lacto_vegetarian"]
+    listed = client.get("/vendor/me/menu", headers=_h()).json()
+    assert listed[0]["dietary_tags"] == ["ovo_lacto_vegetarian"]
+
+
+def test_invalid_dietary_tag_rejected_422(tmp_path: Path) -> None:
+    client, _, _ = _setup(tmp_path)
+
+    resp = client.post(
+        "/vendor/me/menu",
+        headers=_h(),
+        json={"name": "Rice Bowl", "price_cents": 120, "dietary_tags": ["keto"]},
+    )
+
+    assert resp.status_code == 422
+
+
+def test_vegetarian_cannot_be_combined_with_meat_tags(tmp_path: Path) -> None:
+    client, _, _ = _setup(tmp_path)
+
+    resp = client.post(
+        "/vendor/me/menu",
+        headers=_h(),
+        json={
+            "name": "Confusing Bowl",
+            "price_cents": 120,
+            "dietary_tags": ["vegetarian", "contains_beef"],
+        },
+    )
+
+    assert resp.status_code == 422
 
 
 def test_daily_quota_round_trip_null_and_zero(tmp_path: Path) -> None:

--- a/frontend/src/api/employee.js
+++ b/frontend/src/api/employee.js
@@ -1,6 +1,7 @@
 import { apiFetch } from "./client";
 import { appendFacilityParam, facilityPayload } from "./facilityParams";
 import { MOCK_VENDORS, MOCK_MENU } from "./mockData";
+import { matchesDietaryFilters } from "../utils/dietaryTags";
 
 function withMockFallback(apiCall, mockResult) {
   return apiCall().catch((err) => {
@@ -115,7 +116,7 @@ export function getVendorMenu(vendorId, { available, facilityId, mealDate } = {}
   );
 }
 
-function mockRandomMeal({ mealDate, vendorIds, facilityId }) {
+function mockRandomMeal({ mealDate, vendorIds, facilityId, includeTags, excludeTags }) {
   const selectedIds = vendorIds?.length ? vendorIds.map(Number) : MOCK_VENDORS.map((v) => v.id);
   const visibleVendorIds = selectedIds.filter((vendorId) => {
     if (facilityId == null) return true;
@@ -125,6 +126,7 @@ function mockRandomMeal({ mealDate, vendorIds, facilityId }) {
   const candidates = visibleVendorIds.flatMap((vendorId) =>
     (MOCK_MENU[vendorId] ?? [])
       .filter((item) => item.available && item.daily_quota !== 0)
+      .filter((item) => matchesDietaryFilters(item, { includeTags, excludeTags }))
       .map((item) => ({
         meal_date: mealDate,
         vendor: MOCK_VENDORS.find((v) => v.id === vendorId),
@@ -143,25 +145,29 @@ function mockRandomMeal({ mealDate, vendorIds, facilityId }) {
   return candidates[Math.floor(Math.random() * candidates.length)];
 }
 
-export function getRecommendations({ facilityId, mealDate, limit } = {}) {
+export function getRecommendations({ facilityId, mealDate, limit, includeTags, excludeTags } = {}) {
   const params = new URLSearchParams();
   if (facilityId != null) params.set("facility_id", facilityId);
   if (mealDate) params.set("meal_date", mealDate);
   if (limit) params.set("limit", limit);
+  if (includeTags?.length) params.set("include_tags", includeTags.join(","));
+  if (excludeTags?.length) params.set("exclude_tags", excludeTags.join(","));
   const qs = params.toString();
   return apiFetch(`/employee/recommendations${qs ? `?${qs}` : ""}`);
 }
 
-export function drawRandomMeal({ mealDate, vendorIds, facilityId }) {
+export function drawRandomMeal({ mealDate, vendorIds, facilityId, includeTags, excludeTags }) {
   const payload = { meal_date: mealDate, ...facilityPayload(facilityId) };
   if (vendorIds != null) payload.vendor_ids = vendorIds;
+  if (includeTags?.length) payload.include_tags = includeTags;
+  if (excludeTags?.length) payload.exclude_tags = excludeTags;
   return withMockFallback(
     () => apiFetch("/employee/random-meals/draw", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     }),
-    () => mockRandomMeal({ mealDate, vendorIds, facilityId }),
+    () => mockRandomMeal({ mealDate, vendorIds, facilityId, includeTags, excludeTags }),
   );
 }
 

--- a/frontend/src/api/mockData.js
+++ b/frontend/src/api/mockData.js
@@ -86,6 +86,7 @@ export const MOCK_MENU = {
       price_cents: 9000,
       available: true,
       daily_quota: 50,
+      dietary_tags: ["contains_beef"],
       photo_path: null,
     },
     {
@@ -97,6 +98,7 @@ export const MOCK_MENU = {
       price_cents: 8500,
       available: true,
       daily_quota: 30,
+      dietary_tags: ["contains_pork"],
       photo_path: null,
     },
     {
@@ -108,6 +110,7 @@ export const MOCK_MENU = {
       price_cents: 7500,
       available: true,
       daily_quota: null,
+      dietary_tags: ["vegetarian"],
       photo_path: null,
     },
     {
@@ -119,6 +122,7 @@ export const MOCK_MENU = {
       price_cents: 8000,
       available: true,
       daily_quota: 0,
+      dietary_tags: ["ovo_lacto_vegetarian"],
       photo_path: null,
     },
   ],
@@ -132,6 +136,7 @@ export const MOCK_MENU = {
       price_cents: 10000,
       available: true,
       daily_quota: 40,
+      dietary_tags: ["contains_beef"],
       photo_path: null,
     },
     {
@@ -143,6 +148,7 @@ export const MOCK_MENU = {
       price_cents: 13500,
       available: true,
       daily_quota: 20,
+      dietary_tags: ["contains_pork"],
       photo_path: null,
     },
     {
@@ -154,6 +160,7 @@ export const MOCK_MENU = {
       price_cents: 9500,
       available: false,
       daily_quota: 15,
+      dietary_tags: [],
       photo_path: null,
     },
   ],
@@ -167,6 +174,7 @@ export const MOCK_MENU = {
       price_cents: 8500,
       available: true,
       daily_quota: 60,
+      dietary_tags: ["vegetarian"],
       photo_path: null,
     },
     {
@@ -178,6 +186,7 @@ export const MOCK_MENU = {
       price_cents: 9000,
       available: true,
       daily_quota: 35,
+      dietary_tags: ["ovo_lacto_vegetarian"],
       photo_path: null,
     },
   ],

--- a/frontend/src/components/employee/MealDetailModal.jsx
+++ b/frontend/src/components/employee/MealDetailModal.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useCart } from "../../cart/CartContext";
 import { formatPrice, photoUrl, quotaLabel } from "../../utils/format";
 import { maxAddQuantity } from "../../cart/quantity";
+import { dietaryTagLabel, normalizeDietaryTags } from "../../utils/dietaryTags";
 
 export default function MealDetailModal({ item, onClose, mealDate = null, remaining = null }) {
   const photo = photoUrl(item.photo_path);
@@ -11,6 +12,7 @@ export default function MealDetailModal({ item, onClose, mealDate = null, remain
   const soldOut = effectiveRemaining === 0;
   const unavailable = !item.available || soldOut;
   const quota = quotaLabel(effectiveRemaining);
+  const dietaryTags = normalizeDietaryTags(item.dietary_tags);
 
   const [quantity, setQuantity] = useState(1);
   const [added, setAdded] = useState(false);
@@ -92,6 +94,18 @@ export default function MealDetailModal({ item, onClose, mealDate = null, remain
               <div className="modal-detail-row">
                 <span className="modal-detail-label">今日配額</span>
                 <span style={{ color: "var(--muted)" }}>無限制</span>
+              </div>
+            )}
+            {dietaryTags.length > 0 && (
+              <div className="modal-detail-row">
+                <span className="modal-detail-label">飲食標籤</span>
+                <span className="item-badges" style={{ justifyContent: "flex-end" }}>
+                  {dietaryTags.map((tag) => (
+                    <span className="badge badge-quota" key={tag}>
+                      {dietaryTagLabel(tag)}
+                    </span>
+                  ))}
+                </span>
               </div>
             )}
           </div>

--- a/frontend/src/components/employee/MealDetailModal.test.jsx
+++ b/frontend/src/components/employee/MealDetailModal.test.jsx
@@ -18,6 +18,7 @@ const baseItem = {
   daily_quota: 10,
   remaining_quantity: 10,
   photo_path: null,
+  dietary_tags: ["vegetarian"],
 };
 
 beforeEach(() => addItem.mockClear());
@@ -28,6 +29,7 @@ describe("MealDetailModal", () => {
     render(<MealDetailModal item={baseItem} mealDate="2026-06-03" remaining={5} onClose={() => {}} />);
 
     expect(screen.getByText("雞腿便當")).toBeInTheDocument();
+    expect(screen.getByText("素食")).toBeInTheDocument();
 
     await user.click(screen.getByLabelText("增加數量")); // 1 -> 2
     await user.click(screen.getByRole("button", { name: "加入購物車" }));

--- a/frontend/src/components/employee/MenuItemCard.jsx
+++ b/frontend/src/components/employee/MenuItemCard.jsx
@@ -1,10 +1,12 @@
 import { formatPrice, photoUrl, quotaLabel } from "../../utils/format";
+import { dietaryTagLabel, normalizeDietaryTags } from "../../utils/dietaryTags";
 
 export default function MenuItemCard({ item, onClick }) {
   const photo = photoUrl(item.photo_path);
   const soldOut = item.remaining_quantity === 0;
   const unavailable = !item.available || soldOut;
   const quota = quotaLabel(item.remaining_quantity);
+  const dietaryTags = normalizeDietaryTags(item.dietary_tags);
 
   return (
     <button
@@ -35,6 +37,11 @@ export default function MenuItemCard({ item, onClick }) {
           {quota && !soldOut && (
             <span className="badge badge-quota">{quota}</span>
           )}
+          {dietaryTags.map((tag) => (
+            <span className="badge badge-quota" key={tag}>
+              {dietaryTagLabel(tag)}
+            </span>
+          ))}
         </div>
       </div>
     </button>

--- a/frontend/src/components/employee/MenuItemCard.test.jsx
+++ b/frontend/src/components/employee/MenuItemCard.test.jsx
@@ -6,6 +6,7 @@ import MenuItemCard from "./MenuItemCard";
 const available = {
   id: 1, vendor_id: 2, name: "排骨飯", price_cents: 9000,
   available: true, daily_quota: 5, remaining_quantity: 5, photo_path: null,
+  dietary_tags: ["ovo_lacto_vegetarian"],
 };
 const soldOut = { ...available, id: 2, name: "賣完飯", remaining_quantity: 0 };
 
@@ -16,6 +17,7 @@ describe("MenuItemCard", () => {
     render(<MenuItemCard item={available} onClick={onClick} />);
     expect(screen.getByText("排骨飯")).toBeInTheDocument();
     expect(screen.getByText("供應中")).toBeInTheDocument();
+    expect(screen.getByText("蛋奶素")).toBeInTheDocument();
     await user.click(screen.getByRole("button"));
     expect(onClick).toHaveBeenCalledOnce();
   });

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -6,6 +6,7 @@ import { useFacility } from "../../facility/FacilityContext";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { useVendors } from "../../hooks/useVendors";
 import { toLocalIso } from "../../utils/date";
+import { dietaryTagLabel, normalizeDietaryTags } from "../../utils/dietaryTags";
 import { formatPrice, quotaLabel } from "../../utils/format";
 
 function addDaysIso(days) {
@@ -48,10 +49,28 @@ export default function RandomMealPage() {
   const [recLoading, setRecLoading] = useState(false);
   const [recError, setRecError] = useState(null);
   const [limit, setLimit] = useState(10);
+  const [filters, setFilters] = useState({
+    excludeBeef: false,
+    excludePork: false,
+    vegetarian: false,
+    ovoLactoVegetarian: false,
+  });
 
   const selectedCount = allVendors ? vendors.length : selectedVendorIds.length;
   const mealDateInRange = mealDate >= minMealDate && mealDate <= maxMealDate;
   const canDraw = mealDateInRange && selectedCount > 0 && !drawing && !loading;
+  const includeTags = useMemo(() => {
+    const tags = [];
+    if (filters.vegetarian) tags.push("vegetarian");
+    if (filters.ovoLactoVegetarian) tags.push("ovo_lacto_vegetarian");
+    return tags;
+  }, [filters.vegetarian, filters.ovoLactoVegetarian]);
+  const excludeTags = useMemo(() => {
+    const tags = [];
+    if (filters.excludeBeef) tags.push("contains_beef");
+    if (filters.excludePork) tags.push("contains_pork");
+    return tags;
+  }, [filters.excludeBeef, filters.excludePork]);
   const remainingLabel = useMemo(() => {
     if (!draw) return null;
     if (draw.remaining_quantity == null) return "不限量";
@@ -69,7 +88,7 @@ export default function RandomMealPage() {
     let cancelled = false;
     setRecLoading(true);
     setRecError(null);
-    getRecommendations({ facilityId: selectedFacilityId, mealDate, limit })
+    getRecommendations({ facilityId: selectedFacilityId, mealDate, limit, includeTags, excludeTags })
       .then((data) => {
         if (!cancelled) setRecommendations(data);
       })
@@ -83,7 +102,7 @@ export default function RandomMealPage() {
         if (!cancelled) setRecLoading(false);
       });
     return () => { cancelled = true; };
-  }, [tab, mealDate, selectedFacilityId, limit]);
+  }, [tab, mealDate, selectedFacilityId, limit, includeTags, excludeTags]);
 
   function toggleVendor(vendorId) {
     setSelectedVendorIds((current) =>
@@ -91,6 +110,16 @@ export default function RandomMealPage() {
         ? current.filter((id) => id !== vendorId)
         : [...current, vendorId],
     );
+    setDraw(null);
+  }
+
+  function toggleDietaryFilter(name) {
+    setFilters((current) => {
+      const next = { ...current, [name]: !current[name] };
+      if (name === "vegetarian" && next.vegetarian) next.ovoLactoVegetarian = false;
+      if (name === "ovoLactoVegetarian" && next.ovoLactoVegetarian) next.vegetarian = false;
+      return next;
+    });
     setDraw(null);
   }
 
@@ -103,6 +132,8 @@ export default function RandomMealPage() {
         mealDate,
         vendorIds: allVendors ? null : selectedVendorIds,
         facilityId: selectedFacilityId,
+        includeTags,
+        excludeTags,
       });
       setDraw(result);
     } catch (err) {
@@ -116,6 +147,15 @@ export default function RandomMealPage() {
   function recRemainingLabel(rec) {
     if (rec.remaining_quantity == null) return quotaLabel(rec.item.daily_quota);
     return `剩餘 ${rec.remaining_quantity} 份`;
+  }
+
+  function DietaryBadges({ item }) {
+    const tags = normalizeDietaryTags(item.dietary_tags);
+    return tags.map((tag) => (
+      <span className="badge badge-quota" key={tag}>
+        {dietaryTagLabel(tag)}
+      </span>
+    ));
   }
 
   return (
@@ -144,6 +184,42 @@ export default function RandomMealPage() {
               setDraw(null);
             }}
           />
+
+          <div style={{ display: "grid", gap: 10 }}>
+            <span className="field-label">飲食偏好</span>
+            <label className="toggle-row">
+              <input
+                type="checkbox"
+                checked={filters.excludeBeef}
+                onChange={() => toggleDietaryFilter("excludeBeef")}
+              />
+              <span>不含牛肉</span>
+            </label>
+            <label className="toggle-row">
+              <input
+                type="checkbox"
+                checked={filters.excludePork}
+                onChange={() => toggleDietaryFilter("excludePork")}
+              />
+              <span>不含豬肉</span>
+            </label>
+            <label className="toggle-row">
+              <input
+                type="checkbox"
+                checked={filters.vegetarian}
+                onChange={() => toggleDietaryFilter("vegetarian")}
+              />
+              <span>只看素食</span>
+            </label>
+            <label className="toggle-row">
+              <input
+                type="checkbox"
+                checked={filters.ovoLactoVegetarian}
+                onChange={() => toggleDietaryFilter("ovoLactoVegetarian")}
+              />
+              <span>只看蛋奶素</span>
+            </label>
+          </div>
 
           {/* Vendor selector — only shown for 隨機抽餐 tab */}
           {tab === "random" && (
@@ -277,6 +353,7 @@ export default function RandomMealPage() {
                           <span className="badge badge-quota">
                             {recRemainingLabel(rec)}
                           </span>
+                          <DietaryBadges item={rec.item} />
                         </div>
                       </div>
                     </div>
@@ -325,6 +402,7 @@ export default function RandomMealPage() {
                     <span className="badge badge-quota">
                       {remainingLabel ?? quotaLabel(draw.item.daily_quota)}
                     </span>
+                    <DietaryBadges item={draw.item} />
                   </div>
 
                 </div>

--- a/frontend/src/pages/employee/RandomMealPage.test.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.test.jsx
@@ -1,7 +1,8 @@
 import { describe, test, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
+import { getRecommendations } from "../../api/employee";
 import RandomMealPage from "./RandomMealPage";
 
 const rec = vi.hoisted(() => ({
@@ -9,7 +10,7 @@ const rec = vi.hoisted(() => ({
   item: {
     id: 7, vendor_id: 3, name: "招牌雞腿飯", description: "",
     price_cents: 8000, available: true, daily_quota: 10,
-    remaining_quantity: 6, photo_path: null,
+    remaining_quantity: 6, photo_path: null, dietary_tags: ["vegetarian"],
   },
   quantity_sold: 12, remaining_quantity: 6, from_sales: true,
 }));
@@ -40,5 +41,25 @@ describe("RandomMealPage", () => {
     await user.click(name.closest(".recommend-card"));
 
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    expect(screen.getAllByText("素食").length).toBeGreaterThan(0);
+  });
+
+  test("dietary filters are sent to recommendations", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <RandomMealPage />
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("招牌雞腿飯");
+    vi.mocked(getRecommendations).mockClear();
+    await user.click(screen.getByText("不含牛肉"));
+
+    await waitFor(() => {
+      expect(getRecommendations).toHaveBeenLastCalledWith(expect.objectContaining({
+        excludeTags: ["contains_beef"],
+      }));
+    });
   });
 });

--- a/frontend/src/pages/vendor/VendorMenuFormPage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuFormPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { photoUrl } from "../../utils/format";
+import { DIETARY_TAG_OPTIONS, nextDietaryTags } from "../../utils/dietaryTags";
 import { useVendorMenu } from "../../vendor/VendorMenuContext";
 
 const EMPTY_FORM = {
@@ -9,6 +10,7 @@ const EMPTY_FORM = {
   price_cents: "",
   available: true,
   daily_quota: "",
+  dietary_tags: [],
 };
 
 function formToData(form) {
@@ -18,6 +20,7 @@ function formToData(form) {
     price_cents: Math.round(parseFloat(form.price_cents) * 100),
     available: form.available,
     daily_quota: form.daily_quota === "" ? null : Number(form.daily_quota),
+    dietary_tags: form.dietary_tags,
   };
 }
 
@@ -49,12 +52,17 @@ export default function VendorMenuFormPage() {
       price_cents: (item.price_cents / 100).toString(),
       available: item.available,
       daily_quota: item.daily_quota === null || item.daily_quota === undefined ? "" : String(item.daily_quota),
+      dietary_tags: item.dietary_tags ?? [],
     });
   }, [isEdit, itemId, loading, getItem]);
 
   function handleChange(e) {
     const { name, value, type, checked } = e.target;
     setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
+  }
+
+  function handleDietaryTagToggle(tag) {
+    setForm((prev) => ({ ...prev, dietary_tags: nextDietaryTags(prev.dietary_tags, tag) }));
   }
 
   async function handleSubmit(e) {
@@ -328,6 +336,26 @@ export default function VendorMenuFormPage() {
             />
             <span style={{ fontWeight: 600 }}>供應中</span>
           </label>
+
+          <div style={{ display: "grid", gap: 10 }}>
+            <span style={{ fontWeight: 600 }}>飲食標籤</span>
+            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+              {DIETARY_TAG_OPTIONS.map((option) => (
+                <label
+                  key={option.value}
+                  className="toggle-row"
+                  style={{ minHeight: 36, margin: 0 }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={form.dietary_tags.includes(option.value)}
+                    onChange={() => handleDietaryTagToggle(option.value)}
+                  />
+                  <span>{option.label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
 
         </div>
 

--- a/frontend/src/pages/vendor/VendorMenuListPage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuListPage.jsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
+import { dietaryTagLabel, normalizeDietaryTags } from "../../utils/dietaryTags";
 import { formatPrice, photoUrl } from "../../utils/format";
 import { useVendorMenu } from "../../vendor/VendorMenuContext";
 
@@ -250,6 +251,15 @@ export default function VendorMenuListPage() {
                   >
                     {item.description}
                   </p>
+                )}
+                {normalizeDietaryTags(item.dietary_tags).length > 0 && (
+                  <div className="item-badges" style={{ marginTop: 6 }}>
+                    {normalizeDietaryTags(item.dietary_tags).map((tag) => (
+                      <span className="badge badge-quota" key={tag}>
+                        {dietaryTagLabel(tag)}
+                      </span>
+                    ))}
+                  </div>
                 )}
               </div>
 

--- a/frontend/src/utils/dietaryTags.js
+++ b/frontend/src/utils/dietaryTags.js
@@ -1,0 +1,44 @@
+export const DIETARY_TAG_OPTIONS = [
+  { value: "contains_beef", label: "含牛肉" },
+  { value: "contains_pork", label: "含豬肉" },
+  { value: "vegetarian", label: "素食" },
+  { value: "ovo_lacto_vegetarian", label: "蛋奶素" },
+];
+
+export const DIETARY_TAG_LABELS = Object.fromEntries(
+  DIETARY_TAG_OPTIONS.map((option) => [option.value, option.label]),
+);
+
+const MEAT_TAGS = new Set(["contains_beef", "contains_pork"]);
+const VEGETARIAN_TAGS = new Set(["vegetarian", "ovo_lacto_vegetarian"]);
+
+export function dietaryTagLabel(tag) {
+  return DIETARY_TAG_LABELS[tag] ?? tag;
+}
+
+export function normalizeDietaryTags(tags) {
+  return Array.isArray(tags) ? tags.filter((tag, index) => tags.indexOf(tag) === index) : [];
+}
+
+export function nextDietaryTags(currentTags, tag) {
+  const current = new Set(normalizeDietaryTags(currentTags));
+  if (current.has(tag)) {
+    current.delete(tag);
+    return Array.from(current);
+  }
+
+  current.add(tag);
+  if (VEGETARIAN_TAGS.has(tag)) {
+    for (const meatTag of MEAT_TAGS) current.delete(meatTag);
+  }
+  if (MEAT_TAGS.has(tag)) {
+    for (const vegetarianTag of VEGETARIAN_TAGS) current.delete(vegetarianTag);
+  }
+  return Array.from(current);
+}
+
+export function matchesDietaryFilters(item, { includeTags = [], excludeTags = [] } = {}) {
+  const tags = new Set(normalizeDietaryTags(item?.dietary_tags));
+  return includeTags.every((tag) => tags.has(tag))
+    && excludeTags.every((tag) => !tags.has(tag));
+}


### PR DESCRIPTION
## Summary
- add dietary_tags migration, schema validation, and repository persistence for menu items
- filter employee recommendations and random meal draw by include/exclude dietary tags
- add vendor tag controls plus employee/vendor tag badges and mock fallback filtering

## Tests
- pytest backend/tests/test_menu_item_repository.py backend/tests/test_vendor_menu.py backend/tests/test_recommendation.py backend/tests/test_recommendation_route.py backend/tests/test_employee_ordering.py -q --basetemp=.tmp_pytest
- pytest backend/tests -q --basetemp=.tmp_pytest
- frontend npm test not run locally: node/npm are not available in this PowerShell PATH

Closes #164