### PR TITLE
chore(ci): clear Node 20 deprecation + filter third-party pytest warnings (#163)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ permissions:
   contents: read
   packages: write
 
+# Opt every job's JS actions into the Node 24 runtime to silence GitHub's
+# "Node.js 20 actions are deprecated" annotation (forced default 2026-06-16).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   unit:
     runs-on: ubuntu-latest
@@ -28,10 +33,6 @@ jobs:
 
   frontend-test:
     runs-on: ubuntu-latest
-    # Opt the JS actions into the Node 24 runtime now to silence GitHub's
-    # "Node.js 20 actions are deprecated" annotation on this job.
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,9 @@
 [pytest]
 markers =
     integration: requires a real Postgres (skipped until DB layer wires up)
+filterwarnings =
+    # Third-party library internals (our own code already uses the modern APIs):
+    # python-jose 3.3.0 still calls datetime.utcnow() inside jose/jwt.py.
+    ignore:.*datetime.datetime.utcnow.*:DeprecationWarning
+    # passlib 1.7.4 (unmaintained) imports the deprecated stdlib `crypt` module at load.
+    ignore:.*'crypt' is deprecated.*:DeprecationWarning


### PR DESCRIPTION
Closes #163

## What & why

Cleans up the two highest-value, lowest-risk CI warning categories so a real new warning stands out instead of drowning in noise. Config-only — no test outcome or product behaviour change.

## Changes

- **Node 20 deprecation (all jobs):** add a top-level `env: FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to `test.yml`, opting every job's JS actions into the Node 24 runtime. This silences GitHub's "Node.js 20 actions are deprecated" annotation across `unit`/`integration`/`sonar`/`frontend-test`/`build-push`/deploy jobs. Removed the now-redundant per-job copy on `frontend-test` (added in #160).
- **Backend pytest deprecations:** add a `filterwarnings` block to `pytest.ini` that ignores only the two third-party internals — `python-jose` calling `datetime.utcnow()` and `passlib` importing the deprecated `crypt` module. Our own code already uses the modern APIs (`datetime.now(timezone.utc)`); these libraries are the source (passlib is unmaintained). All other warnings stay visible.

## Verification

- `pytest backend/tests`: 343 passed, 39 skipped — **warnings summary dropped from 32 to 0** (the jose/passlib entries are gone); pass/skip counts unchanged.
- `npm test` (frontend): unaffected, all green.
- Node 24 opt-in is verified in CI on this PR (cannot be reproduced locally — it is a GitHub runner annotation).

## Out of scope (benign / documented won't-fix)

- Frontend npm audit (esbuild dev-server advisory) — already silenced in `frontend-test`; only affects `vite dev`, never run in CI/production; real fix needs a breaking Vite major.
- Postgres test-container `initdb: trust authentication`; SonarCloud `HTML files not indexed` (INFO); `deploy-preview` intentional "build start not confirmed" fallback.