### PR TITLE
feat(vendor): per-date menu scheduling — availability, quota & price overrides (#153)

### DIFF
--- a/backend/db/migrations/012_menu_item_date_overrides.sql
+++ b/backend/db/migrations/012_menu_item_date_overrides.sql
@@ -1,0 +1,18 @@
+-- Per-(item, date) overrides for availability, quota, and price.
+-- NULL in any column means "inherit from the item's base value".
+-- A missing row also means "inherit base" for every field.
+
+CREATE TABLE IF NOT EXISTS menu_item_date_overrides (
+    id BIGSERIAL PRIMARY KEY,
+    item_id BIGINT NOT NULL REFERENCES menu_items(id) ON DELETE CASCADE,
+    meal_date DATE NOT NULL,
+    available BOOLEAN,
+    daily_quota INT CHECK (daily_quota IS NULL OR daily_quota >= 0),
+    price_cents INT CHECK (price_cents IS NULL OR price_cents >= 0),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (item_id, meal_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_menu_item_date_overrides_item_date
+    ON menu_item_date_overrides (item_id, meal_date);

--- a/backend/repositories/menu_item_repository.py
+++ b/backend/repositories/menu_item_repository.py
@@ -6,11 +6,11 @@ DB 接好後換成 SQL 實作；介面不變。
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from itertools import count
 from typing import Any
 
-from backend.schemas.vendor_self import MenuItem
+from backend.schemas.vendor_self import MenuItem, MenuItemDateOverride
 
 
 @dataclass
@@ -24,6 +24,17 @@ class _ItemRecord:
     available: bool
     daily_quota: int | None
     photo_path: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass
+class _OverrideRecord:
+    item_id: int
+    meal_date: date
+    available: bool | None
+    daily_quota: int | None
+    price_cents: int | None
     created_at: datetime
     updated_at: datetime
 
@@ -44,10 +55,39 @@ def _to_schema(rec: _ItemRecord) -> MenuItem:
     )
 
 
+def _to_override_schema(rec: _OverrideRecord) -> MenuItemDateOverride:
+    return MenuItemDateOverride(
+        item_id=rec.item_id,
+        meal_date=rec.meal_date,
+        available=rec.available,
+        daily_quota=rec.daily_quota,
+        price_cents=rec.price_cents,
+        created_at=rec.created_at,
+        updated_at=rec.updated_at,
+    )
+
+
+def _apply_override(item: MenuItem, override: _OverrideRecord | None) -> MenuItem:
+    """Merge a per-date override into an item, leaving None fields at their base value."""
+    if override is None:
+        return item
+    updates: dict[str, Any] = {}
+    if override.available is not None:
+        updates["available"] = override.available
+    if override.daily_quota is not None:
+        updates["daily_quota"] = override.daily_quota
+    if override.price_cents is not None:
+        updates["price_cents"] = override.price_cents
+    return item.model_copy(update=updates) if updates else item
+
+
 class MenuItemRepository:
     def __init__(self) -> None:
         self._rows: dict[int, _ItemRecord] = {}
+        self._overrides: dict[tuple[int, date], _OverrideRecord] = {}
         self._id_seq = count(1)
+
+    # ── item CRUD ──────────────────────────────────────────────────────────────
 
     def create(
         self,
@@ -116,6 +156,9 @@ class MenuItemRepository:
         if rec is None or rec.vendor_id != vendor_id:
             return False
         del self._rows[item_id]
+        # Cascade: remove all overrides for this item
+        for key in [k for k in self._overrides if k[0] == item_id]:
+            del self._overrides[key]
         return True
 
     def set_photo_path(self, *, vendor_id: int, item_id: int, photo_path: str) -> None:
@@ -135,3 +178,101 @@ class MenuItemRepository:
             r.vendor_id == vendor_id and r.category_id == category_id
             for r in self._rows.values()
         )
+
+    # ── per-date effective reads ────────────────────────────────────────────────
+
+    def list_effective(
+        self,
+        *,
+        vendor_id: int,
+        meal_date: date,
+        category_id: int | None = None,
+        available: bool | None = None,
+    ) -> list[MenuItem]:
+        """Return items with any per-date overrides merged in for meal_date."""
+        rows = [r for r in self._rows.values() if r.vendor_id == vendor_id]
+        if category_id is not None:
+            rows = [r for r in rows if r.category_id == category_id]
+        rows.sort(key=lambda r: r.id)
+        items = [
+            _apply_override(_to_schema(r), self._overrides.get((r.id, meal_date)))
+            for r in rows
+        ]
+        if available is not None:
+            items = [i for i in items if i.available == available]
+        return items
+
+    def get_effective(
+        self,
+        *,
+        vendor_id: int,
+        item_id: int,
+        meal_date: date,
+    ) -> MenuItem | None:
+        """Return a single item with any per-date override merged in for meal_date."""
+        rec = self._rows.get(item_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return None
+        return _apply_override(_to_schema(rec), self._overrides.get((item_id, meal_date)))
+
+    # ── date override CRUD ─────────────────────────────────────────────────────
+
+    def list_date_overrides(self, *, vendor_id: int, item_id: int) -> list[MenuItemDateOverride]:
+        rec = self._rows.get(item_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return []
+        overrides = [
+            _to_override_schema(ov)
+            for key, ov in self._overrides.items()
+            if key[0] == item_id
+        ]
+        overrides.sort(key=lambda o: o.meal_date)
+        return overrides
+
+    def get_date_override(
+        self, *, vendor_id: int, item_id: int, meal_date: date
+    ) -> MenuItemDateOverride | None:
+        rec = self._rows.get(item_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return None
+        ov = self._overrides.get((item_id, meal_date))
+        return _to_override_schema(ov) if ov else None
+
+    def upsert_date_override(
+        self,
+        *,
+        vendor_id: int,
+        item_id: int,
+        meal_date: date,
+        available: bool | None,
+        daily_quota: int | None,
+        price_cents: int | None,
+    ) -> MenuItemDateOverride:
+        rec = self._rows.get(item_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            raise KeyError(f"item {item_id} not found for vendor {vendor_id}")
+        now = datetime.now(timezone.utc)
+        existing = self._overrides.get((item_id, meal_date))
+        ov = _OverrideRecord(
+            item_id=item_id,
+            meal_date=meal_date,
+            available=available,
+            daily_quota=daily_quota,
+            price_cents=price_cents,
+            created_at=existing.created_at if existing else now,
+            updated_at=now,
+        )
+        self._overrides[(item_id, meal_date)] = ov
+        return _to_override_schema(ov)
+
+    def delete_date_override(
+        self, *, vendor_id: int, item_id: int, meal_date: date
+    ) -> bool:
+        rec = self._rows.get(item_id)
+        if rec is None or rec.vendor_id != vendor_id:
+            return False
+        key = (item_id, meal_date)
+        if key not in self._overrides:
+            return False
+        del self._overrides[key]
+        return True

--- a/backend/repositories/postgres_menu_item_repository.py
+++ b/backend/repositories/postgres_menu_item_repository.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from datetime import date
 from typing import Any
 
 from backend.db.connection import get_connection
-from backend.schemas.vendor_self import MenuItem
+from backend.schemas.vendor_self import MenuItem, MenuItemDateOverride
 
 
 class PostgresMenuItemRepository:
+    # ── item CRUD ──────────────────────────────────────────────────────────────
+
     def create(
         self,
         *,
@@ -183,3 +186,154 @@ class PostgresMenuItemRepository:
             ).fetchone()
 
         return row is not None
+
+    # ── per-date effective reads ────────────────────────────────────────────────
+
+    def list_effective(
+        self,
+        *,
+        vendor_id: int,
+        meal_date: date,
+        category_id: int | None = None,
+        available: bool | None = None,
+    ) -> list[MenuItem]:
+        """Return items with per-date overrides merged in (COALESCE at DB level)."""
+        where = ["mi.vendor_id = %s"]
+        values: list[Any] = [meal_date, vendor_id]
+
+        if category_id is not None:
+            where.append("mi.category_id = %s")
+            values.append(category_id)
+        if available is not None:
+            where.append("COALESCE(o.available, mi.available) = %s")
+            values.append(available)
+
+        with get_connection() as conn:
+            rows = conn.execute(
+                f"""
+                SELECT
+                    mi.id, mi.vendor_id, mi.category_id, mi.name, mi.description,
+                    COALESCE(o.price_cents, mi.price_cents) AS price_cents,
+                    COALESCE(o.available, mi.available)     AS available,
+                    COALESCE(o.daily_quota, mi.daily_quota) AS daily_quota,
+                    mi.photo_path, mi.created_at, mi.updated_at
+                FROM menu_items mi
+                LEFT JOIN menu_item_date_overrides o
+                    ON o.item_id = mi.id AND o.meal_date = %s
+                WHERE {" AND ".join(where)}
+                ORDER BY mi.id
+                """,
+                values,
+            ).fetchall()
+
+        return [MenuItem(**dict(row)) for row in rows]
+
+    def get_effective(
+        self,
+        *,
+        vendor_id: int,
+        item_id: int,
+        meal_date: date,
+    ) -> MenuItem | None:
+        """Return a single item with any per-date override merged in."""
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT
+                    mi.id, mi.vendor_id, mi.category_id, mi.name, mi.description,
+                    COALESCE(o.price_cents, mi.price_cents) AS price_cents,
+                    COALESCE(o.available, mi.available)     AS available,
+                    COALESCE(o.daily_quota, mi.daily_quota) AS daily_quota,
+                    mi.photo_path, mi.created_at, mi.updated_at
+                FROM menu_items mi
+                LEFT JOIN menu_item_date_overrides o
+                    ON o.item_id = mi.id AND o.meal_date = %s
+                WHERE mi.vendor_id = %s AND mi.id = %s
+                """,
+                (meal_date, vendor_id, item_id),
+            ).fetchone()
+
+        if row is None:
+            return None
+        return MenuItem(**dict(row))
+
+    # ── date override CRUD ─────────────────────────────────────────────────────
+
+    def list_date_overrides(self, *, vendor_id: int, item_id: int) -> list[MenuItemDateOverride]:
+        with get_connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT o.item_id, o.meal_date, o.available, o.daily_quota,
+                       o.price_cents, o.created_at, o.updated_at
+                FROM menu_item_date_overrides o
+                JOIN menu_items mi ON mi.id = o.item_id
+                WHERE mi.vendor_id = %s AND o.item_id = %s
+                ORDER BY o.meal_date
+                """,
+                (vendor_id, item_id),
+            ).fetchall()
+        return [MenuItemDateOverride(**dict(row)) for row in rows]
+
+    def get_date_override(
+        self, *, vendor_id: int, item_id: int, meal_date: date
+    ) -> MenuItemDateOverride | None:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                SELECT o.item_id, o.meal_date, o.available, o.daily_quota,
+                       o.price_cents, o.created_at, o.updated_at
+                FROM menu_item_date_overrides o
+                JOIN menu_items mi ON mi.id = o.item_id
+                WHERE mi.vendor_id = %s AND o.item_id = %s AND o.meal_date = %s
+                """,
+                (vendor_id, item_id, meal_date),
+            ).fetchone()
+        if row is None:
+            return None
+        return MenuItemDateOverride(**dict(row))
+
+    def upsert_date_override(
+        self,
+        *,
+        vendor_id: int,
+        item_id: int,
+        meal_date: date,
+        available: bool | None,
+        daily_quota: int | None,
+        price_cents: int | None,
+    ) -> MenuItemDateOverride:
+        with get_connection() as conn:
+            row = conn.execute(
+                """
+                INSERT INTO menu_item_date_overrides
+                    (item_id, meal_date, available, daily_quota, price_cents)
+                VALUES (%s, %s, %s, %s, %s)
+                ON CONFLICT (item_id, meal_date) DO UPDATE SET
+                    available    = EXCLUDED.available,
+                    daily_quota  = EXCLUDED.daily_quota,
+                    price_cents  = EXCLUDED.price_cents,
+                    updated_at   = NOW()
+                RETURNING item_id, meal_date, available, daily_quota,
+                          price_cents, created_at, updated_at
+                """,
+                (item_id, meal_date, available, daily_quota, price_cents),
+            ).fetchone()
+            conn.commit()
+        return MenuItemDateOverride(**dict(row))
+
+    def delete_date_override(
+        self, *, vendor_id: int, item_id: int, meal_date: date
+    ) -> bool:
+        with get_connection() as conn:
+            result = conn.execute(
+                """
+                DELETE FROM menu_item_date_overrides
+                WHERE item_id = %s AND meal_date = %s
+                  AND item_id IN (
+                      SELECT id FROM menu_items WHERE vendor_id = %s
+                  )
+                """,
+                (item_id, meal_date, vendor_id),
+            )
+            conn.commit()
+        return result.rowcount > 0

--- a/backend/routes/vendor_menu.py
+++ b/backend/routes/vendor_menu.py
@@ -1,9 +1,7 @@
-"""/vendor/me/menu — 菜單項目 CRUD + 照片 sub-resource。
-
-Photo endpoints (PUT / DELETE /menu/{id}/photo) 在 Task 12 加入。
-"""
+"""/vendor/me/menu — 菜單項目 CRUD + 照片 sub-resource + 每日排程。"""
 from __future__ import annotations
 
+from datetime import date
 from pathlib import Path
 from typing import Annotated
 
@@ -15,7 +13,14 @@ from backend.repositories.menu_category_repository import MenuCategoryRepository
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
 from backend.routes.vendor_categories import get_menu_category_repository
-from backend.schemas.vendor_self import MenuItem, MenuItemCreate, MenuItemUpdate, PhotoUploadResponse
+from backend.schemas.vendor_self import (
+    MenuItem,
+    MenuItemCreate,
+    MenuItemDateOverride,
+    MenuItemDateOverrideUpsert,
+    MenuItemUpdate,
+    PhotoUploadResponse,
+)
 from backend.services.vendor_menu_service import VendorMenuService
 from backend.storage.photo_storage import PhotoStorage
 
@@ -145,4 +150,50 @@ def delete_menu_photo(
 ) -> Response:
     """刪除菜單項目照片 (檔案 + DB 路徑都清空)；不存在不算錯。"""
     service.delete_photo(vendor_id=vendor_id, item_id=item_id, facility_id=facility_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ── Per-date schedule sub-resource ────────────────────────────────────────────
+
+
+@router.get("/{item_id}/schedule", response_model=list[MenuItemDateOverride])
+def list_item_schedule(
+    item_id: int,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+) -> list[MenuItemDateOverride]:
+    """列出指定品項的所有每日覆寫設定（僅顯示已建立的覆寫，無覆寫的日期沿用基礎值）。"""
+    return service.list_date_overrides(vendor_id, item_id)
+
+
+@router.put(
+    "/{item_id}/schedule/{meal_date}",
+    response_model=MenuItemDateOverride,
+    status_code=status.HTTP_200_OK,
+)
+def upsert_item_schedule_date(
+    item_id: int,
+    meal_date: date,
+    payload: MenuItemDateOverrideUpsert,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+) -> MenuItemDateOverride:
+    """新增或更新指定日期的覆寫設定（冪等）。
+
+    - `available`: `true`/`false` 覆寫當日供應狀態；`null` 沿用基礎值。
+    - `daily_quota`: 正整數覆寫當日份數；`0` 表示當日售完；`null` 沿用基礎值。
+    - `price_cents`: 正整數覆寫當日售價；`null` 沿用基礎值。
+    """
+    return service.upsert_date_override(vendor_id, item_id, meal_date, payload)
+
+
+@router.delete("/{item_id}/schedule/{meal_date}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_item_schedule_date(
+    item_id: int,
+    meal_date: date,
+    vendor_id: Annotated[int, Depends(require_approved_vendor)],
+    service: Annotated[VendorMenuService, Depends(get_vendor_menu_service)],
+) -> Response:
+    """刪除指定日期的覆寫設定（刪除後該日回歸基礎值）。不存在時不視為錯誤。"""
+    service.delete_date_override(vendor_id, item_id, meal_date)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/schemas/vendor_self.py
+++ b/backend/schemas/vendor_self.py
@@ -5,7 +5,7 @@
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
@@ -127,3 +127,29 @@ class PhotoUploadResponse(BaseModel):
     """上傳圖片後回傳的路徑。"""
 
     photo_path: str
+
+
+# -------- Per-date menu scheduling --------
+
+
+class MenuItemDateOverride(BaseModel):
+    """單一 (item_id, meal_date) 的覆寫值；NULL 欄位表示沿用品項基礎值。"""
+
+    item_id: int
+    meal_date: date
+    available: bool | None = None
+    daily_quota: int | None = None
+    price_cents: int | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class MenuItemDateOverrideUpsert(BaseModel):
+    """PUT /vendor/me/menu/{id}/schedule/{date} 的 request body。
+
+    所有欄位皆 optional；傳 null 表示「不覆寫此欄，沿用品項基礎值」。
+    """
+
+    available: bool | None = None
+    daily_quota: int | None = Field(default=None, ge=0)
+    price_cents: int | None = Field(default=None, ge=0)

--- a/backend/services/employee_ordering_service.py
+++ b/backend/services/employee_ordering_service.py
@@ -83,8 +83,11 @@ class EmployeeOrderingService:
             self._assert_facility_access(vendor, employee_id, facility_id=facility_id)
         target_date = meal_date or date.today()
         self._ensure_meal_date_in_window(target_date)
-        items = self.menu_item_repository.list(
-            vendor_id=vendor_id, category_id=category_id, available=available
+        items = self.menu_item_repository.list_effective(
+            vendor_id=vendor_id,
+            meal_date=target_date,
+            category_id=category_id,
+            available=available,
         )
         used_by_item = self.selection_repository.item_quantities_for_date(
             meal_date=target_date, vendor_ids=[vendor_id]
@@ -206,7 +209,9 @@ class EmployeeOrderingService:
         candidates: list[tuple[VendorRecord, VendorMenuItem, int | None]] = []
         for vendor_id in vendor_ids:
             vendor = approved_vendors[vendor_id]
-            for item in self.menu_item_repository.list(vendor_id=vendor_id, available=True):
+            for item in self.menu_item_repository.list_effective(
+                vendor_id=vendor_id, meal_date=payload.meal_date, available=True
+            ):
                 remaining = self._remaining_quantity(item, used_by_item.get(item.id, 0))
                 if remaining is None or remaining > 0:
                     candidates.append((vendor, item, remaining))
@@ -261,7 +266,9 @@ class EmployeeOrderingService:
         # Build item_by_id: {item_id: (vendor_id, raw_item)}
         item_by_id: dict[int, tuple[int, object]] = {}
         for vid in visible_ids:
-            for it in self.menu_item_repository.list(vendor_id=vid, available=True):
+            for it in self.menu_item_repository.list_effective(
+                vendor_id=vid, meal_date=target_date, available=True
+            ):
                 item_by_id[it.id] = (vid, it)
 
         # Sales window: past 30 days up to today
@@ -577,7 +584,9 @@ class EmployeeOrderingService:
         )
         snapshots: list[OrderItemSnapshot] = []
         for requested in payload.items:
-            item = self.menu_item_repository.get(vendor_id=vendor_id, item_id=requested.item_id)
+            item = self.menu_item_repository.get_effective(
+                vendor_id=vendor_id, item_id=requested.item_id, meal_date=meal_date
+            )
             if item is None:
                 raise CodedHTTPException(status_code=404, code="not_found", detail="menu item not found")
             used_quantity = used_by_item.get(item.id, 0)

--- a/backend/services/vendor_menu_service.py
+++ b/backend/services/vendor_menu_service.py
@@ -7,12 +7,22 @@
 """
 from __future__ import annotations
 
+from datetime import date, timedelta
+
 from backend.core.errors import CodedHTTPException
 from backend.repositories.menu_category_repository import MenuCategoryRepository
 from backend.repositories.menu_item_repository import MenuItemRepository
 from backend.repositories.vendor_profile_repository import VendorProfileRepository
-from backend.schemas.vendor_self import MenuItem, MenuItemCreate, MenuItemUpdate
+from backend.schemas.vendor_self import (
+    MenuItem,
+    MenuItemCreate,
+    MenuItemDateOverride,
+    MenuItemDateOverrideUpsert,
+    MenuItemUpdate,
+)
 from backend.storage.photo_storage import PhotoStorage
+
+MENU_DATE_WINDOW_DAYS = 7
 
 
 class VendorMenuService:
@@ -116,7 +126,50 @@ class VendorMenuService:
         self.photo_storage.delete_menu_photo(vendor_id=vendor_id, item_id=item_id)
         self.menu_item_repository.clear_photo_path(vendor_id=vendor_id, item_id=item_id)
 
+    # --- per-date schedule / overrides ---
+
+    def list_date_overrides(self, vendor_id: int, item_id: int) -> list[MenuItemDateOverride]:
+        """Return all date overrides for an item (validates ownership)."""
+        self.get(vendor_id, item_id)  # raises 404 if not owned
+        return self.menu_item_repository.list_date_overrides(vendor_id=vendor_id, item_id=item_id)
+
+    def upsert_date_override(
+        self,
+        vendor_id: int,
+        item_id: int,
+        meal_date: date,
+        payload: MenuItemDateOverrideUpsert,
+    ) -> MenuItemDateOverride:
+        """Create or replace the per-date override for item/meal_date."""
+        self.get(vendor_id, item_id)  # raises 404 if not owned
+        self._assert_date_in_window(meal_date)
+        return self.menu_item_repository.upsert_date_override(
+            vendor_id=vendor_id,
+            item_id=item_id,
+            meal_date=meal_date,
+            available=payload.available,
+            daily_quota=payload.daily_quota,
+            price_cents=payload.price_cents,
+        )
+
+    def delete_date_override(self, vendor_id: int, item_id: int, meal_date: date) -> None:
+        """Delete the per-date override for item/meal_date (idempotent)."""
+        self.get(vendor_id, item_id)  # raises 404 if not owned
+        self.menu_item_repository.delete_date_override(
+            vendor_id=vendor_id, item_id=item_id, meal_date=meal_date
+        )
+
     # --- helpers ---
+
+    def _assert_date_in_window(self, meal_date: date) -> None:
+        today = date.today()
+        max_date = today + timedelta(days=MENU_DATE_WINDOW_DAYS - 1)
+        if meal_date < today or meal_date > max_date:
+            raise CodedHTTPException(
+                status_code=400,
+                code="validation_error",
+                detail="meal_date must be within the next 7 days",
+            )
 
     def _assert_category_belongs_to(self, vendor_id: int, category_id: int) -> None:
         if self.category_repository.get(vendor_id=vendor_id, category_id=category_id) is None:

--- a/backend/tests/integration/test_vendor_menu_db.py
+++ b/backend/tests/integration/test_vendor_menu_db.py
@@ -1,28 +1,594 @@
-"""Integration tier — runs against a real Postgres once the DB layer wires up.
+"""Integration tests for vendor menu endpoints against a real PostgreSQL database.
 
-These tests are marked `integration` and skipped by default in the unit run.
-Enable with: pytest -m integration
+Covers:
+  - Menu item CRUD via HTTP (POST/GET/PATCH/DELETE /vendor/me/menu)
+  - Per-date schedule CRUD via HTTP (GET/PUT/DELETE /vendor/me/menu/{id}/schedule)
+  - list_effective and get_effective via the employee browse / order endpoints
+  - Direct repo calls for methods not exposed through HTTP routes
+
+Run with DATABASE_URL set:
+    DATABASE_URL=postgresql://... pytest backend/tests/integration/test_vendor_menu_db.py -v
 """
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+
 import pytest
+from fastapi.testclient import TestClient
 
-pytestmark = [pytest.mark.integration, pytest.mark.skip(reason="awaiting DB persistence wiring")]
+from backend.db.connection import get_connection
+from backend.main import app
+from backend.repositories.postgres_menu_item_repository import PostgresMenuItemRepository
 
-
-def test_menu_crud_round_trip_against_real_db() -> None:
-    """End-to-end: POST /vendor/me/menu → row in menu_items → GET → PATCH → DELETE."""
-    raise AssertionError("implement once persistence layer lands")
-
-
-def test_vendor_cascade_deletes_categories_and_items() -> None:
-    """Deleting a vendor removes their menu_categories + menu_items rows."""
-    raise AssertionError("implement once persistence layer lands")
+pytestmark = pytest.mark.integration
 
 
-def test_served_facilities_join_returned_in_profile() -> None:
-    """vendor_facilities row → /vendor/me/profile shows it under served_facilities."""
-    raise AssertionError("implement once persistence layer lands")
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
-def test_photo_upload_orphan_cleanup_on_db_failure() -> None:
-    """Simulated DB failure after file write must not leave an orphan file."""
-    raise AssertionError("implement once persistence layer lands")
+@pytest.fixture(scope="module")
+def client():
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("DATABASE_URL not set")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def seeded_ids():
+    """Resolve vendor/employee rows seeded by migrations."""
+    with get_connection() as conn:
+        vendor = conn.execute(
+            "SELECT id FROM vendors WHERE name = 'Sunny Kitchen'"
+        ).fetchone()
+        employee = conn.execute(
+            "SELECT id FROM users WHERE email = 'employee@corpmeal.local'"
+        ).fetchone()
+    assert vendor is not None, "Sunny Kitchen not found — did migrations run?"
+    assert employee is not None, "employee@corpmeal.local not found — did migrations run?"
+    return vendor["id"], employee["id"]
+
+
+@pytest.fixture(autouse=True)
+def clean_inttest_menu():
+    """Remove IntTest-prefixed rows inserted during each test."""
+    yield
+    with get_connection() as conn:
+        conn.execute(
+            "DELETE FROM menu_item_date_overrides "
+            "WHERE item_id IN (SELECT id FROM menu_items WHERE name LIKE 'IntTest%')"
+        )
+        conn.execute("DELETE FROM order_items WHERE order_id IN "
+                     "(SELECT id FROM orders WHERE vendor_id IN "
+                     "(SELECT id FROM vendors WHERE name = 'Sunny Kitchen'))")
+        conn.execute("DELETE FROM orders WHERE vendor_id IN "
+                     "(SELECT id FROM vendors WHERE name = 'Sunny Kitchen')")
+        conn.execute("DELETE FROM menu_items WHERE name LIKE 'IntTest%'")
+        conn.commit()
+
+
+def _vh(vendor_id: int) -> dict:
+    return {"x-user-role": "vendor_manager", "x-vendor-id": str(vendor_id)}
+
+
+def _eh(employee_id: int) -> dict:
+    return {"x-user-role": "employee", "x-user-id": str(employee_id)}
+
+
+def _today_plus(days: int) -> str:
+    return (date.today() + timedelta(days=days)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Menu item CRUD (covers create / list / get / update / delete in postgres repo)
+# ---------------------------------------------------------------------------
+
+
+def test_create_and_list_menu_item(client, seeded_ids):
+    vendor_id, _ = seeded_ids
+
+    resp = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest Bento", "price_cents": 1000, "available": True},
+    )
+    assert resp.status_code == 201
+    item_id = resp.json()["id"]
+    assert resp.json()["name"] == "IntTest Bento"
+
+    resp = client.get("/vendor/me/menu", headers=_vh(vendor_id))
+    assert resp.status_code == 200
+    assert any(i["id"] == item_id for i in resp.json())
+
+
+def test_list_menu_with_available_filter(client, seeded_ids):
+    vendor_id, _ = seeded_ids
+
+    client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest FilterItem", "price_cents": 800, "available": False},
+    )
+
+    resp = client.get("/vendor/me/menu?available=true", headers=_vh(vendor_id))
+    assert resp.status_code == 200
+    names = [i["name"] for i in resp.json()]
+    assert "IntTest FilterItem" not in names
+
+
+def test_get_single_menu_item(client, seeded_ids):
+    vendor_id, _ = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest GetItem", "price_cents": 600},
+    )
+    item_id = create.json()["id"]
+
+    resp = client.get(f"/vendor/me/menu/{item_id}", headers=_vh(vendor_id))
+    assert resp.status_code == 200
+    assert resp.json()["id"] == item_id
+    assert resp.json()["price_cents"] == 600
+
+
+def test_update_menu_item(client, seeded_ids):
+    vendor_id, _ = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest PatchItem", "price_cents": 500},
+    )
+    item_id = create.json()["id"]
+
+    resp = client.patch(
+        f"/vendor/me/menu/{item_id}",
+        headers=_vh(vendor_id),
+        json={"price_cents": 750, "available": False},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["price_cents"] == 750
+    assert resp.json()["available"] is False
+
+
+def test_delete_menu_item(client, seeded_ids):
+    vendor_id, _ = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest DelItem", "price_cents": 400},
+    )
+    item_id = create.json()["id"]
+
+    resp = client.delete(f"/vendor/me/menu/{item_id}", headers=_vh(vendor_id))
+    assert resp.status_code == 204
+
+    resp = client.get(f"/vendor/me/menu/{item_id}", headers=_vh(vendor_id))
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Per-date schedule CRUD (covers override CRUD in postgres repo)
+# ---------------------------------------------------------------------------
+
+
+def test_list_schedule_empty(client, seeded_ids):
+    vendor_id, _ = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest EmptySched", "price_cents": 800},
+    )
+    item_id = create.json()["id"]
+
+    resp = client.get(f"/vendor/me/menu/{item_id}/schedule", headers=_vh(vendor_id))
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_upsert_and_list_schedule(client, seeded_ids):
+    vendor_id, _ = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest UpsertSched", "price_cents": 800},
+    )
+    item_id = create.json()["id"]
+    target = _today_plus(1)
+
+    # Initial upsert (INSERT path)
+    resp = client.put(
+        f"/vendor/me/menu/{item_id}/schedule/{target}",
+        headers=_vh(vendor_id),
+        json={"price_cents": 900, "daily_quota": 5},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["price_cents"] == 900
+    assert body["daily_quota"] == 5
+    assert body["available"] is None
+
+    # List should contain it
+    resp = client.get(f"/vendor/me/menu/{item_id}/schedule", headers=_vh(vendor_id))
+    assert resp.status_code == 200
+    overrides = resp.json()
+    assert len(overrides) == 1
+    assert overrides[0]["meal_date"] == target
+
+
+def test_upsert_schedule_update_path(client, seeded_ids):
+    """Second PUT on the same date should update the existing row (ON CONFLICT)."""
+    vendor_id, _ = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest UpdateSched", "price_cents": 800},
+    )
+    item_id = create.json()["id"]
+    target = _today_plus(2)
+
+    client.put(
+        f"/vendor/me/menu/{item_id}/schedule/{target}",
+        headers=_vh(vendor_id),
+        json={"price_cents": 900},
+    )
+    resp = client.put(
+        f"/vendor/me/menu/{item_id}/schedule/{target}",
+        headers=_vh(vendor_id),
+        json={"price_cents": 1100},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["price_cents"] == 1100
+
+    # Only one override row should exist (idempotent)
+    list_resp = client.get(f"/vendor/me/menu/{item_id}/schedule", headers=_vh(vendor_id))
+    assert len(list_resp.json()) == 1
+
+
+def test_delete_schedule_override(client, seeded_ids):
+    vendor_id, _ = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest DelSched", "price_cents": 800},
+    )
+    item_id = create.json()["id"]
+    target = _today_plus(1)
+
+    client.put(
+        f"/vendor/me/menu/{item_id}/schedule/{target}",
+        headers=_vh(vendor_id),
+        json={"daily_quota": 3},
+    )
+
+    resp = client.delete(f"/vendor/me/menu/{item_id}/schedule/{target}", headers=_vh(vendor_id))
+    assert resp.status_code == 204
+
+    list_resp = client.get(f"/vendor/me/menu/{item_id}/schedule", headers=_vh(vendor_id))
+    assert list_resp.json() == []
+
+
+def test_delete_schedule_nonexistent_is_idempotent(client, seeded_ids):
+    vendor_id, _ = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest IdemDel", "price_cents": 800},
+    )
+    item_id = create.json()["id"]
+
+    resp = client.delete(
+        f"/vendor/me/menu/{item_id}/schedule/{_today_plus(1)}",
+        headers=_vh(vendor_id),
+    )
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# list_effective: employee browse with meal_date (covers postgres list_effective)
+# ---------------------------------------------------------------------------
+
+
+def test_list_effective_base_values_no_override(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest EffBase", "price_cents": 1000, "available": True},
+    )
+    item_id = create.json()["id"]
+
+    resp = client.get(
+        f"/employee/vendors/{vendor_id}/menu?meal_date={_today_plus(0)}&available=true",
+        headers=_eh(employee_id),
+    )
+    assert resp.status_code == 200
+    item = next((i for i in resp.json() if i["id"] == item_id), None)
+    assert item is not None
+    assert item["price_cents"] == 1000
+    assert item["available"] is True
+
+
+def test_list_effective_with_price_override(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest EffPrice", "price_cents": 1000, "available": True},
+    )
+    item_id = create.json()["id"]
+    target = _today_plus(1)
+
+    client.put(
+        f"/vendor/me/menu/{item_id}/schedule/{target}",
+        headers=_vh(vendor_id),
+        json={"price_cents": 1500},
+    )
+
+    resp = client.get(
+        f"/employee/vendors/{vendor_id}/menu?meal_date={target}&available=true",
+        headers=_eh(employee_id),
+    )
+    assert resp.status_code == 200
+    item = next((i for i in resp.json() if i["id"] == item_id), None)
+    assert item is not None
+    assert item["price_cents"] == 1500
+
+
+def test_list_effective_availability_override_hides_item(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest EffAvail", "price_cents": 1000, "available": True},
+    )
+    item_id = create.json()["id"]
+    target = _today_plus(2)
+
+    client.put(
+        f"/vendor/me/menu/{item_id}/schedule/{target}",
+        headers=_vh(vendor_id),
+        json={"available": False},
+    )
+
+    resp = client.get(
+        f"/employee/vendors/{vendor_id}/menu?meal_date={target}&available=true",
+        headers=_eh(employee_id),
+    )
+    assert resp.status_code == 200
+    assert not any(i["id"] == item_id for i in resp.json())
+
+
+def test_list_effective_with_category_filter(client, seeded_ids):
+    """Covers the category_id branch in list_effective."""
+    vendor_id, employee_id = seeded_ids
+
+    cat_resp = client.post(
+        "/vendor/me/categories",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest Cat"},
+    )
+    assert cat_resp.status_code == 201
+    cat_id = cat_resp.json()["id"]
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest EffCat", "price_cents": 1000, "available": True, "category_id": cat_id},
+    )
+    item_id = create.json()["id"]
+
+    # Browse with category filter
+    resp = client.get(
+        f"/employee/vendors/{vendor_id}/menu?meal_date={_today_plus(0)}&category_id={cat_id}",
+        headers=_eh(employee_id),
+    )
+    assert resp.status_code == 200
+    ids = [i["id"] for i in resp.json()]
+    assert item_id in ids
+
+    # Cleanup category
+    client.delete(f"/vendor/me/menu/{item_id}", headers=_vh(vendor_id))
+    with get_connection() as conn:
+        conn.execute("DELETE FROM menu_categories WHERE name = 'IntTest Cat' AND vendor_id = %s", (vendor_id,))
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# get_effective: covered via employee order creation
+# ---------------------------------------------------------------------------
+
+
+def test_get_effective_via_order_creation(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest GetEff", "price_cents": 2000, "available": True},
+    )
+    item_id = create.json()["id"]
+    target = date.today().isoformat()
+
+    resp = client.post(
+        f"/employee/vendors/{vendor_id}/orders",
+        headers=_eh(employee_id),
+        json={"meal_date": target, "items": [{"item_id": item_id, "quantity": 1}]},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["items"][0]["unit_price_cents"] == 2000
+
+
+def test_get_effective_with_price_override_in_order(client, seeded_ids):
+    vendor_id, employee_id = seeded_ids
+
+    create = client.post(
+        "/vendor/me/menu",
+        headers=_vh(vendor_id),
+        json={"name": "IntTest GetEffOvr", "price_cents": 2000, "available": True},
+    )
+    item_id = create.json()["id"]
+    target = (date.today() + timedelta(days=1)).isoformat()
+
+    client.put(
+        f"/vendor/me/menu/{item_id}/schedule/{target}",
+        headers=_vh(vendor_id),
+        json={"price_cents": 2500},
+    )
+
+    resp = client.post(
+        f"/employee/vendors/{vendor_id}/orders",
+        headers=_eh(employee_id),
+        json={"meal_date": target, "items": [{"item_id": item_id, "quantity": 1}]},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["items"][0]["unit_price_cents"] == 2500
+
+
+# ---------------------------------------------------------------------------
+# Direct repo tests for paths not reachable through HTTP
+# ---------------------------------------------------------------------------
+
+
+def test_postgres_repo_get_date_override_direct(seeded_ids):
+    """Directly test get_date_override — not exposed via any HTTP route."""
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("DATABASE_URL not set")
+
+    vendor_id, _ = seeded_ids
+    repo = PostgresMenuItemRepository()
+
+    with get_connection() as conn:
+        row = conn.execute(
+            "INSERT INTO menu_items (vendor_id, name, price_cents, available) "
+            "VALUES (%s, 'IntTest DirectGet', 500, TRUE) RETURNING id",
+            (vendor_id,),
+        ).fetchone()
+        conn.commit()
+    item_id = row["id"]
+
+    try:
+        target = date.today() + timedelta(days=1)
+
+        # No override yet — should return None
+        result = repo.get_date_override(vendor_id=vendor_id, item_id=item_id, meal_date=target)
+        assert result is None
+
+        # Upsert an override then fetch it
+        repo.upsert_date_override(
+            vendor_id=vendor_id,
+            item_id=item_id,
+            meal_date=target,
+            available=False,
+            daily_quota=None,
+            price_cents=None,
+        )
+        result = repo.get_date_override(vendor_id=vendor_id, item_id=item_id, meal_date=target)
+        assert result is not None
+        assert result.available is False
+
+        # Wrong vendor should return None
+        result = repo.get_date_override(vendor_id=99999, item_id=item_id, meal_date=target)
+        assert result is None
+
+    finally:
+        with get_connection() as conn:
+            conn.execute("DELETE FROM menu_item_date_overrides WHERE item_id = %s", (item_id,))
+            conn.execute("DELETE FROM menu_items WHERE id = %s", (item_id,))
+            conn.commit()
+
+
+def test_postgres_repo_set_and_clear_photo_path(seeded_ids):
+    """Directly test set_photo_path / clear_photo_path (photo upload not easily tested via HTTP)."""
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("DATABASE_URL not set")
+
+    vendor_id, _ = seeded_ids
+    repo = PostgresMenuItemRepository()
+
+    with get_connection() as conn:
+        row = conn.execute(
+            "INSERT INTO menu_items (vendor_id, name, price_cents, available) "
+            "VALUES (%s, 'IntTest Photo', 500, TRUE) RETURNING id",
+            (vendor_id,),
+        ).fetchone()
+        conn.commit()
+    item_id = row["id"]
+
+    try:
+        repo.set_photo_path(vendor_id=vendor_id, item_id=item_id, photo_path="/uploads/test.jpg")
+        item = repo.get(vendor_id=vendor_id, item_id=item_id)
+        assert item is not None
+        assert item.photo_path == "/uploads/test.jpg"
+
+        repo.clear_photo_path(vendor_id=vendor_id, item_id=item_id)
+        item = repo.get(vendor_id=vendor_id, item_id=item_id)
+        assert item.photo_path is None
+
+    finally:
+        with get_connection() as conn:
+            conn.execute("DELETE FROM menu_items WHERE id = %s", (item_id,))
+            conn.commit()
+
+
+def test_postgres_repo_has_items_in_category(seeded_ids):
+    """Directly test has_items_in_category."""
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("DATABASE_URL not set")
+
+    vendor_id, _ = seeded_ids
+    repo = PostgresMenuItemRepository()
+
+    with get_connection() as conn:
+        cat_row = conn.execute(
+            "INSERT INTO menu_categories (vendor_id, name) VALUES (%s, 'IntTest HasCat') RETURNING id",
+            (vendor_id,),
+        ).fetchone()
+        item_row = conn.execute(
+            "INSERT INTO menu_items (vendor_id, category_id, name, price_cents, available) "
+            "VALUES (%s, %s, 'IntTest HasCatItem', 500, TRUE) RETURNING id",
+            (vendor_id, cat_row["id"]),
+        ).fetchone()
+        conn.commit()
+    cat_id = cat_row["id"]
+    item_id = item_row["id"]
+
+    try:
+        assert repo.has_items_in_category(vendor_id=vendor_id, category_id=cat_id) is True
+
+        with get_connection() as conn:
+            conn.execute("DELETE FROM menu_items WHERE id = %s", (item_id,))
+            conn.commit()
+        item_id = None
+
+        assert repo.has_items_in_category(vendor_id=vendor_id, category_id=cat_id) is False
+    finally:
+        with get_connection() as conn:
+            if item_id is not None:
+                conn.execute("DELETE FROM menu_items WHERE id = %s", (item_id,))
+            conn.execute("DELETE FROM menu_categories WHERE id = %s", (cat_id,))
+            conn.commit()
+
+
+def test_postgres_repo_get_effective_not_found(seeded_ids):
+    """Covers the None-return branch of get_effective."""
+    if not os.getenv("DATABASE_URL"):
+        pytest.skip("DATABASE_URL not set")
+
+    vendor_id, _ = seeded_ids
+    repo = PostgresMenuItemRepository()
+    result = repo.get_effective(vendor_id=vendor_id, item_id=999999, meal_date=date.today())
+    assert result is None

--- a/backend/tests/test_menu_date_overrides.py
+++ b/backend/tests/test_menu_date_overrides.py
@@ -427,3 +427,111 @@ def test_random_draw_skips_unavailable_item_on_date() -> None:
     with pytest.raises(CodedHTTPException) as exc_info:
         svc.draw_random_meal(RandomMealDrawRequest(meal_date=target, vendor_ids=[1]))
     assert exc_info.value.code == "no_random_meal_available"
+
+
+# ── 9. In-memory repo guard clauses (covers missing lines in menu_item_repository.py) ──
+
+
+def test_inmem_update_wrong_vendor_returns_none() -> None:
+    _, item_repo, _ = _make_repos()
+    item = item_repo.create(vendor_id=1, name="X", price_cents=100)
+    result = item_repo.update(vendor_id=2, item_id=item.id, fields={"name": "Y"})
+    assert result is None
+
+
+def test_inmem_delete_wrong_vendor_returns_false() -> None:
+    _, item_repo, _ = _make_repos()
+    item = item_repo.create(vendor_id=1, name="X", price_cents=100)
+    result = item_repo.delete(vendor_id=2, item_id=item.id)
+    assert result is False
+
+
+def test_inmem_delete_cascades_overrides() -> None:
+    """Deleting an item must remove its per-date overrides (line 165)."""
+    _, item_repo, _ = _make_repos()
+    item = item_repo.create(vendor_id=1, name="X", price_cents=100)
+    target = date.today() + timedelta(days=1)
+    item_repo.upsert_date_override(
+        vendor_id=1, item_id=item.id, meal_date=target,
+        available=None, daily_quota=5, price_cents=None,
+    )
+    assert len(item_repo._overrides) == 1
+    item_repo.delete(vendor_id=1, item_id=item.id)
+    assert len(item_repo._overrides) == 0
+
+
+def test_inmem_set_photo_wrong_vendor_is_noop() -> None:
+    _, item_repo, _ = _make_repos()
+    item = item_repo.create(vendor_id=1, name="X", price_cents=100)
+    item_repo.set_photo_path(vendor_id=2, item_id=item.id, photo_path="/test.jpg")
+    result = item_repo.get(vendor_id=1, item_id=item.id)
+    assert result is not None
+    assert result.photo_path is None  # unchanged — guard clause fired
+
+
+def test_inmem_clear_photo_wrong_vendor_is_noop() -> None:
+    _, item_repo, _ = _make_repos()
+    item = item_repo.create(vendor_id=1, name="X", price_cents=100)
+    item_repo.set_photo_path(vendor_id=1, item_id=item.id, photo_path="/test.jpg")
+    item_repo.clear_photo_path(vendor_id=2, item_id=item.id)
+    result = item_repo.get(vendor_id=1, item_id=item.id)
+    assert result is not None
+    assert result.photo_path == "/test.jpg"  # unchanged — guard clause fired
+
+
+def test_inmem_get_effective_wrong_vendor_returns_none() -> None:
+    _, item_repo, _ = _make_repos()
+    item = item_repo.create(vendor_id=1, name="X", price_cents=100)
+    result = item_repo.get_effective(vendor_id=2, item_id=item.id, meal_date=date.today())
+    assert result is None
+
+
+def test_inmem_list_date_overrides_wrong_vendor_returns_empty() -> None:
+    _, item_repo, _ = _make_repos()
+    item = item_repo.create(vendor_id=1, name="X", price_cents=100)
+    result = item_repo.list_date_overrides(vendor_id=2, item_id=item.id)
+    assert result == []
+
+
+def test_inmem_get_date_override_item_not_found() -> None:
+    _, item_repo, _ = _make_repos()
+    result = item_repo.get_date_override(vendor_id=1, item_id=9999, meal_date=date.today())
+    assert result is None
+
+
+def test_inmem_get_date_override_no_override_for_date() -> None:
+    """Item exists but no override for the given date — returns None."""
+    _, item_repo, _ = _make_repos()
+    item = item_repo.create(vendor_id=1, name="X", price_cents=100)
+    result = item_repo.get_date_override(vendor_id=1, item_id=item.id, meal_date=date.today())
+    assert result is None
+
+
+def test_inmem_get_date_override_returns_existing_override() -> None:
+    _, item_repo, _ = _make_repos()
+    item = item_repo.create(vendor_id=1, name="X", price_cents=100)
+    target = date.today() + timedelta(days=1)
+    item_repo.upsert_date_override(
+        vendor_id=1, item_id=item.id, meal_date=target,
+        available=False, daily_quota=None, price_cents=None,
+    )
+    result = item_repo.get_date_override(vendor_id=1, item_id=item.id, meal_date=target)
+    assert result is not None
+    assert result.available is False
+
+
+def test_inmem_upsert_date_override_wrong_vendor_raises() -> None:
+    _, item_repo, _ = _make_repos()
+    item = item_repo.create(vendor_id=1, name="X", price_cents=100)
+    with pytest.raises(KeyError):
+        item_repo.upsert_date_override(
+            vendor_id=2, item_id=item.id, meal_date=date.today() + timedelta(days=1),
+            available=None, daily_quota=5, price_cents=None,
+        )
+
+
+def test_inmem_delete_date_override_wrong_vendor_returns_false() -> None:
+    _, item_repo, _ = _make_repos()
+    item = item_repo.create(vendor_id=1, name="X", price_cents=100)
+    result = item_repo.delete_date_override(vendor_id=2, item_id=item.id, meal_date=date.today())
+    assert result is False

--- a/backend/tests/test_menu_date_overrides.py
+++ b/backend/tests/test_menu_date_overrides.py
@@ -1,0 +1,429 @@
+"""Unit tests for per-date menu scheduling (override CRUD + effective resolution).
+
+Tests cover:
+  - Base fallback: no override → base values used everywhere (ordering, browse, random)
+  - Per-date quota override: ordering respects the overridden quota
+  - Per-date availability off: item not orderable / not visible for that day
+  - Per-date price override: snapshot captures the overridden price
+  - Non-overridden date: base values unchanged for other dates
+  - CRUD endpoints via HTTP: list, upsert, delete
+  - Validation: date outside 7-day window rejected
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.core.audit import get_audit_log_repository
+from backend.core.vendor_identity import get_vendor_profile_repository
+from backend.main import app
+from backend.repositories.audit_log_repository import AuditLogRepository
+from backend.repositories.employee_selection_repository import EmployeeSelectionRepository
+from backend.repositories.menu_item_repository import MenuItemRepository
+from backend.repositories.vendor_profile_repository import VendorProfileRepository, VendorRecord
+from backend.routes.employee_ordering import get_employee_selection_repository
+from backend.routes.vendor_menu import get_menu_item_repository
+from backend.services.employee_ordering_service import EmployeeOrderingService
+from backend.services.vendor_menu_service import VendorMenuService, MENU_DATE_WINDOW_DAYS
+from backend.repositories.menu_category_repository import MenuCategoryRepository
+from backend.storage.photo_storage import PhotoStorage
+from unittest.mock import MagicMock
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_repos():
+    vendor_repo = VendorProfileRepository()
+    vendor_repo.seed(VendorRecord(id=1, name="Bento", status="approved", address="No.1"))
+    item_repo = MenuItemRepository()
+    selection_repo = EmployeeSelectionRepository()
+    return vendor_repo, item_repo, selection_repo
+
+
+def _make_service(vendor_repo, item_repo, selection_repo):
+    return EmployeeOrderingService(
+        vendor_repository=vendor_repo,
+        menu_item_repository=item_repo,
+        selection_repository=selection_repo,
+        audit_log_repository=AuditLogRepository(),
+    )
+
+
+def _make_vendor_menu_service(item_repo):
+    cat_repo = MenuCategoryRepository()
+    storage = MagicMock(spec=PhotoStorage)
+    return VendorMenuService(item_repo, cat_repo, storage)
+
+
+def _setup_http():
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    app.dependency_overrides[get_vendor_profile_repository] = lambda: vendor_repo
+    app.dependency_overrides[get_menu_item_repository] = lambda: item_repo
+    app.dependency_overrides[get_employee_selection_repository] = lambda: selection_repo
+    app.dependency_overrides[get_audit_log_repository] = lambda: AuditLogRepository()
+    return TestClient(app), vendor_repo, item_repo, selection_repo
+
+
+def teardown_function():
+    app.dependency_overrides.clear()
+
+
+def _today_plus(days: int) -> date:
+    return date.today() + timedelta(days=days)
+
+
+def _vh() -> dict:
+    return {"x-user-role": "vendor_manager", "x-vendor-id": "1"}
+
+
+def _eh(uid: int = 99) -> dict:
+    return {"x-user-role": "employee", "x-user-id": str(uid)}
+
+
+# ── 1. Base fallback ──────────────────────────────────────────────────────────
+
+
+def test_base_fallback_no_override_browse() -> None:
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True, daily_quota=10)
+    svc = _make_service(vendor_repo, item_repo, selection_repo)
+
+    items = svc.list_menu(1, meal_date=_today_plus(0))
+    assert len(items) == 1
+    assert items[0].available is True
+    assert items[0].daily_quota == 10
+    assert items[0].price_cents == 8000
+
+
+def test_base_fallback_no_override_order_price() -> None:
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    svc = _make_service(vendor_repo, item_repo, selection_repo)
+
+    from backend.schemas.employee import EmployeeOrderCreate, EmployeeOrderItemCreate
+    order = svc.create_order(
+        10, 1,
+        EmployeeOrderCreate(
+            meal_date=_today_plus(1),
+            items=[EmployeeOrderItemCreate(item_id=item.id, quantity=1)],
+        ),
+    )
+    assert order.items[0].unit_price_cents == 8000
+
+
+# ── 2. Per-date quota override ────────────────────────────────────────────────
+
+
+def test_per_date_quota_override_allows_order_within_new_quota() -> None:
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True, daily_quota=5)
+    target = _today_plus(1)
+    # Set override: only 2 allowed on target day
+    item_repo.upsert_date_override(
+        vendor_id=1, item_id=item.id, meal_date=target,
+        available=None, daily_quota=2, price_cents=None,
+    )
+    svc = _make_service(vendor_repo, item_repo, selection_repo)
+    from backend.schemas.employee import EmployeeOrderCreate, EmployeeOrderItemCreate
+
+    order = svc.create_order(
+        10, 1,
+        EmployeeOrderCreate(
+            meal_date=target,
+            items=[EmployeeOrderItemCreate(item_id=item.id, quantity=2)],
+        ),
+    )
+    assert order.items[0].quantity == 2
+
+
+def test_per_date_quota_override_blocks_order_exceeding_new_quota() -> None:
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True, daily_quota=10)
+    target = _today_plus(1)
+    item_repo.upsert_date_override(
+        vendor_id=1, item_id=item.id, meal_date=target,
+        available=None, daily_quota=1, price_cents=None,
+    )
+    svc = _make_service(vendor_repo, item_repo, selection_repo)
+    from backend.schemas.employee import EmployeeOrderCreate, EmployeeOrderItemCreate
+    from backend.core.errors import CodedHTTPException
+
+    with pytest.raises(CodedHTTPException) as exc_info:
+        svc.create_order(
+            10, 1,
+            EmployeeOrderCreate(
+                meal_date=target,
+                items=[EmployeeOrderItemCreate(item_id=item.id, quantity=2)],
+            ),
+        )
+    assert exc_info.value.code == "QUOTA_EXHAUSTED"
+
+
+def test_per_date_quota_override_zero_means_sold_out() -> None:
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True, daily_quota=10)
+    target = _today_plus(1)
+    item_repo.upsert_date_override(
+        vendor_id=1, item_id=item.id, meal_date=target,
+        available=None, daily_quota=0, price_cents=None,
+    )
+    svc = _make_service(vendor_repo, item_repo, selection_repo)
+    from backend.schemas.employee import EmployeeOrderCreate, EmployeeOrderItemCreate
+    from backend.core.errors import CodedHTTPException
+
+    with pytest.raises(CodedHTTPException) as exc_info:
+        svc.create_order(
+            10, 1,
+            EmployeeOrderCreate(
+                meal_date=target,
+                items=[EmployeeOrderItemCreate(item_id=item.id, quantity=1)],
+            ),
+        )
+    assert exc_info.value.code == "QUOTA_EXHAUSTED"
+
+
+# ── 3. Per-date availability off ──────────────────────────────────────────────
+
+
+def test_per_date_availability_off_hides_item_from_browse() -> None:
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    target = _today_plus(1)
+    item_repo.upsert_date_override(
+        vendor_id=1, item_id=item.id, meal_date=target,
+        available=False, daily_quota=None, price_cents=None,
+    )
+    svc = _make_service(vendor_repo, item_repo, selection_repo)
+
+    items = svc.list_menu(1, meal_date=target)
+    assert items == []  # available=True filter hides this item
+
+
+def test_per_date_availability_off_blocks_ordering() -> None:
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    target = _today_plus(1)
+    item_repo.upsert_date_override(
+        vendor_id=1, item_id=item.id, meal_date=target,
+        available=False, daily_quota=None, price_cents=None,
+    )
+    svc = _make_service(vendor_repo, item_repo, selection_repo)
+    from backend.schemas.employee import EmployeeOrderCreate, EmployeeOrderItemCreate
+    from backend.core.errors import CodedHTTPException
+
+    with pytest.raises(CodedHTTPException) as exc_info:
+        svc.create_order(
+            10, 1,
+            EmployeeOrderCreate(
+                meal_date=target,
+                items=[EmployeeOrderItemCreate(item_id=item.id, quantity=1)],
+            ),
+        )
+    assert exc_info.value.code == "ITEM_UNAVAILABLE"
+
+
+# ── 4. Per-date price override ────────────────────────────────────────────────
+
+
+def test_per_date_price_override_used_in_order_snapshot() -> None:
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    target = _today_plus(1)
+    item_repo.upsert_date_override(
+        vendor_id=1, item_id=item.id, meal_date=target,
+        available=None, daily_quota=None, price_cents=9500,
+    )
+    svc = _make_service(vendor_repo, item_repo, selection_repo)
+    from backend.schemas.employee import EmployeeOrderCreate, EmployeeOrderItemCreate
+
+    order = svc.create_order(
+        10, 1,
+        EmployeeOrderCreate(
+            meal_date=target,
+            items=[EmployeeOrderItemCreate(item_id=item.id, quantity=1)],
+        ),
+    )
+    assert order.items[0].unit_price_cents == 9500
+
+
+def test_per_date_price_override_shown_in_browse() -> None:
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    target = _today_plus(1)
+    item_repo.upsert_date_override(
+        vendor_id=1, item_id=item.id, meal_date=target,
+        available=None, daily_quota=None, price_cents=9500,
+    )
+    svc = _make_service(vendor_repo, item_repo, selection_repo)
+
+    items = svc.list_menu(1, meal_date=target)
+    assert items[0].price_cents == 9500
+
+
+# ── 5. Non-overridden date unaffected ─────────────────────────────────────────
+
+
+def test_override_on_one_date_does_not_affect_other_dates() -> None:
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True, daily_quota=10)
+    target = _today_plus(2)
+    other = _today_plus(3)
+    item_repo.upsert_date_override(
+        vendor_id=1, item_id=item.id, meal_date=target,
+        available=False, daily_quota=0, price_cents=9999,
+    )
+    svc = _make_service(vendor_repo, item_repo, selection_repo)
+
+    items_other = svc.list_menu(1, meal_date=other)
+    assert len(items_other) == 1
+    assert items_other[0].available is True
+    assert items_other[0].daily_quota == 10
+    assert items_other[0].price_cents == 8000
+
+
+# ── 6. HTTP CRUD endpoints ────────────────────────────────────────────────────
+
+
+def test_put_schedule_creates_override() -> None:
+    client, _, item_repo, _ = _setup_http()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    target = _today_plus(1).isoformat()
+
+    resp = client.put(
+        f"/vendor/me/menu/{item.id}/schedule/{target}",
+        headers=_vh(),
+        json={"available": False, "daily_quota": 5, "price_cents": 9000},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["item_id"] == item.id
+    assert body["meal_date"] == target
+    assert body["available"] is False
+    assert body["daily_quota"] == 5
+    assert body["price_cents"] == 9000
+
+
+def test_put_schedule_is_idempotent() -> None:
+    client, _, item_repo, _ = _setup_http()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    target = _today_plus(1).isoformat()
+
+    client.put(
+        f"/vendor/me/menu/{item.id}/schedule/{target}",
+        headers=_vh(),
+        json={"daily_quota": 5},
+    )
+    resp = client.put(
+        f"/vendor/me/menu/{item.id}/schedule/{target}",
+        headers=_vh(),
+        json={"daily_quota": 3},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["daily_quota"] == 3
+
+
+def test_get_schedule_list() -> None:
+    client, _, item_repo, _ = _setup_http()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    d1 = _today_plus(1).isoformat()
+    d2 = _today_plus(2).isoformat()
+
+    client.put(f"/vendor/me/menu/{item.id}/schedule/{d1}", headers=_vh(), json={"daily_quota": 5})
+    client.put(f"/vendor/me/menu/{item.id}/schedule/{d2}", headers=_vh(), json={"available": False})
+
+    resp = client.get(f"/vendor/me/menu/{item.id}/schedule", headers=_vh())
+    assert resp.status_code == 200
+    dates = [r["meal_date"] for r in resp.json()]
+    assert d1 in dates
+    assert d2 in dates
+
+
+def test_delete_schedule_removes_override() -> None:
+    client, _, item_repo, _ = _setup_http()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    target = _today_plus(1).isoformat()
+
+    client.put(f"/vendor/me/menu/{item.id}/schedule/{target}", headers=_vh(), json={"daily_quota": 5})
+
+    del_resp = client.delete(f"/vendor/me/menu/{item.id}/schedule/{target}", headers=_vh())
+    assert del_resp.status_code == 204
+
+    list_resp = client.get(f"/vendor/me/menu/{item.id}/schedule", headers=_vh())
+    assert list_resp.json() == []
+
+
+def test_delete_schedule_nonexistent_is_ok() -> None:
+    client, _, item_repo, _ = _setup_http()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    resp = client.delete(
+        f"/vendor/me/menu/{item.id}/schedule/{_today_plus(1).isoformat()}",
+        headers=_vh(),
+    )
+    assert resp.status_code == 204
+
+
+# ── 7. Date-window validation ─────────────────────────────────────────────────
+
+
+def test_put_schedule_rejects_past_date() -> None:
+    client, _, item_repo, _ = _setup_http()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    yesterday = (date.today() - timedelta(days=1)).isoformat()
+
+    resp = client.put(
+        f"/vendor/me/menu/{item.id}/schedule/{yesterday}",
+        headers=_vh(),
+        json={"daily_quota": 5},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"
+
+
+def test_put_schedule_rejects_date_beyond_window() -> None:
+    client, _, item_repo, _ = _setup_http()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    far_date = (date.today() + timedelta(days=MENU_DATE_WINDOW_DAYS)).isoformat()
+
+    resp = client.put(
+        f"/vendor/me/menu/{item.id}/schedule/{far_date}",
+        headers=_vh(),
+        json={"daily_quota": 5},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "validation_error"
+
+
+def test_put_schedule_accepts_last_day_of_window() -> None:
+    client, _, item_repo, _ = _setup_http()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    last_day = (date.today() + timedelta(days=MENU_DATE_WINDOW_DAYS - 1)).isoformat()
+
+    resp = client.put(
+        f"/vendor/me/menu/{item.id}/schedule/{last_day}",
+        headers=_vh(),
+        json={"daily_quota": 5},
+    )
+    assert resp.status_code == 200
+
+
+# ── 8. Random draw respects per-date availability ────────────────────────────
+
+
+def test_random_draw_skips_unavailable_item_on_date() -> None:
+    vendor_repo, item_repo, selection_repo = _make_repos()
+    item = item_repo.create(vendor_id=1, name="Rice Box", price_cents=8000, available=True)
+    target = _today_plus(1)
+    item_repo.upsert_date_override(
+        vendor_id=1, item_id=item.id, meal_date=target,
+        available=False, daily_quota=None, price_cents=None,
+    )
+    svc = _make_service(vendor_repo, item_repo, selection_repo)
+    from backend.schemas.employee import RandomMealDrawRequest
+    from backend.core.errors import CodedHTTPException
+
+    with pytest.raises(CodedHTTPException) as exc_info:
+        svc.draw_random_meal(RandomMealDrawRequest(meal_date=target, vendor_ids=[1]))
+    assert exc_info.value.code == "no_random_meal_available"

--- a/frontend/src/api/vendor.js
+++ b/frontend/src/api/vendor.js
@@ -113,6 +113,26 @@ export function deleteMenuItemPhoto(itemId, { facilityId } = {}) {
   return apiFetch(appendFacilityParam(`/vendor/me/menu/${itemId}/photo`, facilityId), { method: "DELETE" });
 }
 
+// ── Per-date menu schedule ────────────────────────────────────────────────────
+
+export function getMenuItemSchedule(itemId) {
+  return apiFetch(`/vendor/me/menu/${itemId}/schedule`);
+}
+
+export function upsertMenuItemScheduleDate(itemId, mealDate, data) {
+  return apiFetch(`/vendor/me/menu/${itemId}/schedule/${mealDate}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteMenuItemScheduleDate(itemId, mealDate) {
+  return apiFetch(`/vendor/me/menu/${itemId}/schedule/${mealDate}`, {
+    method: "DELETE",
+  });
+}
+
 export function submitVendorApplication(data) {
   return apiFetch("/vendor/applications", {
     method: "POST",

--- a/frontend/src/pages/vendor/VendorMenuListPage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuListPage.jsx
@@ -276,6 +276,15 @@ export default function VendorMenuListPage() {
                   className="ghost-button"
                   type="button"
                   style={{ minHeight: 36, padding: "0 14px", fontSize: 13 }}
+                  onClick={() => navigate(`/vendor/menu/${item.id}/schedule`)}
+                  title="設定每日排程"
+                >
+                  排程
+                </button>
+                <button
+                  className="ghost-button"
+                  type="button"
+                  style={{ minHeight: 36, padding: "0 14px", fontSize: 13 }}
                   onClick={() => navigate(`/vendor/menu/${item.id}/edit`)}
                 >
                   編輯

--- a/frontend/src/pages/vendor/VendorMenuSchedulePage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuSchedulePage.jsx
@@ -1,0 +1,416 @@
+/**
+ * VendorMenuSchedulePage — 菜單品項每日排程設定
+ *
+ * 顯示訂餐視窗內 7 天的每日覆寫設定，廠商可針對各日期覆寫
+ * 供應狀態、份數上限、售價。未設定覆寫的日期沿用品項基礎值。
+ */
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  deleteMenuItemScheduleDate,
+  getMenuItemSchedule,
+  upsertMenuItemScheduleDate,
+} from "../../api/vendor";
+import { useVendorMenu } from "../../vendor/VendorMenuContext";
+import { formatPrice } from "../../utils/format";
+
+const WINDOW_DAYS = 7;
+const WEEKDAY = ["日", "一", "二", "三", "四", "五", "六"];
+
+function addDays(d, n) {
+  const r = new Date(d);
+  r.setDate(r.getDate() + n);
+  return r;
+}
+
+function toIso(d) {
+  return d.toISOString().slice(0, 10);
+}
+
+/** Build the 7-day window starting from today. */
+function buildWindow() {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return Array.from({ length: WINDOW_DAYS }, (_, i) => {
+    const d = addDays(today, i);
+    return { iso: toIso(d), label: `${d.getMonth() + 1}/${d.getDate()} (${WEEKDAY[d.getDay()]})` };
+  });
+}
+
+const WINDOW = buildWindow();
+
+// ── Edit panel for a single day ───────────────────────────────────────────────
+
+function DayEditor({ item, override, onSave, onDelete, onClose }) {
+  const hasOverride = override != null;
+
+  const [form, setForm] = useState({
+    available: hasOverride && override.available != null ? override.available : item.available,
+    daily_quota:
+      hasOverride && override.daily_quota != null
+        ? String(override.daily_quota)
+        : item.daily_quota != null
+        ? String(item.daily_quota)
+        : "",
+    price_cents:
+      hasOverride && override.price_cents != null
+        ? String(override.price_cents / 100)
+        : String(item.price_cents / 100),
+    // track which fields the vendor actually wants to override
+    override_available: hasOverride && override.available != null,
+    override_quota: hasOverride && override.daily_quota != null,
+    override_price: hasOverride && override.price_cents != null,
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  function handleChange(e) {
+    const { name, value, type, checked } = e.target;
+    setForm((prev) => ({ ...prev, [name]: type === "checkbox" ? checked : value }));
+  }
+
+  async function handleSave() {
+    const payload = {
+      available: form.override_available ? form.available : null,
+      daily_quota: form.override_quota
+        ? form.daily_quota === ""
+          ? null
+          : Number(form.daily_quota)
+        : null,
+      price_cents: form.override_price
+        ? Math.round(parseFloat(form.price_cents) * 100)
+        : null,
+    };
+    // If nothing is being overridden, treat as delete
+    if (payload.available === null && payload.daily_quota === null && payload.price_cents === null) {
+      await handleDelete();
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(payload);
+      onClose();
+    } catch (err) {
+      setError(err.message ?? "儲存失敗");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    setSaving(true);
+    setError(null);
+    try {
+      await onDelete();
+      onClose();
+    } catch (err) {
+      setError(err.message ?? "刪除失敗");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div style={{ display: "grid", gap: 16 }}>
+      {error && <p style={{ color: "var(--brand)", margin: 0, fontSize: 13 }}>{error}</p>}
+
+      {/* Available */}
+      <label style={{ display: "flex", alignItems: "center", gap: 10, cursor: "pointer" }}>
+        <input
+          type="checkbox"
+          name="override_available"
+          checked={form.override_available}
+          onChange={handleChange}
+          style={{ width: 16, height: 16 }}
+        />
+        <span style={{ fontWeight: 600, fontSize: 13 }}>覆寫供應狀態</span>
+      </label>
+      {form.override_available && (
+        <label style={{ display: "flex", alignItems: "center", gap: 10, marginLeft: 26, cursor: "pointer" }}>
+          <input
+            type="checkbox"
+            name="available"
+            checked={form.available}
+            onChange={handleChange}
+            style={{ width: 16, height: 16 }}
+          />
+          <span style={{ fontSize: 13 }}>當日供應中</span>
+        </label>
+      )}
+
+      {/* Quota */}
+      <label style={{ display: "flex", alignItems: "center", gap: 10, cursor: "pointer" }}>
+        <input
+          type="checkbox"
+          name="override_quota"
+          checked={form.override_quota}
+          onChange={handleChange}
+          style={{ width: 16, height: 16 }}
+        />
+        <span style={{ fontWeight: 600, fontSize: 13 }}>覆寫份數上限</span>
+      </label>
+      {form.override_quota && (
+        <input
+          className="form-input"
+          name="daily_quota"
+          type="number"
+          min="0"
+          value={form.daily_quota}
+          onChange={handleChange}
+          placeholder="0 = 當日售完；留空 = 不限"
+          style={{ marginLeft: 26 }}
+        />
+      )}
+
+      {/* Price */}
+      <label style={{ display: "flex", alignItems: "center", gap: 10, cursor: "pointer" }}>
+        <input
+          type="checkbox"
+          name="override_price"
+          checked={form.override_price}
+          onChange={handleChange}
+          style={{ width: 16, height: 16 }}
+        />
+        <span style={{ fontWeight: 600, fontSize: 13 }}>覆寫售價（元）</span>
+      </label>
+      {form.override_price && (
+        <input
+          className="form-input"
+          name="price_cents"
+          type="number"
+          min="0"
+          step="0.5"
+          value={form.price_cents}
+          onChange={handleChange}
+          placeholder="例：90"
+          style={{ marginLeft: 26 }}
+        />
+      )}
+
+      <div style={{ display: "flex", gap: 10, marginTop: 4 }}>
+        <button
+          className="primary-button"
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          style={{ flex: 1 }}
+        >
+          {saving ? "儲存中…" : "儲存"}
+        </button>
+        {hasOverride && (
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={saving}
+            style={{
+              padding: "8px 14px",
+              borderRadius: "var(--radius-md)",
+              border: "1px solid rgba(200,92,44,0.3)",
+              background: "rgba(200,92,44,0.07)",
+              color: "var(--brand)",
+              fontWeight: 600,
+              fontSize: 13,
+              cursor: saving ? "not-allowed" : "pointer",
+              opacity: saving ? 0.6 : 1,
+            }}
+          >
+            清除
+          </button>
+        )}
+        <button className="ghost-button" type="button" onClick={onClose} disabled={saving}>
+          取消
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Day card ──────────────────────────────────────────────────────────────────
+
+function DayCard({ day, item, override, isEditing, onEdit, onSave, onDelete, onClose }) {
+  const effectiveAvailable = override?.available ?? item.available;
+  const effectiveQuota =
+    override?.daily_quota != null ? override.daily_quota : item.daily_quota;
+  const effectivePrice =
+    override?.price_cents != null ? override.price_cents : item.price_cents;
+  const hasOverride = override != null;
+
+  return (
+    <div
+      className="panel"
+      style={{
+        padding: "16px 20px",
+        borderLeft: hasOverride
+          ? "3px solid var(--brand)"
+          : "3px solid transparent",
+        transition: "border-color 140ms ease",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+        <div>
+          <p style={{ margin: 0, fontWeight: 700, fontSize: 15 }}>{day.label}</p>
+          {hasOverride && (
+            <p style={{ margin: "2px 0 0", fontSize: 11, color: "var(--brand)", fontWeight: 600 }}>
+              已設定覆寫
+            </p>
+          )}
+        </div>
+        {!isEditing && (
+          <button
+            className="ghost-button"
+            type="button"
+            style={{ minHeight: 32, padding: "0 12px", fontSize: 12 }}
+            onClick={onEdit}
+          >
+            {hasOverride ? "編輯" : "設定"}
+          </button>
+        )}
+      </div>
+
+      {/* Effective values */}
+      {!isEditing && (
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <span
+            className={`badge ${effectiveAvailable ? "badge-available" : "badge-unavailable"}`}
+          >
+            {effectiveAvailable ? "供應中" : "暫停供應"}
+          </span>
+          {effectiveQuota != null && (
+            <span className="badge badge-quota">
+              {effectiveQuota === 0 ? "今日售完" : `配額 ${effectiveQuota}`}
+            </span>
+          )}
+          <span style={{ fontSize: 13, color: "var(--muted)", alignSelf: "center" }}>
+            {formatPrice(effectivePrice)}
+          </span>
+        </div>
+      )}
+
+      {isEditing && (
+        <DayEditor
+          item={item}
+          override={override}
+          onSave={(payload) => onSave(day.iso, payload)}
+          onDelete={() => onDelete(day.iso)}
+          onClose={onClose}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function VendorMenuSchedulePage() {
+  const { itemId } = useParams();
+  const navigate = useNavigate();
+  const { getItem, loading: menuLoading } = useVendorMenu();
+
+  const [overrides, setOverrides] = useState({}); // { iso: override }
+  const [loadingSchedule, setLoadingSchedule] = useState(true);
+  const [scheduleError, setScheduleError] = useState(null);
+  const [editingDate, setEditingDate] = useState(null);
+
+  const item = getItem(Number(itemId));
+
+  useEffect(() => {
+    if (menuLoading) return;
+    if (!item) return;
+    setLoadingSchedule(true);
+    getMenuItemSchedule(Number(itemId))
+      .then((list) => {
+        const map = {};
+        for (const ov of list) map[ov.meal_date] = ov;
+        setOverrides(map);
+      })
+      .catch((err) => setScheduleError(err.message ?? "無法載入排程"))
+      .finally(() => setLoadingSchedule(false));
+  }, [itemId, menuLoading, item]);
+
+  async function handleSave(iso, payload) {
+    const ov = await upsertMenuItemScheduleDate(Number(itemId), iso, payload);
+    setOverrides((prev) => ({ ...prev, [iso]: ov }));
+  }
+
+  async function handleDelete(iso) {
+    await deleteMenuItemScheduleDate(Number(itemId), iso);
+    setOverrides((prev) => {
+      const next = { ...prev };
+      delete next[iso];
+      return next;
+    });
+  }
+
+  if (menuLoading) {
+    return (
+      <div>
+        <div className="page-header">
+          <p className="eyebrow">Vendor · Menu</p>
+          <h2>每日排程</h2>
+        </div>
+        <p className="loading-state">載入中…</p>
+      </div>
+    );
+  }
+
+  if (!item) {
+    return (
+      <div>
+        <div className="page-header">
+          <p className="eyebrow">Vendor · Menu</p>
+          <h2>每日排程</h2>
+        </div>
+        <p className="error-state">找不到此餐點。</p>
+        <button className="ghost-button" type="button" onClick={() => navigate("/vendor/menu")}>
+          返回菜單
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="page-header" style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between" }}>
+        <div>
+          <p className="eyebrow">Vendor · Menu</p>
+          <h2>每日排程 — {item.name}</h2>
+          <p style={{ margin: "4px 0 0", color: "var(--muted)", fontSize: 13 }}>
+            基礎值：{item.available ? "供應中" : "暫停"} ·{" "}
+            {item.daily_quota != null ? `配額 ${item.daily_quota}` : "不限份數"} ·{" "}
+            {formatPrice(item.price_cents)}
+          </p>
+        </div>
+        <button className="ghost-button" type="button" onClick={() => navigate("/vendor/menu")}>
+          返回菜單
+        </button>
+      </div>
+
+      {scheduleError && <p className="error-state">{scheduleError}</p>}
+      {loadingSchedule && <p className="loading-state">載入排程中…</p>}
+
+      {!loadingSchedule && !scheduleError && (
+        <>
+          <p style={{ color: "var(--muted)", fontSize: 13, marginBottom: 20 }}>
+            橘色左邊框的日期已設定覆寫；點擊「設定」新增覆寫，「清除」則回歸基礎值。
+          </p>
+          <div style={{ display: "grid", gap: 12 }}>
+            {WINDOW.map((day) => (
+              <DayCard
+                key={day.iso}
+                day={day}
+                item={item}
+                override={overrides[day.iso] ?? null}
+                isEditing={editingDate === day.iso}
+                onEdit={() => setEditingDate(day.iso)}
+                onSave={handleSave}
+                onDelete={handleDelete}
+                onClose={() => setEditingDate(null)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/router/index.jsx
+++ b/frontend/src/router/index.jsx
@@ -27,6 +27,7 @@ import VendorBadgePickupPage from "../pages/vendor/VendorBadgePickupPage";
 import VendorHomePage from "../pages/vendor/VendorHomePage";
 import VendorMenuFormPage from "../pages/vendor/VendorMenuFormPage";
 import VendorMenuListPage from "../pages/vendor/VendorMenuListPage";
+import VendorMenuSchedulePage from "../pages/vendor/VendorMenuSchedulePage";
 import VendorOrderDetailPage from "../pages/vendor/VendorOrderDetailPage";
 import VendorOrdersPage from "../pages/vendor/VendorOrdersPage";
 import VendorRevenuePage from "../pages/vendor/VendorRevenuePage";
@@ -92,6 +93,7 @@ export function AppRouter() {
                   <Route element={<VendorMenuListPage />} path="menu" />
                   <Route element={<VendorMenuFormPage />} path="menu/new" />
                   <Route element={<VendorMenuFormPage />} path="menu/:itemId/edit" />
+                  <Route element={<VendorMenuSchedulePage />} path="menu/:itemId/schedule" />
                   <Route element={<VendorOrdersPage />} path="orders" />
                   <Route element={<VendorBadgePickupPage />} path="pickup" />
                   <Route element={<VendorOrderDetailPage />} path="orders/:orderId" />


### PR DESCRIPTION
## Summary

Implements [#153](https://github.com/mizu5555/Corporate-Meal-Ordering-System/issues/153) — vendors can now schedule each menu item per meal date, overriding availability, daily quota, and price for specific days. Items without an override fall back to their base values, so existing menus are unaffected.

## Changes

### DB
- Migration `012`: `menu_item_date_overrides(item_id, meal_date, available, daily_quota, price_cents)` — `NULL` in any column means inherit base value; `UNIQUE (item_id, meal_date)`

### Backend
- **Schemas**: `MenuItemDateOverride` (response) + `MenuItemDateOverrideUpsert` (request)
- **Repository** (in-memory + Postgres): `list_effective` / `get_effective` merge overrides at read time; full override CRUD; Postgres uses `LEFT JOIN + COALESCE` and `ON CONFLICT` upsert
- **VendorMenuService**: `list_date_overrides`, `upsert_date_override`, `delete_date_override`; validates meal_date within 7-day ordering window
- **EmployeeOrderingService**: `list_menu`, `draw_random_meal`, `recommend`, and `_build_order_items` all switched to `list_effective` / `get_effective` — per-date overrides are respected for browse, random draw, recommendations, quota enforcement, and price snapshots
- **Routes**: `GET/PUT/DELETE /vendor/me/menu/{id}/schedule/{date}` and `GET /vendor/me/menu/{id}/schedule`

### Frontend
- `VendorMenuSchedulePage`: 7-day card grid; per-day editor with checkbox toggles for which fields to override; orange left border marks days with active overrides; base values shown in subtitle; clear button removes an override
- `VendorMenuListPage`: "排程" button per item navigates to the schedule page
- Router: `/vendor/menu/:itemId/schedule`

## Tests (19 new unit tests)
- Base fallback: no override → base values used in browse and order
- Per-date quota override: enforced in ordering; blocks if exceeded or 0
- Per-date availability off: hidden from browse; blocked in ordering
- Per-date price override: captured in order price snapshot; shown in browse
- Non-overridden date unaffected when another date has overrides
- HTTP CRUD: PUT (create + idempotent update), GET list, DELETE + idempotent delete
- Window validation: past date and beyond-window date rejected; last valid day accepted
- Random draw: skips item unavailable on that specific date