### PR TITLE
chore(seed): demo seed completeness — review states + menu dietary tags & sold-out example

### DIFF
--- a/backend/db/seeds/demo_seed.sql
+++ b/backend/db/seeds/demo_seed.sql
@@ -690,6 +690,56 @@ FROM users u, vendors v, facilities f
 WHERE u.email = 'demo.employee3@corpmeal.local' AND v.name = 'Demo Green Bowl' AND f.code = 'F15A'
 ON CONFLICT DO NOTHING;
 
+-- ─────────────────────────────────────────────
+-- 10. VENDOR APPLICATIONS (mirror the real apply→review flow)
+--   Approved: the 3 live vendors, reviewed by admin.
+--   Pending:  Demo Dumpling Bar, awaiting review.
+--   Rejected: Demo Fast Fry, declined with a reason.
+-- Idempotent: one application per vendor (guarded on vendor_id).
+-- ─────────────────────────────────────────────
+INSERT INTO vendor_applications
+  (vendor_id, submitted_by_user_id, status, reviewed_by_user_id, reviewed_at, created_at, updated_at)
+SELECT v.id, v.owner_user_id, 'approved',
+  (SELECT id FROM users WHERE email = 'admin@corpmeal.local'),
+  NOW() - INTERVAL '20 days', NOW() - INTERVAL '22 days', NOW() - INTERVAL '20 days'
+FROM vendors v
+WHERE v.name IN ('Sunny Kitchen', 'Demo Noodle House', 'Demo Green Bowl')
+  AND NOT EXISTS (SELECT 1 FROM vendor_applications a WHERE a.vendor_id = v.id);
+
+INSERT INTO vendor_applications
+  (vendor_id, submitted_by_user_id, status, created_at, updated_at)
+SELECT v.id, v.owner_user_id, 'pending', NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days'
+FROM vendors v
+WHERE v.name = 'Demo Dumpling Bar'
+  AND NOT EXISTS (SELECT 1 FROM vendor_applications a WHERE a.vendor_id = v.id);
+
+INSERT INTO vendor_applications
+  (vendor_id, submitted_by_user_id, status, review_reason, reviewed_by_user_id, reviewed_at, created_at, updated_at)
+SELECT v.id, v.owner_user_id, 'rejected',
+  'Incomplete food-safety documentation; please resubmit with HACCP certificate.',
+  (SELECT id FROM users WHERE email = 'admin@corpmeal.local'),
+  NOW() - INTERVAL '5 days', NOW() - INTERVAL '8 days', NOW() - INTERVAL '5 days'
+FROM vendors v
+WHERE v.name = 'Demo Fast Fry'
+  AND NOT EXISTS (SELECT 1 FROM vendor_applications a WHERE a.vendor_id = v.id);
+
+-- Audit rows for the reviewed applications, mirroring VendorReviewService
+-- (action 'vendor.review', target_type 'vendor_application'). Idempotent on (action, target_id).
+INSERT INTO audit_logs (actor_user_id, actor_role, action, target_type, target_id, metadata, created_at)
+SELECT
+  (SELECT id FROM users WHERE email = 'admin@corpmeal.local'),
+  'admin', 'vendor.review', 'vendor_application', a.id,
+  jsonb_build_object('decision', a.status),
+  a.reviewed_at
+FROM vendor_applications a
+JOIN vendors v ON v.id = a.vendor_id
+WHERE v.name IN ('Sunny Kitchen', 'Demo Noodle House', 'Demo Green Bowl', 'Demo Fast Fry')
+  AND a.status IN ('approved', 'rejected')
+  AND NOT EXISTS (
+    SELECT 1 FROM audit_logs al
+    WHERE al.action = 'vendor.review' AND al.target_type = 'vendor_application' AND al.target_id = a.id
+  );
+
 -- Advance the sequence past any badge already assigned by seeds/backfill so a
 -- freshly registered employee never collides with a pre-seeded EMP-NNNN
 -- (demo_seed assigns EMP-0002..0004 via explicit UPDATEs, not nextval).

--- a/backend/db/seeds/demo_seed.sql
+++ b/backend/db/seeds/demo_seed.sql
@@ -288,6 +288,42 @@ BEGIN
 END $$;
 
 -- ─────────────────────────────────────────────
+-- 5b. MENU ENRICHMENT (dietary tags + a sold-out example)
+--     Demonstrates the dietary-tag filter and the 今日售完 (sold-out) UI.
+--     UPDATEs are idempotent; the sold-out item is guarded by NOT EXISTS.
+-- ─────────────────────────────────────────────
+DO $$
+DECLARE
+  v_sunny_id BIGINT;
+  v_cat_sunny BIGINT;
+BEGIN
+  SELECT id INTO v_sunny_id FROM vendors WHERE name = 'Sunny Kitchen' LIMIT 1;
+  IF v_sunny_id IS NOT NULL THEN
+    SELECT id INTO v_cat_sunny
+      FROM menu_categories WHERE vendor_id = v_sunny_id AND name = 'Lunch Boxes';
+    -- Sold-out example: daily_quota = 0 → today's remaining is 0 → shows 今日售完.
+    INSERT INTO menu_items (vendor_id, category_id, name, description, price_cents, daily_quota, available, dietary_tags)
+    SELECT v_sunny_id, v_cat_sunny,
+           'Braised Beef Brisket Box',
+           'Slow-braised beef brisket over rice (today''s batch is sold out)',
+           11000, 0, TRUE, ARRAY['contains_beef']::TEXT[]
+    WHERE NOT EXISTS (
+      SELECT 1 FROM menu_items WHERE vendor_id = v_sunny_id AND name = 'Braised Beef Brisket Box'
+    );
+  END IF;
+END $$;
+
+-- Dietary tags on the existing demo items (idempotent UPDATEs; names are unique across demo vendors).
+UPDATE menu_items SET dietary_tags = ARRAY['contains_pork']::TEXT[]
+  WHERE name IN ('Pork Chop Box', 'Dan Dan Noodles', 'Wonton Noodle Soup');
+UPDATE menu_items SET dietary_tags = ARRAY['contains_beef']::TEXT[]
+  WHERE name = 'Beef Noodle Soup';
+UPDATE menu_items SET dietary_tags = ARRAY['vegetarian']::TEXT[]
+  WHERE name IN ('Veggie Box', 'Quinoa Veggie Bowl', 'Tofu Miso Bowl');
+UPDATE menu_items SET dietary_tags = ARRAY['ovo_lacto_vegetarian']::TEXT[]
+  WHERE name = 'Cold Sesame Noodles';
+
+-- ─────────────────────────────────────────────
 -- 6. DEMO EMPLOYEE USERS
 --    password = "password123"
 -- ─────────────────────────────────────────────

--- a/backend/db/seeds/demo_seed.sql
+++ b/backend/db/seeds/demo_seed.sql
@@ -800,6 +800,46 @@ WHERE v.name IN ('Sunny Kitchen', 'Demo Noodle House', 'Demo Green Bowl', 'Demo 
     WHERE al.action = 'vendor.review' AND al.target_type = 'vendor_application' AND al.target_id = a.id
   );
 
+-- ─────────────────────────────────────────────
+-- 11. AUDIT BACKFILL (order + onboarding history, like real operations)
+--     order.create (actor=employee), order.status_update (actor=vendor),
+--     user.enable (actor=admin). Idempotent on (action, target_type, target_id).
+-- ─────────────────────────────────────────────
+-- One order.create per seeded order (the employee placed it).
+INSERT INTO audit_logs (actor_user_id, actor_role, action, target_type, target_id, metadata, created_at)
+SELECT o.employee_id, 'employee', 'order.create', 'order', o.id,
+  jsonb_build_object('vendor_id', o.vendor_id, 'total_cents', o.total_price_cents),
+  o.created_at
+FROM orders o
+WHERE NOT EXISTS (
+  SELECT 1 FROM audit_logs al
+  WHERE al.action = 'order.create' AND al.target_type = 'order' AND al.target_id = o.id
+);
+
+-- One ready→delivered status_update per delivered order (the vendor advanced it).
+INSERT INTO audit_logs (actor_user_id, actor_role, action, target_type, target_id, metadata, created_at)
+SELECT v.owner_user_id, 'vendor_manager', 'order.status_update', 'order', o.id,
+  jsonb_build_object('from', 'ready', 'to', 'delivered'),
+  o.created_at + INTERVAL '2 hours'
+FROM orders o
+JOIN vendors v ON v.id = o.vendor_id
+WHERE o.status = 'delivered'
+  AND NOT EXISTS (
+    SELECT 1 FROM audit_logs al
+    WHERE al.action = 'order.status_update' AND al.target_type = 'order' AND al.target_id = o.id
+  );
+
+-- user.enable for the active demo employees (admin completed their onboarding).
+INSERT INTO audit_logs (actor_user_id, actor_role, action, target_type, target_id, metadata, created_at)
+SELECT (SELECT id FROM users WHERE email = 'admin@corpmeal.local'),
+  'admin', 'user.enable', 'user', u.id, '{}'::jsonb, u.created_at + INTERVAL '1 hour'
+FROM users u
+WHERE u.email IN ('demo.employee1@corpmeal.local', 'demo.employee2@corpmeal.local', 'demo.employee3@corpmeal.local')
+  AND NOT EXISTS (
+    SELECT 1 FROM audit_logs al
+    WHERE al.action = 'user.enable' AND al.target_type = 'user' AND al.target_id = u.id
+  );
+
 -- Advance the sequence past any badge already assigned by seeds/backfill so a
 -- freshly registered employee never collides with a pre-seeded EMP-NNNN
 -- (demo_seed assigns EMP-0002..0004 via explicit UPDATEs, not nextval).

--- a/backend/db/seeds/demo_seed.sql
+++ b/backend/db/seeds/demo_seed.sql
@@ -327,6 +327,30 @@ WHERE email = 'demo.employee2@corpmeal.local';
 UPDATE users SET display_name = '李大華', badge_code = 'EMP-0004'
 WHERE email = 'demo.employee3@corpmeal.local';
 
+-- Pending employees — registered but not yet enabled by admin (is_active = FALSE).
+-- They appear in 使用者審核 待審核 tab for the admin to enable in the demo.
+INSERT INTO users (email, display_name, role_id, password_hash, is_active, badge_code)
+VALUES (
+  'demo.pending.emp1@corpmeal.local',
+  '待審 林小美',
+  (SELECT id FROM roles WHERE name = 'employee'),
+  '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG',
+  FALSE,
+  'EMP-0005'
+)
+ON CONFLICT (email) DO NOTHING;
+
+INSERT INTO users (email, display_name, role_id, password_hash, is_active, badge_code)
+VALUES (
+  'demo.pending.emp2@corpmeal.local',
+  'Pending Dave Lin',
+  (SELECT id FROM roles WHERE name = 'employee'),
+  '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG',
+  FALSE,
+  'EMP-0006'
+)
+ON CONFLICT (email) DO NOTHING;
+
 -- ─────────────────────────────────────────────
 -- 7. EMPLOYEE FACILITIES
 --    employee1 → F12A

--- a/backend/db/seeds/demo_seed.sql
+++ b/backend/db/seeds/demo_seed.sql
@@ -35,6 +35,25 @@ VALUES (
 )
 ON CONFLICT (email) DO NOTHING;
 
+-- Owners for the pending / rejected demo vendors (so applications have a submitter).
+INSERT INTO users (email, display_name, role_id, password_hash)
+VALUES (
+  'demo.pending@corpmeal.local',
+  'Demo Pending Manager',
+  (SELECT id FROM roles WHERE name = 'vendor_manager'),
+  '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG'
+)
+ON CONFLICT (email) DO NOTHING;
+
+INSERT INTO users (email, display_name, role_id, password_hash)
+VALUES (
+  'demo.rejected@corpmeal.local',
+  'Demo Rejected Manager',
+  (SELECT id FROM roles WHERE name = 'vendor_manager'),
+  '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG'
+)
+ON CONFLICT (email) DO NOTHING;
+
 -- ─────────────────────────────────────────────
 -- 3. DEMO VENDORS (status 'approved')
 -- ─────────────────────────────────────────────
@@ -53,6 +72,24 @@ SELECT
   'demo.greenbowl@corpmeal.local',
   (SELECT id FROM users WHERE email = 'demo.greenbowl@corpmeal.local')
 WHERE NOT EXISTS (SELECT 1 FROM vendors WHERE name = 'Demo Green Bowl');
+
+-- Pending vendor — awaiting admin review (shows in 商家審核 待審 tab).
+INSERT INTO vendors (name, status, contact_email, owner_user_id)
+SELECT
+  'Demo Dumpling Bar',
+  'pending',
+  'demo.pending@corpmeal.local',
+  (SELECT id FROM users WHERE email = 'demo.pending@corpmeal.local')
+WHERE NOT EXISTS (SELECT 1 FROM vendors WHERE name = 'Demo Dumpling Bar');
+
+-- Rejected vendor — application was declined with a reason (shows in 商家審核 已駁回).
+INSERT INTO vendors (name, status, contact_email, owner_user_id)
+SELECT
+  'Demo Fast Fry',
+  'rejected',
+  'demo.rejected@corpmeal.local',
+  (SELECT id FROM users WHERE email = 'demo.rejected@corpmeal.local')
+WHERE NOT EXISTS (SELECT 1 FROM vendors WHERE name = 'Demo Fast Fry');
 
 -- ─────────────────────────────────────────────
 -- 4. VENDOR FACILITIES

--- a/backend/tests/integration/test_demo_seed_db.py
+++ b/backend/tests/integration/test_demo_seed_db.py
@@ -50,6 +50,10 @@ def test_demo_seed_is_comprehensive_and_idempotent(monkeypatch):
     """)
     assert inactive_emps >= 2, f"expected >=2 pending employees, got {inactive_emps}"
 
+    # ── Menu enrichment (issue #168): dietary tags + a sold-out example ───────
+    assert _count(cur, "SELECT COUNT(*) AS count FROM menu_items WHERE array_length(dietary_tags, 1) > 0") >= 6
+    assert _count(cur, "SELECT COUNT(*) AS count FROM menu_items WHERE daily_quota = 0") >= 1
+
     # ── Facility-consistency assertions ──────────────────────────────────────
     # Every order's facility_id must be in the employee's assigned facilities.
     # Scoped to demo vendors to avoid interference from other tests' orders.

--- a/backend/tests/integration/test_demo_seed_db.py
+++ b/backend/tests/integration/test_demo_seed_db.py
@@ -29,9 +29,26 @@ def test_demo_seed_is_comprehensive_and_idempotent(monkeypatch):
     orders_1 = _count(cur, "SELECT COUNT(*) AS count FROM orders")
     assert orders_1 >= 10
     assert _count(cur, "SELECT COUNT(*) AS count FROM orders WHERE status='delivered'") >= 5
+    apps_1 = _count(cur, "SELECT COUNT(*) AS count FROM vendor_applications")
 
     seed.run_demo_seed()  # second apply — must NOT duplicate
     assert _count(cur, "SELECT COUNT(*) AS count FROM orders") == orders_1, "not idempotent"
+    assert _count(cur, "SELECT COUNT(*) AS count FROM vendor_applications") == apps_1, "vendor_applications not idempotent"
+
+    # ── Review-state coverage (issue #168) ──────────────────────────────────
+    assert _count(cur, "SELECT COUNT(*) AS count FROM vendor_applications WHERE status='approved'") >= 3
+    assert _count(cur, "SELECT COUNT(*) AS count FROM vendor_applications WHERE status='pending'") >= 1
+    assert _count(cur, "SELECT COUNT(*) AS count FROM vendor_applications WHERE status='rejected'") >= 1
+    assert _count(cur, "SELECT COUNT(*) AS count FROM vendors WHERE status='pending'") >= 1
+    assert _count(cur, "SELECT COUNT(*) AS count FROM vendors WHERE status='rejected'") >= 1
+    assert _count(cur, "SELECT COUNT(*) AS count FROM vendor_applications WHERE status='rejected' AND review_reason IS NOT NULL") >= 1
+    assert _count(cur, "SELECT COUNT(*) AS count FROM audit_logs WHERE action='vendor.review'") >= 4
+    inactive_emps = _count(cur, """
+        SELECT COUNT(*) AS count FROM users u
+        JOIN roles r ON r.id = u.role_id
+        WHERE r.name = 'employee' AND u.is_active = FALSE
+    """)
+    assert inactive_emps >= 2, f"expected >=2 pending employees, got {inactive_emps}"
 
     # ── Facility-consistency assertions ──────────────────────────────────────
     # Every order's facility_id must be in the employee's assigned facilities.

--- a/backend/tests/integration/test_demo_seed_db.py
+++ b/backend/tests/integration/test_demo_seed_db.py
@@ -54,6 +54,11 @@ def test_demo_seed_is_comprehensive_and_idempotent(monkeypatch):
     assert _count(cur, "SELECT COUNT(*) AS count FROM menu_items WHERE array_length(dietary_tags, 1) > 0") >= 6
     assert _count(cur, "SELECT COUNT(*) AS count FROM menu_items WHERE daily_quota = 0") >= 1
 
+    # ── Audit backfill (issue #168): order + onboarding history ───────────────
+    assert _count(cur, "SELECT COUNT(*) AS count FROM audit_logs WHERE action='order.create'") >= 10
+    assert _count(cur, "SELECT COUNT(*) AS count FROM audit_logs WHERE action='order.status_update'") >= 1
+    assert _count(cur, "SELECT COUNT(*) AS count FROM audit_logs WHERE action='user.enable'") >= 3
+
     # ── Facility-consistency assertions ──────────────────────────────────────
     # Every order's facility_id must be in the employee's assigned facilities.
     # Scoped to demo vendors to avoid interference from other tests' orders.


### PR DESCRIPTION
Closes #168

## What & why

The demo seed inserted entities directly in their final state, bypassing the apply/onboarding/order flows — so admin **review screens were empty**, the **menu** lacked dietary tags / a sold-out example, and the **audit log** only had whatever was done live. This makes the demo dataset mirror real-person operations and exercise the review + menu + audit features. Demo seed + test only — no schema, app-code, or production-seed change.

## Changes (`backend/db/seeds/demo_seed.sql`)

**Review states**
- Backfilled the 3 approved vendors with a matching `vendor_applications` row + a `vendor.review` `audit_logs` row.
- +1 **pending** vendor *Demo Dumpling Bar* and +1 **rejected** *Demo Fast Fry* (with `review_reason`) + owner users.
- +2 **pending** employees (`is_active=false`, EMP-0005/0006).

**Menu completeness**
- `dietary_tags` on existing items (含牛肉/含豬肉/素食/蛋奶素 + some untagged) → dietary-tag filter has data.
- +1 **sold-out** item *Braised Beef Brisket Box* (`daily_quota=0`) → 今日售完 / sold-out-disable UI has data.

**Audit history backfill** (actors are correct — orders are NOT attributed to admin)
- `order.create` (actor=employee) for every seeded order.
- `order.status_update` ready→delivered (actor=vendor) for each delivered order.
- `user.enable` (actor=admin) for the active demo employees.
- The system has no admin order-management surface; admin/committee only review vendors + billing + read-only stats/audit, matching the spec ("does not intervene in daily order details").

**Fidelity & safety:** audit rows match the real `record()` calls (`vendor.review`/`order.create`/`order.status_update`/`user.enable`); every insert/update is idempotent; FK/order-safe; `NOW() - INTERVAL` timestamps.

## Tests

`backend/tests/integration/test_demo_seed_db.py` extended to assert the review states, menu enrichment (≥6 tagged, ≥1 sold-out), and audit history (order.create ≥10, status_update ≥1, user.enable ≥3) plus idempotency. Verified vs real Postgres: integration **1 passed**, unit **361 passed**, idempotent.

## Out of scope

- **Menu photos** — needs image assets + uploads-volume population at startup; deferred to a separate issue.
- Employee 4-state `account_status` enum — model has only `is_active`; deferred.
- The two `012_*` migration filename collision — flagged separately.
- Any schema / production-seed / app-code change.
