### PR TITLE
fix: prevent demo seed badge_code collisions on startup

### DIFF
--- a/backend/db/seeds/demo_seed.sql
+++ b/backend/db/seeds/demo_seed.sql
@@ -354,38 +354,65 @@ VALUES (
 )
 ON CONFLICT (email) DO NOTHING;
 
--- Badge backfill for demo employees (idempotent). Mixed CJK/Western names show
--- vendor-facing name masking works for both.
-UPDATE users SET display_name = '王小明', badge_code = 'EMP-0002'
-WHERE email = 'demo.employee1@corpmeal.local';
-UPDATE users SET display_name = 'John Smith', badge_code = 'EMP-0003'
-WHERE email = 'demo.employee2@corpmeal.local';
-UPDATE users SET display_name = '李大華', badge_code = 'EMP-0004'
-WHERE email = 'demo.employee3@corpmeal.local';
-
 -- Pending employees — registered but not yet enabled by admin (is_active = FALSE).
 -- They appear in 使用者審核 待審核 tab for the admin to enable in the demo.
-INSERT INTO users (email, display_name, role_id, password_hash, is_active, badge_code)
+INSERT INTO users (email, display_name, role_id, password_hash, is_active)
 VALUES (
   'demo.pending.emp1@corpmeal.local',
   '待審 林小美',
   (SELECT id FROM roles WHERE name = 'employee'),
   '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG',
-  FALSE,
-  'EMP-0005'
+  FALSE
 )
 ON CONFLICT (email) DO NOTHING;
 
-INSERT INTO users (email, display_name, role_id, password_hash, is_active, badge_code)
+INSERT INTO users (email, display_name, role_id, password_hash, is_active)
 VALUES (
   'demo.pending.emp2@corpmeal.local',
   'Pending Dave Lin',
   (SELECT id FROM roles WHERE name = 'employee'),
   '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG',
-  FALSE,
-  'EMP-0006'
+  FALSE
 )
 ON CONFLICT (email) DO NOTHING;
+
+-- Bring the employee badge sequence in sync before assigning any missing demo
+-- badges. This keeps the seed idempotent even if a previous startup crashed
+-- before the end-of-file setval() or if real users were registered in between.
+SELECT setval(
+    'employee_badge_seq',
+    GREATEST(
+        (SELECT COALESCE(MAX(CAST(SUBSTRING(badge_code FROM 'EMP-([0-9]+)$') AS INTEGER)), 0)
+         FROM users WHERE badge_code ~ '^EMP-[0-9]+$'),
+        1
+    )
+);
+
+-- Badge backfill for demo employees (idempotent). Preserve any existing
+-- badge_code on reruns; only mint a new code for demo accounts still missing
+-- one. Mixed CJK/Western names show vendor-facing name masking works for both.
+UPDATE users
+SET display_name = '王小明',
+    badge_code = COALESCE(badge_code, 'EMP-' || LPAD(nextval('employee_badge_seq')::text, 4, '0'))
+WHERE email = 'demo.employee1@corpmeal.local';
+
+UPDATE users
+SET display_name = 'John Smith',
+    badge_code = COALESCE(badge_code, 'EMP-' || LPAD(nextval('employee_badge_seq')::text, 4, '0'))
+WHERE email = 'demo.employee2@corpmeal.local';
+
+UPDATE users
+SET display_name = '李大華',
+    badge_code = COALESCE(badge_code, 'EMP-' || LPAD(nextval('employee_badge_seq')::text, 4, '0'))
+WHERE email = 'demo.employee3@corpmeal.local';
+
+UPDATE users
+SET badge_code = COALESCE(badge_code, 'EMP-' || LPAD(nextval('employee_badge_seq')::text, 4, '0'))
+WHERE email = 'demo.pending.emp1@corpmeal.local';
+
+UPDATE users
+SET badge_code = COALESCE(badge_code, 'EMP-' || LPAD(nextval('employee_badge_seq')::text, 4, '0'))
+WHERE email = 'demo.pending.emp2@corpmeal.local';
 
 -- ─────────────────────────────────────────────
 -- 7. EMPLOYEE FACILITIES

--- a/backend/tests/integration/test_demo_seed_db.py
+++ b/backend/tests/integration/test_demo_seed_db.py
@@ -111,6 +111,32 @@ def test_demo_seed_handles_existing_badge_collisions(monkeypatch):
     conn = connect(os.environ["DATABASE_URL"], row_factory=dict_row, autocommit=True)
     cur = conn.cursor()
 
+    # First apply ensures the demo users exist. Then simulate the class of bug we
+    # care about: the badge sequence lags behind while a real employee has
+    # already claimed the next code. On the second apply the seed must resync
+    # the sequence before minting replacement demo badges.
+    seed.run_demo_seed()
+
+    cur.execute(
+        """
+        UPDATE users
+        SET badge_code = NULL
+        WHERE email IN ('demo.pending.emp1@corpmeal.local', 'demo.pending.emp2@corpmeal.local')
+        """
+    )
+
+    cur.execute(
+        """
+        SELECT COALESCE(MAX(CAST(SUBSTRING(badge_code FROM 'EMP-([0-9]+)$') AS INTEGER)), 0) AS max_badge
+        FROM users
+        WHERE badge_code ~ '^EMP-[0-9]+$'
+        """
+    )
+    previous_max = cur.fetchone()["max_badge"]
+    collision_num = previous_max + 1
+    collision_code = f"EMP-{collision_num:04d}"
+
+    cur.execute("DELETE FROM users WHERE email = 'collision.employee@corpmeal.local'")
     cur.execute(
         """
         INSERT INTO users (email, display_name, role_id, password_hash, badge_code, is_active)
@@ -119,13 +145,18 @@ def test_demo_seed_handles_existing_badge_collisions(monkeypatch):
             'Collision Employee',
             (SELECT id FROM roles WHERE name = 'employee'),
             %s,
-            'EMP-0005',
+            %s,
             TRUE
         )
         ON CONFLICT (email) DO NOTHING
         """,
-        ('$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG',),
+        (
+            '$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG',
+            collision_code,
+        ),
     )
+
+    cur.execute("SELECT setval('employee_badge_seq', %s)", (previous_max,))
 
     seed.run_demo_seed()
 
@@ -134,21 +165,19 @@ def test_demo_seed_handles_existing_badge_collisions(monkeypatch):
         SELECT email, badge_code
         FROM users
         WHERE email IN (
-            'demo.employee1@corpmeal.local',
-            'demo.employee2@corpmeal.local',
-            'demo.employee3@corpmeal.local',
             'demo.pending.emp1@corpmeal.local',
             'demo.pending.emp2@corpmeal.local'
         )
         ORDER BY email
         """
     )
-    demo_users = cur.fetchall()
-    badge_codes = [row["badge_code"] for row in demo_users]
+    pending_demo_users = cur.fetchall()
+    badge_codes = [row["badge_code"] for row in pending_demo_users]
 
-    assert len(demo_users) == 5
+    assert len(pending_demo_users) == 2
     assert all(code is not None for code in badge_codes)
-    assert len(set(badge_codes)) == 5
-    assert "EMP-0005" not in badge_codes
+    assert len(set(badge_codes)) == 2
+    assert collision_code not in badge_codes
 
+    cur.execute("DELETE FROM users WHERE email = 'collision.employee@corpmeal.local'")
     conn.close()

--- a/backend/tests/integration/test_demo_seed_db.py
+++ b/backend/tests/integration/test_demo_seed_db.py
@@ -96,3 +96,59 @@ def test_demo_seed_is_comprehensive_and_idempotent(monkeypatch):
     )
 
     conn.close()
+
+
+def test_demo_seed_handles_existing_badge_collisions(monkeypatch):
+    from psycopg import connect
+    from psycopg.rows import dict_row
+    from backend.core.config import settings
+    from backend.db.migrate import run_migrations
+    from backend.db import seed
+
+    run_migrations()
+    monkeypatch.setattr(settings, "seed_demo_data", True)
+
+    conn = connect(os.environ["DATABASE_URL"], row_factory=dict_row, autocommit=True)
+    cur = conn.cursor()
+
+    cur.execute(
+        """
+        INSERT INTO users (email, display_name, role_id, password_hash, badge_code, is_active)
+        VALUES (
+            'collision.employee@corpmeal.local',
+            'Collision Employee',
+            (SELECT id FROM roles WHERE name = 'employee'),
+            %s,
+            'EMP-0005',
+            TRUE
+        )
+        ON CONFLICT (email) DO NOTHING
+        """,
+        ('$2b$12$V92j2Sanc/Ie9L.w1HsXh.Go4a4oDKcq1sovHfObRIsOJ.5F/hxhG',),
+    )
+
+    seed.run_demo_seed()
+
+    cur.execute(
+        """
+        SELECT email, badge_code
+        FROM users
+        WHERE email IN (
+            'demo.employee1@corpmeal.local',
+            'demo.employee2@corpmeal.local',
+            'demo.employee3@corpmeal.local',
+            'demo.pending.emp1@corpmeal.local',
+            'demo.pending.emp2@corpmeal.local'
+        )
+        ORDER BY email
+        """
+    )
+    demo_users = cur.fetchall()
+    badge_codes = [row["badge_code"] for row in demo_users]
+
+    assert len(demo_users) == 5
+    assert all(code is not None for code in badge_codes)
+    assert len(set(badge_codes)) == 5
+    assert "EMP-0005" not in badge_codes
+
+    conn.close()


### PR DESCRIPTION
## Summary

Fix demo seed startup failures caused by `badge_code` unique-key collisions.

The root issue was that `backend/db/seeds/demo_seed.sql` assigned fixed badge codes
like `EMP-0005` and `EMP-0006` to demo employees. If the local database already
contained real employee accounts with those codes, backend startup failed during
`run_demo_seed()` and `/auth/login` became unavailable.

## Changes

- update demo seed badge assignment to avoid fixed `EMP-0005` / `EMP-0006` writes
- sync `employee_badge_seq` with the current max existing badge before assigning any missing demo badges
- only assign badge codes to demo users that do not already have one
- add an integration test covering the collision case where `EMP-0005` is already taken

## Why

Without this fix:
- backend can fail during startup
- Caddy returns `502` for `/auth/login`
- default admin login appears broken even though credentials are correct

With this fix:
- demo seed is safe to rerun in a database that already has employee badges
- backend starts successfully
- default admin login works again

## Validation

- confirmed backend startup succeeds after the seed fix
- confirmed `/auth/login` returns `200` for the default admin account from inside the backend container
- added integration coverage for existing badge collision handling

## Notes

This PR only includes:
- `backend/db/seeds/demo_seed.sql`
- `backend/tests/integration/test_demo_seed_db.py`