### PR TITLE
feat(employee-ui): refine employee interface with functional improvements and localization

### DIFF
--- a/frontend/src/layout/Sidebar.jsx
+++ b/frontend/src/layout/Sidebar.jsx
@@ -4,8 +4,8 @@ export default function Sidebar({ items }) {
   return (
     <aside className="sidebar">
       <div>
-        <p className="eyebrow">Corporate Meal</p>
-        <h1 className="sidebar-title">Operations Console</h1>
+        <p className="eyebrow">企業訂餐</p>
+        <h1 className="sidebar-title">訂餐管理平台</h1>
       </div>
       <nav className="nav-list" aria-label="Primary">
         {items.map((item) => (

--- a/frontend/src/layout/navigation.js
+++ b/frontend/src/layout/navigation.js
@@ -6,13 +6,13 @@ export const roleHomePath = {
 
 export const navigationByRole = {
   employee: [
-    { label: "Dashboard", to: "/employee" },
-    { label: "Browse Meals", to: "/employee/menu" },
-    { label: "Random Meal", to: "/employee/random-meal" },
-    { label: "Current Orders", to: "/employee/orders" },
-    { label: "My Badge", to: "/employee/badge" },
+    { label: "首頁", to: "/employee" },
+    { label: "菜單瀏覽", to: "/employee/menu" },
+    { label: "隨機訂餐", to: "/employee/random-meal" },
+    { label: "訂單狀況", to: "/employee/orders" },
+    { label: "取餐編號", to: "/employee/badge" },
     { label: "帳號設定", to: "/employee/account" },
-    { label: "Notifications", to: "/notifications" },
+    { label: "通知", to: "/notifications" },
   ],
   vendor_manager: [
     { label: "Dashboard", to: "/vendor" },

--- a/frontend/src/pages/employee/AccountPage.jsx
+++ b/frontend/src/pages/employee/AccountPage.jsx
@@ -4,6 +4,48 @@ import { changePassword } from "../../api/employee";
 import { useFacility } from "../../facility/FacilityContext";
 import { saveHomeFacilityId } from "../../facility/facilitySelection";
 
+function PasswordInput({ label, value, onChange, autoComplete, minLength, placeholder }) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <label className="field">
+      <span className="field-label">{label}</span>
+      <span className="pw-field">
+        <input
+          className="form-input"
+          required
+          type={visible ? "text" : "password"}
+          value={value}
+          onChange={onChange}
+          autoComplete={autoComplete}
+          minLength={minLength}
+          placeholder={placeholder}
+        />
+        <button
+          type="button"
+          className="pw-toggle"
+          onClick={() => setVisible((show) => !show)}
+          aria-label={visible ? `隱藏${label}` : `顯示${label}`}
+          aria-pressed={visible}
+          title={visible ? `隱藏${label}` : `顯示${label}`}
+        >
+          {visible ? (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+              <line x1="1" y1="1" x2="23" y2="23" />
+            </svg>
+          ) : (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+          )}
+        </button>
+      </span>
+    </label>
+  );
+}
+
 function ChangePasswordForm() {
   const [current, setCurrent] = useState("");
   const [next, setNext] = useState("");
@@ -46,42 +88,36 @@ function ChangePasswordForm() {
 
   return (
     <div className="panel" style={{ marginBottom: 24 }}>
-      <h3 style={{ margin: "0 0 16px" }}>修改密碼</h3>
-      <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", gap: 14, maxWidth: 360 }}>
-        <label className="field">
-          <span>目前密碼</span>
-          <input
-            required
-            type="password"
-            value={current}
-            onChange={(e) => setCurrent(e.target.value)}
-            autoComplete="current-password"
-          />
-        </label>
-        <label className="field">
-          <span>新密碼</span>
-          <input
-            required
-            type="password"
-            value={next}
-            onChange={(e) => setNext(e.target.value)}
-            autoComplete="new-password"
-            minLength={8}
-          />
-        </label>
-        <label className="field">
-          <span>確認新密碼</span>
-          <input
-            required
-            type="password"
-            value={confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-            autoComplete="new-password"
-          />
-        </label>
-        {error && <p className="form-error" style={{ margin: 0 }}>{error}</p>}
-        {success && <p style={{ margin: 0, color: "var(--success)", fontSize: 14 }}>密碼修改成功。</p>}
-        <button className="button-primary" disabled={saving} type="submit" style={{ alignSelf: "flex-start" }}>
+      <div className="account-form-header">
+        <h3 style={{ margin: 0 }}>修改密碼</h3>
+        <p className="panel-copy">建議使用至少 8 個字元，並避免與其他系統共用密碼。</p>
+      </div>
+      <form className="account-password-form" onSubmit={handleSubmit}>
+        <PasswordInput
+          label="目前密碼"
+          value={current}
+          onChange={(e) => setCurrent(e.target.value)}
+          autoComplete="current-password"
+          placeholder="輸入目前密碼"
+        />
+        <PasswordInput
+          label="新密碼"
+          value={next}
+          onChange={(e) => setNext(e.target.value)}
+          autoComplete="new-password"
+          minLength={8}
+          placeholder="至少 8 個字元"
+        />
+        <PasswordInput
+          label="確認新密碼"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+          autoComplete="new-password"
+          placeholder="再次輸入新密碼"
+        />
+        {error && <p className="error-state" style={{ margin: 0, textAlign: "left" }}>{error}</p>}
+        {success && <p style={{ margin: 0, color: "var(--success)", fontSize: 14, fontWeight: 700 }}>密碼修改成功。</p>}
+        <button className="primary-button" disabled={saving} type="submit" style={{ alignSelf: "flex-start" }}>
           {saving ? "儲存中..." : "儲存"}
         </button>
       </form>

--- a/frontend/src/pages/employee/EmployeeHomePage.jsx
+++ b/frontend/src/pages/employee/EmployeeHomePage.jsx
@@ -1,9 +1,55 @@
+import { useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../auth/AuthContext";
+import { useFacility } from "../../facility/FacilityContext";
+import { useMyOrders } from "../../hooks/useMyOrders";
+import { useVendors } from "../../hooks/useVendors";
+import { todayIso } from "../../utils/date";
+
+const STATUS_LABELS = {
+  pending:   "待確認",
+  confirmed: "已確認",
+  preparing: "準備中",
+  ready:     "可取餐",
+  delivered: "已完成",
+  cancelled: "已取消",
+};
+
+const STATUS_BADGE = {
+  pending:   "badge-status-pending",
+  confirmed: "badge-status-confirmed",
+  preparing: "badge-status-preparing",
+  ready:     "badge-status-ready",
+  delivered: "badge-status-delivered",
+  cancelled: "badge-status-cancelled",
+};
 
 export default function EmployeeHomePage() {
   const { user } = useAuth();
   const navigate = useNavigate();
+  const { selectedFacilityId } = useFacility();
+
+  const today = useMemo(() => todayIso(), []);
+  const todayRange = useMemo(() => ({ startDate: today, endDate: today }), [today]);
+  const { orders, loading: ordersLoading } = useMyOrders(todayRange);
+  const { vendors } = useVendors({ facilityId: selectedFacilityId });
+  const todayOrders = useMemo(
+    () => orders.filter((order) => order.status !== "cancelled"),
+    [orders],
+  );
+  const vendorNamesById = useMemo(
+    () => new Map(vendors.map((vendor) => [vendor.id, vendor.name])),
+    [vendors],
+  );
+  const latestTodayOrder = useMemo(() => {
+    if (todayOrders.length === 0) return null;
+    return [...todayOrders].sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+    )[0];
+  }, [todayOrders]);
+  const latestVendorName = latestTodayOrder
+    ? vendorNamesById.get(latestTodayOrder.vendor_id) ?? `店家 #${latestTodayOrder.vendor_id}`
+    : null;
 
   return (
     <section className="dashboard-grid">
@@ -28,11 +74,11 @@ export default function EmployeeHomePage() {
         <div style={{ display: "grid", gap: 10, marginTop: 12 }}>
           <button
             className="role-card"
-            onClick={() => navigate("/employee/menu")}
+            onClick={() => navigate("/employee/random-meal")}
             type="button"
           >
-            <strong>🍱 瀏覽菜單</strong>
-            <span>查看廠商與今日供應餐點</span>
+            <strong>❓ 隨機抽餐</strong>
+            <span>不知道吃什麼就來試試推薦清單和手氣吧</span>
           </button>
           <button
             className="role-card"
@@ -46,11 +92,90 @@ export default function EmployeeHomePage() {
       </article>
 
       <article className="panel">
-        <h3>本期進度</h3>
-        <p className="panel-copy">
-          菜單瀏覽（E2）、搜尋篩選（E3）、餐點詳情（E4）已完成。
-          訂購流程（E5–E7）將在下一個分支實作。
-        </p>
+        <h3>今日最新訂單</h3>
+
+        {ordersLoading && (
+          <p className="panel-copy" style={{ marginTop: 8 }}>載入中...</p>
+        )}
+
+        {!ordersLoading && !latestTodayOrder && (
+          <>
+            <p className="panel-copy" style={{ marginTop: 8 }}>今日尚未訂餐</p>
+            <button
+              className="ghost-button"
+              type="button"
+              style={{ marginTop: 12 }}
+              onClick={() => navigate("/employee/menu")}
+            >
+              去點餐 →
+            </button>
+          </>
+        )}
+
+        {!ordersLoading && latestTodayOrder && (
+          <div style={{ display: "grid", gap: 14, marginTop: 12 }}>
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "flex-start",
+                gap: 12,
+                flexWrap: "wrap",
+              }}
+            >
+              <div style={{ display: "grid", gap: 6 }}>
+                <span style={{ fontSize: 13, color: "var(--muted)" }}>
+                  訂單 #{latestTodayOrder.id}
+                  {latestTodayOrder.meal_date && (
+                    <span style={{ marginLeft: 6 }}>· {latestTodayOrder.meal_date}</span>
+                  )}
+                </span>
+                <p style={{ fontSize: 16, fontWeight: 700 }}>{latestVendorName}</p>
+              </div>
+              <span className={`badge ${STATUS_BADGE[latestTodayOrder.status] ?? "badge-status-confirmed"}`}>
+                {STATUS_LABELS[latestTodayOrder.status] ?? latestTodayOrder.status}
+              </span>
+            </div>
+
+            <div
+              style={{
+                display: "grid",
+                gap: 10,
+                padding: "14px 16px",
+                border: "1px solid var(--line)",
+                borderRadius: "var(--radius-md)",
+                background: "rgba(255, 255, 255, 0.42)",
+              }}
+            >
+              <p style={{ fontSize: 13, fontWeight: 700, color: "var(--muted)" }}>品項</p>
+              <div style={{ display: "grid", gap: 8 }}>
+                {latestTodayOrder.items.map((item) => (
+                  <div
+                    key={item.id}
+                    style={{
+                      display: "flex",
+                      justifyContent: "space-between",
+                      gap: 12,
+                      alignItems: "baseline",
+                    }}
+                  >
+                    <span style={{ fontWeight: 600 }}>{item.item_name}</span>
+                    <span style={{ fontSize: 13, color: "var(--muted)" }}>x{item.quantity}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <button
+              className="ghost-button"
+              type="button"
+              style={{ marginTop: 4, justifySelf: "start" }}
+              onClick={() => navigate("/employee/orders")}
+            >
+              查看全部 →
+            </button>
+          </div>
+        )}
       </article>
     </section>
   );

--- a/frontend/src/pages/employee/OrdersPage.jsx
+++ b/frontend/src/pages/employee/OrdersPage.jsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { deleteMyOrder, getMyBilling, updateMyOrder } from "../../api/employee";
+import { useFacility } from "../../facility/FacilityContext";
 import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { useMyOrders } from "../../hooks/useMyOrders";
+import { useVendors } from "../../hooks/useVendors";
 import { formatMoney, formatPrice } from "../../utils/format";
 import { datesWithoutOrders, getDefaultOrderHistoryRange, getFutureMealDates } from "../../utils/orderHistoryRange";
 
@@ -15,6 +17,15 @@ const STATUS_LABELS = {
   cancelled: "已取消",
 };
 
+const STATUS_BADGE = {
+  pending: "badge-status-pending",
+  confirmed: "badge-status-confirmed",
+  preparing: "badge-status-preparing",
+  ready: "badge-status-ready",
+  delivered: "badge-status-delivered",
+  cancelled: "badge-status-cancelled",
+};
+
 function formatDate(isoString) {
   const d = new Date(isoString);
   return d.toLocaleString("zh-TW", {
@@ -22,6 +33,17 @@ function formatDate(isoString) {
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
+  });
+}
+
+function formatMealDateLabel(mealDate) {
+  if (!mealDate) return "未指定用餐日";
+  const d = new Date(`${mealDate}T00:00:00`);
+  return d.toLocaleDateString("zh-TW", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    weekday: "short",
   });
 }
 
@@ -49,9 +71,11 @@ function currentPeriod() {
 
 export default function OrdersPage() {
   const navigate = useNavigate();
+  const { selectedFacilityId } = useFacility();
   const orderRange = useMemo(() => getDefaultOrderHistoryRange(), []);
   const futureMealDates = useMemo(() => getFutureMealDates(), []);
   const { orders, setOrders, loading, error } = useMyOrders(orderRange);
+  const { vendors } = useVendors({ facilityId: selectedFacilityId });
   const [billing, setBilling] = useState(null);
   const [billingError, setBillingError] = useState(false);
   const [editingOrderId, setEditingOrderId] = useState(null);
@@ -59,7 +83,37 @@ export default function OrdersPage() {
   const [busyOrderId, setBusyOrderId] = useState(null);
   const [actionError, setActionError] = useState(null);
 
-  const visibleOrders = orders.filter((order) => order.status !== "cancelled");
+  const visibleOrders = useMemo(
+    () => orders.filter((order) => order.status !== "cancelled"),
+    [orders],
+  );
+  const vendorNamesById = useMemo(
+    () => new Map(vendors.map((vendor) => [vendor.id, vendor.name])),
+    [vendors],
+  );
+  const groupedVisibleOrders = useMemo(() => {
+    const groups = new Map();
+
+    for (const order of visibleOrders) {
+      const key = order.meal_date ?? "unscheduled";
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(order);
+    }
+
+    return Array.from(groups.entries())
+      .sort(([a], [b]) => {
+        if (a === "unscheduled") return 1;
+        if (b === "unscheduled") return -1;
+        return b.localeCompare(a);
+      })
+      .map(([mealDate, entries]) => ({
+        mealDate,
+        label: formatMealDateLabel(mealDate === "unscheduled" ? null : mealDate),
+        orders: [...entries].sort(
+          (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+        ),
+      }));
+  }, [visibleOrders]);
   const missingFutureOrderDates = datesWithoutOrders(orders, futureMealDates);
 
   useEffect(() => {
@@ -127,7 +181,7 @@ export default function OrdersPage() {
     <div>
       <div className="page-header">
         <FacilityScopeLabel label="Current facility" />
-        <p className="eyebrow">Employee · Orders</p>
+        <p className="eyebrow">Employee · My Orders</p>
         <h2>我的訂單</h2>
       </div>
 
@@ -172,153 +226,163 @@ export default function OrdersPage() {
       )}
 
       {!loading && !error && visibleOrders.length > 0 && (
-        <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
-          {visibleOrders.map((order, idx) => {
-            const isEditing = editingOrderId === order.id;
-            const canEdit = order.status === "pending";
-            const total = isEditing
-              ? order.items.reduce(
-                  (sum, item) => sum + item.unit_price_cents * (draftQuantities[item.id] ?? item.quantity),
-                  0,
-                )
-              : order.total_price_cents;
-
-            return (
-              <div
-                key={order.id}
-                style={{
-                  display: "grid",
-                  gap: 14,
-                  padding: "18px 20px",
-                  borderBottom: idx < visibleOrders.length - 1 ? "1px solid var(--line)" : "none",
-                }}
-              >
-                <div style={{ display: "flex", justifyContent: "space-between", gap: 16, flexWrap: "wrap" }}>
-                  <div>
-                    <p style={{ fontWeight: 700, margin: 0 }}>訂單 #{order.id}</p>
-                    <p style={{ color: "var(--muted)", fontSize: 13, margin: "4px 0 0" }}>
-                      {order.meal_date ? `用餐日 ${order.meal_date}` : formatDate(order.created_at)}
-                    </p>
-                    {order.pickup_code && (
-                      <p style={{ margin: "4px 0 0", fontSize: 13, fontWeight: 700 }}>
-                        取餐碼 {order.pickup_code}
-                      </p>
-                    )}
-                  </div>
-                  <div style={{ textAlign: "right" }}>
-                    <p style={{ fontWeight: 800, margin: 0 }}>{formatMoney(total)}</p>
-                    <p style={{ color: "var(--muted)", fontSize: 13, margin: "4px 0 0" }}>
-                      {STATUS_LABELS[order.status] ?? order.status}
-                    </p>
-                    {order.status === "ready" && (
-                      <span className="badge badge-available" style={{ marginTop: 6 }}>
-                        可領餐
-                      </span>
-                    )}
-                  </div>
+        <div className="orders-date-groups">
+          {groupedVisibleOrders.map((group) => (
+            <section className="panel orders-date-group" key={group.mealDate}>
+              <div className="orders-date-header">
+                <div>
+                  <p className="eyebrow">Meal Date</p>
+                  <h3 style={{ margin: "6px 0 0" }}>{group.label}</h3>
                 </div>
+                <span className="badge badge-quota">{group.orders.length} 筆訂單</span>
+              </div>
 
-                <div style={{ display: "grid", gap: 10 }}>
-                  {order.items.map((item) => (
+              <div className="orders-date-list">
+                {group.orders.map((order, idx) => {
+                  const isEditing = editingOrderId === order.id;
+                  const canEdit = order.status === "pending";
+                  const total = isEditing
+                    ? order.items.reduce(
+                      (sum, item) => sum + item.unit_price_cents * (draftQuantities[item.id] ?? item.quantity),
+                      0,
+                    )
+                    : order.total_price_cents;
+
+                  return (
                     <div
-                      key={item.id}
+                      key={order.id}
+                      className="employee-order-card"
                       style={{
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "space-between",
-                        gap: 12,
+                        borderBottom: idx < group.orders.length - 1 ? "1px solid var(--line)" : "none",
                       }}
                     >
-                      <div>
-                        <p style={{ fontWeight: 600, margin: 0 }}>{item.item_name}</p>
-                        <p style={{ color: "var(--muted)", fontSize: 13, margin: "2px 0 0" }}>
-                          {formatPrice(item.unit_price_cents)} / 份
-                        </p>
-                      </div>
-                      {isEditing ? (
-                        <div className="quantity-stepper" style={{ marginRight: 0 }}>
-                          <button
-                            className="stepper-btn"
-                            type="button"
-                            aria-label="減少數量"
-                            onClick={() => updateDraft(item.id, (draftQuantities[item.id] ?? item.quantity) - 1)}
-                            disabled={(draftQuantities[item.id] ?? item.quantity) <= 1 || busyOrderId === order.id}
-                          >
-                            -
-                          </button>
-                          <span className="stepper-value">{draftQuantities[item.id] ?? item.quantity}</span>
-                          <button
-                            className="stepper-btn"
-                            type="button"
-                            aria-label="增加數量"
-                            onClick={() => updateDraft(item.id, (draftQuantities[item.id] ?? item.quantity) + 1)}
-                            disabled={busyOrderId === order.id}
-                          >
-                            +
-                          </button>
+                      <div className="employee-order-top">
+                        <div className="employee-order-heading">
+                          <p className="employee-order-vendor">
+                            {vendorNamesById.get(order.vendor_id) ?? `餐廳 #${order.vendor_id}`}
+                          </p>
+                          <div className="employee-order-meta">
+                            <span>訂單 #{order.id}</span>
+                            <span>建立時間 {formatDate(order.created_at)}</span>
+                          </div>
+                          {order.pickup_code && (
+                            <p className="employee-order-pickup">
+                              取餐碼 {order.pickup_code}
+                            </p>
+                          )}
                         </div>
-                      ) : (
-                        <p style={{ color: "var(--muted)", fontSize: 14, margin: 0 }}>
-                          x {item.quantity}
-                        </p>
+                        <div className="employee-order-summary">
+                          <p style={{ fontWeight: 800, margin: 0 }}>{formatMoney(total)}</p>
+                          <span className={`badge ${STATUS_BADGE[order.status] ?? "badge-status-confirmed"}`}>
+                            {STATUS_LABELS[order.status] ?? order.status}
+                          </span>
+                        </div>
+                      </div>
+
+                      <div style={{ display: "grid", gap: 10 }}>
+                        {order.items.map((item) => (
+                          <div
+                            key={item.id}
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "space-between",
+                              gap: 12,
+                            }}
+                          >
+                            <div>
+                              <p style={{ fontWeight: 600, margin: 0 }}>{item.item_name}</p>
+                              <p style={{ color: "var(--muted)", fontSize: 13, margin: "2px 0 0" }}>
+                                {formatPrice(item.unit_price_cents)} / 份
+                              </p>
+                            </div>
+                            {isEditing ? (
+                              <div className="quantity-stepper" style={{ marginRight: 0 }}>
+                                <button
+                                  className="stepper-btn"
+                                  type="button"
+                                  aria-label="減少數量"
+                                  onClick={() => updateDraft(item.id, (draftQuantities[item.id] ?? item.quantity) - 1)}
+                                  disabled={(draftQuantities[item.id] ?? item.quantity) <= 1 || busyOrderId === order.id}
+                                >
+                                  -
+                                </button>
+                                <span className="stepper-value">{draftQuantities[item.id] ?? item.quantity}</span>
+                                <button
+                                  className="stepper-btn"
+                                  type="button"
+                                  aria-label="增加數量"
+                                  onClick={() => updateDraft(item.id, (draftQuantities[item.id] ?? item.quantity) + 1)}
+                                  disabled={busyOrderId === order.id}
+                                >
+                                  +
+                                </button>
+                              </div>
+                            ) : (
+                              <p style={{ color: "var(--muted)", fontSize: 14, margin: 0 }}>
+                                x {item.quantity}
+                              </p>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+
+                      {canEdit && (
+                        <div style={{ display: "flex", justifyContent: "flex-end", gap: 10, flexWrap: "wrap" }}>
+                          {isEditing ? (
+                            <>
+                              <button
+                                className="ghost-button"
+                                type="button"
+                                onClick={() => setEditingOrderId(null)}
+                                disabled={busyOrderId === order.id}
+                                style={{ color: "var(--text)", borderColor: "var(--line)", background: "var(--surface)" }}
+                              >
+                                取消
+                              </button>
+                              <button
+                                className="primary-button"
+                                type="button"
+                                onClick={() => saveOrder(order)}
+                                disabled={busyOrderId === order.id}
+                              >
+                                {busyOrderId === order.id ? "儲存中..." : "儲存修改"}
+                              </button>
+                            </>
+                          ) : (
+                            <>
+                              <button
+                                className="ghost-button"
+                                type="button"
+                                onClick={() => startEditing(order)}
+                                disabled={busyOrderId === order.id}
+                                style={{ color: "var(--text)", borderColor: "var(--line)", background: "var(--surface)" }}
+                              >
+                                編輯
+                              </button>
+                              <button
+                                className="ghost-button"
+                                type="button"
+                                onClick={() => removeOrder(order)}
+                                disabled={busyOrderId === order.id}
+                                style={{
+                                  color: "var(--brand-deep)",
+                                  borderColor: "rgba(200, 92, 44, 0.28)",
+                                  background: "rgba(200, 92, 44, 0.08)",
+                                }}
+                              >
+                                {busyOrderId === order.id ? "刪除中..." : "刪除"}
+                              </button>
+                            </>
+                          )}
+                        </div>
                       )}
                     </div>
-                  ))}
-                </div>
-
-                {canEdit && (
-                  <div style={{ display: "flex", justifyContent: "flex-end", gap: 10, flexWrap: "wrap" }}>
-                    {isEditing ? (
-                      <>
-                        <button
-                          className="ghost-button"
-                          type="button"
-                          onClick={() => setEditingOrderId(null)}
-                          disabled={busyOrderId === order.id}
-                          style={{ color: "var(--text)", borderColor: "var(--line)", background: "var(--surface)" }}
-                        >
-                          取消
-                        </button>
-                        <button
-                          className="primary-button"
-                          type="button"
-                          onClick={() => saveOrder(order)}
-                          disabled={busyOrderId === order.id}
-                        >
-                          {busyOrderId === order.id ? "儲存中..." : "儲存修改"}
-                        </button>
-                      </>
-                    ) : (
-                      <>
-                        <button
-                          className="ghost-button"
-                          type="button"
-                          onClick={() => startEditing(order)}
-                          disabled={busyOrderId === order.id}
-                          style={{ color: "var(--text)", borderColor: "var(--line)", background: "var(--surface)" }}
-                        >
-                          編輯
-                        </button>
-                        <button
-                          className="ghost-button"
-                          type="button"
-                          onClick={() => removeOrder(order)}
-                          disabled={busyOrderId === order.id}
-                          style={{
-                            color: "var(--brand-deep)",
-                            borderColor: "rgba(200, 92, 44, 0.28)",
-                            background: "rgba(200, 92, 44, 0.08)",
-                          }}
-                        >
-                          {busyOrderId === order.id ? "刪除中..." : "刪除"}
-                        </button>
-                      </>
-                    )}
-                  </div>
-                )}
+                  );
+                })}
               </div>
-            );
-          })}
+            </section>
+          ))}
         </div>
       )}
     </div>

--- a/frontend/src/pages/employee/RandomMealPage.jsx
+++ b/frontend/src/pages/employee/RandomMealPage.jsx
@@ -162,7 +162,7 @@ export default function RandomMealPage() {
     <div>
       <div className="page-header">
         <FacilityScopeLabel label="Ordering facility" />
-        <p className="eyebrow">員工 / 推薦與隨機抽餐</p>
+        <p className="eyebrow">Employee · Random Meal</p>
         <h2>今天吃什麼？</h2>
       </div>
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -637,9 +637,110 @@ p {
   color: #8a5e00;
 }
 
+.badge-status-pending {
+  background: rgba(200, 92, 44, 0.12);
+  color: #9a3f18;
+}
+
+.badge-status-confirmed {
+  background: rgba(31, 105, 141, 0.14);
+  color: #1f698d;
+}
+
+.badge-status-preparing {
+  background: rgba(122, 92, 250, 0.12);
+  color: #5a44b8;
+}
+
+.badge-status-ready {
+  background: rgba(47, 125, 74, 0.12);
+  color: #24633a;
+}
+
+.badge-status-delivered {
+  background: rgba(104, 113, 123, 0.16);
+  color: #46515c;
+}
+
+.badge-status-cancelled {
+  background: rgba(117, 36, 56, 0.12);
+  color: #752438;
+}
+
 .badge-recommended {
   background: rgba(31, 105, 141, 0.14);
   color: #1f698d;
+}
+
+.orders-date-groups {
+  display: grid;
+  gap: 18px;
+}
+
+.orders-date-group {
+  display: grid;
+  gap: 18px;
+}
+
+.orders-date-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.orders-date-list {
+  display: grid;
+}
+
+.employee-order-card {
+  display: grid;
+  gap: 14px;
+  padding: 18px 0;
+}
+
+.employee-order-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.employee-order-heading {
+  display: grid;
+  gap: 6px;
+}
+
+.employee-order-vendor {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 800;
+  line-height: 1.2;
+  color: var(--text);
+}
+
+.employee-order-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.employee-order-pickup {
+  margin: 0;
+  color: var(--brand-deep);
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.employee-order-summary {
+  display: grid;
+  justify-items: end;
+  align-content: start;
+  gap: 8px;
+  text-align: right;
 }
 
 /* Meal detail modal */
@@ -916,6 +1017,33 @@ p {
   font-weight: 700;
 }
 
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.form-input {
+  width: 100%;
+  min-height: 48px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--surface-strong);
+  color: var(--text);
+  font: inherit;
+  transition: border-color 140ms ease, box-shadow 140ms ease, background 140ms ease;
+}
+
+.form-input::placeholder {
+  color: color-mix(in srgb, var(--muted) 78%, white 22%);
+}
+
+.form-input:focus {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(200, 92, 44, 0.12);
+  outline: none;
+}
+
 .date-input {
   width: 100%;
   min-height: 48px;
@@ -1124,6 +1252,18 @@ p {
   background: rgba(47, 125, 74, 0.1);
   color: var(--success);
   font-weight: 700;
+}
+
+.account-form-header {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.account-password-form {
+  display: grid;
+  gap: 14px;
+  max-width: 420px;
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary

Refine the employee-facing UI with functional improvements and Chinese localization.

## Changes

### `EmployeeHomePage`
- Replaced the placeholder "本期進度" panel with a live **今日最新訂單** widget
- Fetches today's orders via `useMyOrders` and displays the latest order with vendor name, items, and status badge
- Fixed quick-access shortcut: "瀏覽菜單" → "隨機抽餐" with corrected route (`/employee/random-meal`)

### `OrdersPage`
- Added vendor name display per order (resolved via `useVendors`)
- Added `formatMealDateLabel` for human-readable meal date with weekday (e.g. `2026/06/02（一）`)
- Replaced generic badge colors with semantic per-status badge classes

### `AccountPage`
- Extracted `PasswordInput` component with show/hide toggle button (`.pw-toggle`)

### `global.css`
- Added semantic order status badge classes: `badge-status-pending`, `badge-status-confirmed`, `badge-status-preparing`, `badge-status-ready`, `badge-status-delivered`, `badge-status-cancelled`

### Localization
- **Sidebar**: `Operations Console` → `訂餐管理平台`
- **Navigation**: `My Badge` → `取餐編號`, `Notifications` → `通知`
- **RandomMealPage**: eyebrow label updated