### PR TITLE
feat(admin): employee facility assignment

### DIFF
--- a/backend/repositories/facility_repository.py
+++ b/backend/repositories/facility_repository.py
@@ -11,7 +11,8 @@ class FacilityRepository:
         self._facilities: dict[int, Facility] = {}
         self._code_index: dict[str, int] = {}  # code -> id
         self._next_id: int = 1
-        self._vendor_facilities: dict[int, list[int]] = {}  # vendor_id -> [facility_id]
+        self._vendor_facilities: dict[int, list[int]] = {}    # vendor_id -> [facility_id]
+        self._employee_facilities: dict[int, list[int]] = {}  # employee_id -> [facility_id]
 
     # ------------------------------------------------------------------
     # Facilities
@@ -46,3 +47,15 @@ class FacilityRepository:
     def set_vendor_facilities(self, vendor_id: int, facility_ids: list[int]) -> None:
         """Replace the vendor's facility set with the given list."""
         self._vendor_facilities[vendor_id] = list(facility_ids)
+
+    # ------------------------------------------------------------------
+    # Employee ↔ Facility assignments
+    # ------------------------------------------------------------------
+
+    def get_employee_facility_ids(self, employee_id: int) -> list[int]:
+        """Return the list of facility IDs assigned to an employee."""
+        return list(self._employee_facilities.get(employee_id, []))
+
+    def set_employee_facilities(self, employee_id: int, facility_ids: list[int]) -> None:
+        """Replace the employee's facility set with the given list."""
+        self._employee_facilities[employee_id] = list(facility_ids)

--- a/backend/repositories/postgres_facility_repository.py
+++ b/backend/repositories/postgres_facility_repository.py
@@ -72,3 +72,33 @@ class PostgresFacilityRepository:
                     """,
                     (vendor_id, fid),
                 )
+
+    # ------------------------------------------------------------------
+    # Employee ↔ Facility assignments
+    # ------------------------------------------------------------------
+
+    def get_employee_facility_ids(self, employee_id: int) -> list[int]:
+        """Return the list of facility IDs assigned to an employee."""
+        with get_connection() as conn:
+            rows = conn.execute(
+                "SELECT facility_id FROM employee_facilities WHERE employee_id = %s",
+                (employee_id,),
+            ).fetchall()
+        return [row["facility_id"] for row in rows]
+
+    def set_employee_facilities(self, employee_id: int, facility_ids: list[int]) -> None:
+        """Replace the employee's facility set with the given list (within one transaction)."""
+        with get_connection() as conn:
+            conn.execute(
+                "DELETE FROM employee_facilities WHERE employee_id = %s",
+                (employee_id,),
+            )
+            for fid in facility_ids:
+                conn.execute(
+                    """
+                    INSERT INTO employee_facilities (employee_id, facility_id)
+                    VALUES (%s, %s)
+                    ON CONFLICT DO NOTHING
+                    """,
+                    (employee_id, fid),
+                )

--- a/backend/routes/admin_facilities.py
+++ b/backend/routes/admin_facilities.py
@@ -104,7 +104,7 @@ def _assert_employee_exists(employee_id: int) -> None:
         raise CodedHTTPException(status_code=404, code="not_found", detail="employee not found")
 
 
-@router.get("/employees/{employee_id}/facilities", response_model=list[Facility])
+@router.get("/employees/{employee_id}/facilities")
 def get_employee_facilities(
     employee_id: int,
     _role: Annotated[str, Depends(require_roles("admin"))],
@@ -114,7 +114,7 @@ def get_employee_facilities(
     return _service(repo).get_employee_facilities(employee_id)
 
 
-@router.put("/employees/{employee_id}/facilities", response_model=list[Facility])
+@router.put("/employees/{employee_id}/facilities")
 def set_employee_facilities(
     employee_id: int,
     body: EmployeeFacilitiesUpdate,

--- a/backend/routes/admin_facilities.py
+++ b/backend/routes/admin_facilities.py
@@ -9,7 +9,8 @@ from backend.core.facilities import get_facility_repository
 from backend.core.errors import CodedHTTPException
 from backend.core.rbac import get_current_user_id, get_current_user_role, require_roles
 from backend.core.vendor_identity import get_vendor_profile_repository
-from backend.schemas.facility_admin import FacilityCreate, VendorFacilitiesUpdate
+from backend.db.connection import get_connection
+from backend.schemas.facility_admin import EmployeeFacilitiesUpdate, FacilityCreate, VendorFacilitiesUpdate
 from backend.schemas.vendor import (
     VendorDailyRecommendationLimit,
     VendorDailyRecommendationLimitUpdate,
@@ -91,6 +92,43 @@ def get_vendor_recommendation_limit(
     return VendorDailyRecommendationLimit(
         vendor_id=vendor_id,
         daily_recommendation_limit=vendor.daily_recommendation_limit,
+    )
+
+
+def _assert_employee_exists(employee_id: int) -> None:
+    with get_connection() as conn:
+        row = conn.execute(
+            "SELECT id FROM users WHERE id = %s", (employee_id,)
+        ).fetchone()
+    if row is None:
+        raise CodedHTTPException(status_code=404, code="not_found", detail="employee not found")
+
+
+@router.get("/employees/{employee_id}/facilities", response_model=list[Facility])
+def get_employee_facilities(
+    employee_id: int,
+    _role: Annotated[str, Depends(require_roles("admin"))],
+    repo: Annotated[object, Depends(get_facility_repository)],
+) -> list[Facility]:
+    _assert_employee_exists(employee_id)
+    return _service(repo).get_employee_facilities(employee_id)
+
+
+@router.put("/employees/{employee_id}/facilities", response_model=list[Facility])
+def set_employee_facilities(
+    employee_id: int,
+    body: EmployeeFacilitiesUpdate,
+    _role: Annotated[str, Depends(require_roles("admin"))],
+    repo: Annotated[object, Depends(get_facility_repository)],
+    actor_id: Annotated[int | None, Depends(get_current_user_id)] = None,
+    actor_role: Annotated[str, Depends(get_current_user_role)] = "anonymous",
+) -> list[Facility]:
+    _assert_employee_exists(employee_id)
+    return _service(repo).set_employee_facilities(
+        employee_id,
+        body.facility_ids,
+        actor_user_id=actor_id,
+        actor_role=actor_role,
     )
 
 

--- a/backend/schemas/facility_admin.py
+++ b/backend/schemas/facility_admin.py
@@ -10,3 +10,7 @@ class FacilityCreate(BaseModel):
 
 class VendorFacilitiesUpdate(BaseModel):
     facility_ids: list[int]
+
+
+class EmployeeFacilitiesUpdate(BaseModel):
+    facility_ids: list[int]

--- a/backend/services/facility_admin_service.py
+++ b/backend/services/facility_admin_service.py
@@ -82,6 +82,40 @@ class FacilityAdminService:
         return self.get_vendor_facilities(vendor_id)
 
     # ------------------------------------------------------------------
+    # Employee ↔ Facility assignments
+    # ------------------------------------------------------------------
+
+    def get_employee_facilities(self, employee_id: int) -> list[Facility]:
+        facility_ids = set(self.facility_repository.get_employee_facility_ids(employee_id))
+        return [f for f in self.facility_repository.list_facilities() if f.id in facility_ids]
+
+    def set_employee_facilities(
+        self,
+        employee_id: int,
+        facility_ids: list[int],
+        *,
+        actor_user_id: int | None = None,
+        actor_role: str | None = None,
+    ) -> list[Facility]:
+        for fid in facility_ids:
+            if not self.facility_repository.facility_exists(fid):
+                raise CodedHTTPException(
+                    status_code=404,
+                    code="not_found",
+                    detail="facility not found",
+                )
+        self.facility_repository.set_employee_facilities(employee_id, facility_ids)
+        self.audit_log_repository.record(
+            actor_user_id=actor_user_id,
+            actor_role=actor_role,
+            action="facility.assign",
+            target_type="employee",
+            target_id=employee_id,
+            metadata={"employee_id": employee_id, "facility_ids": list(facility_ids)},
+        )
+        return self.get_employee_facilities(employee_id)
+
+    # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
 

--- a/backend/tests/test_admin_facilities_route.py
+++ b/backend/tests/test_admin_facilities_route.py
@@ -1,6 +1,8 @@
 """Route tests for GET/POST /admin/facilities and GET/PUT /admin/vendors/{id}/facilities."""
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 from fastapi.testclient import TestClient
 
 from backend.core.facilities import get_facility_repository
@@ -247,4 +249,124 @@ def test_put_vendor_recommendation_limit_employee_forbidden() -> None:
         headers=_EMPLOYEE_HEADERS,
     )
 
+    assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Helper — mock the DB check in _assert_employee_exists
+# ---------------------------------------------------------------------------
+
+
+def _employee_conn(exists: bool = True, employee_id: int = 42) -> MagicMock:
+    """Context-manager mock for get_connection() used in _assert_employee_exists."""
+    result = MagicMock()
+    result.fetchone.return_value = {"id": employee_id} if exists else None
+    conn = MagicMock()
+    conn.execute.return_value = result
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=conn)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/employees/{employee_id}/facilities
+# ---------------------------------------------------------------------------
+
+
+def test_get_employee_facilities_employee_role_forbidden() -> None:
+    _override_facility_repo(FacilityRepository())
+    r = client.get("/admin/employees/42/facilities", headers=_EMPLOYEE_HEADERS)
+    assert r.status_code == 403
+
+
+def test_get_employee_facilities_empty() -> None:
+    _override_facility_repo(FacilityRepository())
+    with patch("backend.routes.admin_facilities.get_connection", return_value=_employee_conn()):
+        r = client.get("/admin/employees/42/facilities", headers=_ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_get_employee_facilities_returns_assigned() -> None:
+    repo = FacilityRepository()
+    f = repo.create_facility("E01", "Employee Fab 1")
+    repo.set_employee_facilities(42, [f.id])
+    _override_facility_repo(repo)
+    with patch("backend.routes.admin_facilities.get_connection", return_value=_employee_conn()):
+        r = client.get("/admin/employees/42/facilities", headers=_ADMIN_HEADERS)
+    assert r.status_code == 200
+    assert r.json()[0]["code"] == "E01"
+
+
+def test_get_employee_facilities_missing_employee_404() -> None:
+    _override_facility_repo(FacilityRepository())
+    with patch("backend.routes.admin_facilities.get_connection", return_value=_employee_conn(exists=False)):
+        r = client.get("/admin/employees/999/facilities", headers=_ADMIN_HEADERS)
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# PUT /admin/employees/{employee_id}/facilities
+# ---------------------------------------------------------------------------
+
+
+def test_put_employee_facilities_assigns_correctly() -> None:
+    repo = FacilityRepository()
+    f = repo.create_facility("E01", "Employee Fab 1")
+    _override_facility_repo(repo)
+    with patch("backend.routes.admin_facilities.get_connection", return_value=_employee_conn()):
+        r = client.put(
+            "/admin/employees/42/facilities",
+            json={"facility_ids": [f.id]},
+            headers=_ADMIN_HEADERS,
+        )
+    assert r.status_code == 200
+    assert r.json()[0]["code"] == "E01"
+
+
+def test_put_employee_facilities_empty_clears_assignment() -> None:
+    repo = FacilityRepository()
+    f = repo.create_facility("E01", "Employee Fab 1")
+    repo.set_employee_facilities(42, [f.id])
+    _override_facility_repo(repo)
+    with patch("backend.routes.admin_facilities.get_connection", return_value=_employee_conn()):
+        r = client.put(
+            "/admin/employees/42/facilities",
+            json={"facility_ids": []},
+            headers=_ADMIN_HEADERS,
+        )
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_put_employee_facilities_nonexistent_facility_404() -> None:
+    _override_facility_repo(FacilityRepository())
+    with patch("backend.routes.admin_facilities.get_connection", return_value=_employee_conn()):
+        r = client.put(
+            "/admin/employees/42/facilities",
+            json={"facility_ids": [9999]},
+            headers=_ADMIN_HEADERS,
+        )
+    assert r.status_code == 404
+
+
+def test_put_employee_facilities_missing_employee_404() -> None:
+    _override_facility_repo(FacilityRepository())
+    with patch("backend.routes.admin_facilities.get_connection", return_value=_employee_conn(exists=False)):
+        r = client.put(
+            "/admin/employees/42/facilities",
+            json={"facility_ids": []},
+            headers=_ADMIN_HEADERS,
+        )
+    assert r.status_code == 404
+
+
+def test_put_employee_facilities_employee_role_forbidden() -> None:
+    _override_facility_repo(FacilityRepository())
+    r = client.put(
+        "/admin/employees/42/facilities",
+        json={"facility_ids": []},
+        headers=_EMPLOYEE_HEADERS,
+    )
     assert r.status_code == 403

--- a/backend/tests/test_facility_admin_service.py
+++ b/backend/tests/test_facility_admin_service.py
@@ -128,3 +128,73 @@ def test_set_vendor_facilities_unknown_vendor_raises_404() -> None:
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.code == "not_found"
+
+
+# ------------------------------------------------------------------
+# get_employee_facilities / set_employee_facilities
+# ------------------------------------------------------------------
+
+def test_set_and_get_employee_facilities() -> None:
+    svc, facility_repo, _, audit_repo = _make_service()
+
+    f1 = facility_repo.create_facility("E01", "Employee Facility 1")
+    f2 = facility_repo.create_facility("E02", "Employee Facility 2")
+
+    result = svc.set_employee_facilities(10, [f1.id, f2.id], actor_user_id=99, actor_role="admin")
+
+    assert {f.id for f in result} == {f1.id, f2.id}
+
+    entries = audit_repo.list(action="facility.assign")
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.target_type == "employee"
+    assert entry.target_id == 10
+    assert entry.actor_user_id == 99
+    assert entry.actor_role == "admin"
+    assert entry.metadata["employee_id"] == 10
+    assert set(entry.metadata["facility_ids"]) == {f1.id, f2.id}
+
+    fetched = svc.get_employee_facilities(10)
+    assert {f.id for f in fetched} == {f1.id, f2.id}
+
+
+def test_set_employee_facilities_replaces_previous() -> None:
+    svc, facility_repo, _, _ = _make_service()
+
+    f1 = facility_repo.create_facility("E01", "Emp Fac 1")
+    f2 = facility_repo.create_facility("E02", "Emp Fac 2")
+
+    svc.set_employee_facilities(10, [f1.id])
+    svc.set_employee_facilities(10, [f2.id])
+
+    fetched = svc.get_employee_facilities(10)
+    assert len(fetched) == 1
+    assert fetched[0].id == f2.id
+
+
+def test_set_employee_facilities_empty_clears_assignment() -> None:
+    svc, facility_repo, _, _ = _make_service()
+
+    f = facility_repo.create_facility("E01", "Emp Fac 1")
+    svc.set_employee_facilities(10, [f.id])
+    svc.set_employee_facilities(10, [])
+
+    assert svc.get_employee_facilities(10) == []
+
+
+def test_set_employee_facilities_invalid_facility_raises_404() -> None:
+    svc, _, _, _ = _make_service()
+
+    with pytest.raises(CodedHTTPException) as exc_info:
+        svc.set_employee_facilities(10, [9999])
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.code == "not_found"
+
+
+def test_get_employee_facilities_unknown_employee_returns_empty() -> None:
+    svc, _, _, _ = _make_service()
+
+    # No facility assignment means unrestricted — returns empty list, not 404
+    result = svc.get_employee_facilities(9999)
+    assert result == []

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -82,6 +82,18 @@ export function setVendorFacilities(vendorId, facilityIds) {
   });
 }
 
+export function getEmployeeFacilities(employeeId) {
+  return apiFetch(`/admin/employees/${employeeId}/facilities`);
+}
+
+export function setEmployeeFacilities(employeeId, facilityIds) {
+  return apiFetch(`/admin/employees/${employeeId}/facilities`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ facility_ids: facilityIds }),
+  });
+}
+
 export function getVendorRecommendationLimit(vendorId) {
   return apiFetch(`/admin/vendors/${vendorId}/recommendation-limit`);
 }

--- a/frontend/src/pages/admin/AdminEmployeeReviewPage.jsx
+++ b/frontend/src/pages/admin/AdminEmployeeReviewPage.jsx
@@ -43,7 +43,7 @@ const GRID_COLS = "1fr 200px 110px 110px 200px";
 // ── Inline facility editor ────────────────────────────────────────────────────
 
 function FacilityEditor({ employeeId, allFacilities, onClose }) {
-  const [checkedIds, setCheckedIds] = useState(new Set());
+  const [selectedId, setSelectedId] = useState("");   // "" = 不限廠區
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
@@ -54,27 +54,18 @@ function FacilityEditor({ employeeId, allFacilities, onClose }) {
     setError(null);
     setSuccess(false);
     getEmployeeFacilities(employeeId)
-      .then((data) => { if (active) setCheckedIds(new Set(data.map((f) => f.id))); })
+      .then((data) => { if (active) setSelectedId(data[0]?.id ?? ""); })
       .catch(() => { if (active) setError("無法載入廠區指派"); })
       .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
   }, [employeeId]);
-
-  function toggle(id) {
-    setCheckedIds((prev) => {
-      const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
-      return next;
-    });
-    setSuccess(false);
-  }
 
   async function handleSave() {
     setLoading(true);
     setError(null);
     setSuccess(false);
     try {
-      await setEmployeeFacilities(employeeId, Array.from(checkedIds));
+      await setEmployeeFacilities(employeeId, selectedId ? [Number(selectedId)] : []);
       setSuccess(true);
     } catch {
       setError("儲存失敗，請稍後再試");
@@ -92,56 +83,45 @@ function FacilityEditor({ employeeId, allFacilities, onClose }) {
         background: "rgba(47,100,200,0.03)",
       }}
     >
-      <p style={{ margin: "0 0 10px", fontSize: 13, fontWeight: 600, color: "#2b5cc8" }}>
-        指派廠區
-        <span style={{ marginLeft: 8, fontSize: 12, fontWeight: 400, color: "var(--muted)" }}>
-          （空選表示不限廠區）
-        </span>
-      </p>
+      <p style={{ margin: "0 0 10px", fontSize: 13, fontWeight: 600, color: "#2b5cc8" }}>指派廠區</p>
 
       {loading && <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>載入中…</p>}
 
-      {!loading && allFacilities.length === 0 && (
-        <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>尚未建立任何廠區。</p>
-      )}
-
-      {!loading && allFacilities.length > 0 && (
-        <>
-          <div style={{ display: "flex", flexWrap: "wrap", gap: "6px 20px", marginBottom: 12 }}>
+      {!loading && (
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <select
+            value={selectedId}
+            onChange={(e) => { setSelectedId(e.target.value); setSuccess(false); }}
+            style={{
+              padding: "6px 12px",
+              borderRadius: "var(--radius-md)",
+              border: "1px solid var(--line)",
+              background: "var(--surface-strong)",
+              fontSize: 13,
+              cursor: "pointer",
+              minWidth: 200,
+            }}
+          >
+            <option value="">— 不限廠區 —</option>
             {allFacilities.map((f) => (
-              <label
-                key={f.id}
-                style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", fontSize: 13 }}
-              >
-                <input
-                  type="checkbox"
-                  checked={checkedIds.has(f.id)}
-                  onChange={() => toggle(f.id)}
-                />
-                <span>{f.code}　{f.name}</span>
-              </label>
+              <option key={f.id} value={f.id}>
+                {f.code}　{f.name}
+              </option>
             ))}
-          </div>
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <button
-              type="button"
-              onClick={handleSave}
-              disabled={loading}
-              style={btnStyle("approve")}
-            >
-              儲存
-            </button>
-            <button type="button" onClick={onClose} style={btnStyle()}>
-              關閉
-            </button>
-            {success && (
-              <span style={{ fontSize: 13, color: "var(--success)", fontWeight: 600 }}>✓ 已儲存</span>
-            )}
-            {error && (
-              <span style={{ fontSize: 13, color: "var(--brand)" }}>{error}</span>
-            )}
-          </div>
-        </>
+          </select>
+          <button type="button" onClick={handleSave} disabled={loading} style={btnStyle("approve")}>
+            儲存
+          </button>
+          <button type="button" onClick={onClose} style={btnStyle()}>
+            關閉
+          </button>
+          {success && (
+            <span style={{ fontSize: 13, color: "var(--success)", fontWeight: 600 }}>✓ 已儲存</span>
+          )}
+          {error && (
+            <span style={{ fontSize: 13, color: "var(--brand)" }}>{error}</span>
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/admin/AdminEmployeeReviewPage.jsx
+++ b/frontend/src/pages/admin/AdminEmployeeReviewPage.jsx
@@ -43,10 +43,11 @@ const GRID_COLS = "1fr 200px 110px 110px 200px";
 // ── Inline facility editor ────────────────────────────────────────────────────
 
 function FacilityEditor({ employeeId, allFacilities, onClose }) {
-  const [selectedId, setSelectedId] = useState("");   // "" = 不限廠區
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [success, setSuccess] = useState(false);
+  const [checkedIds, setCheckedIds] = useState(new Set());
+  const [loading, setLoading]       = useState(true);
+  const [saving, setSaving]         = useState(false);
+  const [error, setError]           = useState(null);
+  const [success, setSuccess]       = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -54,23 +55,33 @@ function FacilityEditor({ employeeId, allFacilities, onClose }) {
     setError(null);
     setSuccess(false);
     getEmployeeFacilities(employeeId)
-      .then((data) => { if (active) setSelectedId(data[0]?.id ?? ""); })
+      .then((data) => { if (active) setCheckedIds(new Set(data.map((f) => f.id))); })
       .catch(() => { if (active) setError("無法載入廠區指派"); })
       .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
   }, [employeeId]);
 
+  function toggleFacility(id) {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+    setSuccess(false);
+  }
+
   async function handleSave() {
-    setLoading(true);
+    setSaving(true);
     setError(null);
     setSuccess(false);
     try {
-      await setEmployeeFacilities(employeeId, selectedId ? [Number(selectedId)] : []);
+      await setEmployeeFacilities(employeeId, Array.from(checkedIds));
       setSuccess(true);
     } catch {
       setError("儲存失敗，請稍後再試");
     } finally {
-      setLoading(false);
+      setSaving(false);
     }
   }
 
@@ -88,39 +99,41 @@ function FacilityEditor({ employeeId, allFacilities, onClose }) {
       {loading && <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>載入中…</p>}
 
       {!loading && (
-        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-          <select
-            value={selectedId}
-            onChange={(e) => { setSelectedId(e.target.value); setSuccess(false); }}
-            style={{
-              padding: "6px 12px",
-              borderRadius: "var(--radius-md)",
-              border: "1px solid var(--line)",
-              background: "var(--surface-strong)",
-              fontSize: 13,
-              cursor: "pointer",
-              minWidth: 200,
-            }}
-          >
-            <option value="">— 不限廠區 —</option>
-            {allFacilities.map((f) => (
-              <option key={f.id} value={f.id}>
-                {f.code}　{f.name}
-              </option>
-            ))}
-          </select>
-          <button type="button" onClick={handleSave} disabled={loading} style={btnStyle("approve")}>
-            儲存
-          </button>
-          <button type="button" onClick={onClose} style={btnStyle()}>
-            關閉
-          </button>
-          {success && (
-            <span style={{ fontSize: 13, color: "var(--success)", fontWeight: 600 }}>✓ 已儲存</span>
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          {allFacilities.length === 0 ? (
+            <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>尚無廠區可指派</p>
+          ) : (
+            <div style={{ display: "flex", flexWrap: "wrap", gap: "8px 24px" }}>
+              {allFacilities.map((f) => (
+                <label
+                  key={f.id}
+                  style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", fontSize: 13 }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checkedIds.has(f.id)}
+                    onChange={() => toggleFacility(f.id)}
+                  />
+                  <span>{f.code}　{f.name}</span>
+                </label>
+              ))}
+            </div>
           )}
-          {error && (
-            <span style={{ fontSize: 13, color: "var(--brand)" }}>{error}</span>
-          )}
+          <p style={{ margin: 0, fontSize: 12, color: "var(--muted)" }}>空選表示不限廠區</p>
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <button type="button" onClick={handleSave} disabled={saving} style={btnStyle("approve")}>
+              {saving ? "儲存中…" : "儲存"}
+            </button>
+            <button type="button" onClick={onClose} style={btnStyle()}>
+              關閉
+            </button>
+            {success && (
+              <span style={{ fontSize: 13, color: "var(--success)", fontWeight: 600 }}>✓ 已儲存</span>
+            )}
+            {error && (
+              <span style={{ fontSize: 13, color: "var(--brand)" }}>{error}</span>
+            )}
+          </div>
         </div>
       )}
     </div>
@@ -130,22 +143,22 @@ function FacilityEditor({ employeeId, allFacilities, onClose }) {
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export default function AdminEmployeeReviewPage() {
-  const [tab, setTab]             = useState(0);   // 0 = 待審核, 1 = 已啟用
+  const [tab, setTab] = useState(0);   // 0 = 待審核, 1 = 已啟用
   const [employees, setEmployees] = useState([]);
-  const [loading, setLoading]     = useState(true);
-  const [error, setError]         = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
   const [actionError, setActionError] = useState(null);
-  const [busy, setBusy]           = useState(null);  // user_id of in-flight action
+  const [busy, setBusy] = useState(null);  // user_id of in-flight action
 
   // Facility editor state
-  const [allFacilities, setAllFacilities]   = useState([]);
-  const [expandedEmpId, setExpandedEmpId]   = useState(null);
+  const [allFacilities, setAllFacilities] = useState([]);
+  const [expandedEmpId, setExpandedEmpId] = useState(null);
 
   const isActive = TABS[tab].is_active;
 
   // Load facilities once
   useEffect(() => {
-    getFacilities().then(setAllFacilities).catch(() => {});
+    getFacilities().then(setAllFacilities).catch(() => { });
   }, []);
 
   useEffect(() => {
@@ -196,7 +209,7 @@ export default function AdminEmployeeReviewPage() {
     <div>
       <div className="page-header">
         <p className="eyebrow">Admin · Employee Review</p>
-        <h2>員工帳號審核</h2>
+        <h2>員工帳號審核與廠區設定</h2>
       </div>
 
       <div className="filter-bar" style={{ marginBottom: 20 }}>
@@ -217,7 +230,7 @@ export default function AdminEmployeeReviewPage() {
       )}
 
       {loading && <p className="loading-state">載入中...</p>}
-      {error   && <p className="error-state">{error}</p>}
+      {error && <p className="error-state">{error}</p>}
 
       {!loading && !error && employees.length === 0 && (
         <p className="empty-state">

--- a/frontend/src/pages/admin/AdminEmployeeReviewPage.jsx
+++ b/frontend/src/pages/admin/AdminEmployeeReviewPage.jsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from "react";
-import { deleteUser, enableUser, getUsers } from "../../api/admin";
+import {
+  deleteUser,
+  enableUser,
+  getEmployeeFacilities,
+  getFacilities,
+  getUsers,
+  setEmployeeFacilities,
+} from "../../api/admin";
 
 const TABS = [
   { label: "待審核", is_active: false },
@@ -25,25 +32,147 @@ function btnStyle(variant) {
   if (variant === "reject") {
     return { ...base, background: "rgba(200,92,44,0.12)", color: "var(--brand)" };
   }
+  if (variant === "facility") {
+    return { ...base, background: "rgba(47,100,200,0.10)", color: "#2b5cc8" };
+  }
   return { ...base, background: "var(--line)", color: "var(--text)" };
 }
 
-const GRID_COLS = "1fr 200px 110px 110px 180px";
+const GRID_COLS = "1fr 200px 110px 110px 200px";
+
+// ── Inline facility editor ────────────────────────────────────────────────────
+
+function FacilityEditor({ employeeId, allFacilities, onClose }) {
+  const [checkedIds, setCheckedIds] = useState(new Set());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+    getEmployeeFacilities(employeeId)
+      .then((data) => { if (active) setCheckedIds(new Set(data.map((f) => f.id))); })
+      .catch(() => { if (active) setError("無法載入廠區指派"); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [employeeId]);
+
+  function toggle(id) {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+    setSuccess(false);
+  }
+
+  async function handleSave() {
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      await setEmployeeFacilities(employeeId, Array.from(checkedIds));
+      setSuccess(true);
+    } catch {
+      setError("儲存失敗，請稍後再試");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        gridColumn: "1 / -1",
+        padding: "14px 20px 16px",
+        borderTop: "1px dashed var(--line)",
+        background: "rgba(47,100,200,0.03)",
+      }}
+    >
+      <p style={{ margin: "0 0 10px", fontSize: 13, fontWeight: 600, color: "#2b5cc8" }}>
+        指派廠區
+        <span style={{ marginLeft: 8, fontSize: 12, fontWeight: 400, color: "var(--muted)" }}>
+          （空選表示不限廠區）
+        </span>
+      </p>
+
+      {loading && <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>載入中…</p>}
+
+      {!loading && allFacilities.length === 0 && (
+        <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>尚未建立任何廠區。</p>
+      )}
+
+      {!loading && allFacilities.length > 0 && (
+        <>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "6px 20px", marginBottom: 12 }}>
+            {allFacilities.map((f) => (
+              <label
+                key={f.id}
+                style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", fontSize: 13 }}
+              >
+                <input
+                  type="checkbox"
+                  checked={checkedIds.has(f.id)}
+                  onChange={() => toggle(f.id)}
+                />
+                <span>{f.code}　{f.name}</span>
+              </label>
+            ))}
+          </div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={loading}
+              style={btnStyle("approve")}
+            >
+              儲存
+            </button>
+            <button type="button" onClick={onClose} style={btnStyle()}>
+              關閉
+            </button>
+            {success && (
+              <span style={{ fontSize: 13, color: "var(--success)", fontWeight: 600 }}>✓ 已儲存</span>
+            )}
+            {error && (
+              <span style={{ fontSize: 13, color: "var(--brand)" }}>{error}</span>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
 
 export default function AdminEmployeeReviewPage() {
-  const [tab, setTab]           = useState(0);   // 0 = 待審核, 1 = 已啟用
+  const [tab, setTab]             = useState(0);   // 0 = 待審核, 1 = 已啟用
   const [employees, setEmployees] = useState([]);
-  const [loading, setLoading]   = useState(true);
-  const [error, setError]       = useState(null);
+  const [loading, setLoading]     = useState(true);
+  const [error, setError]         = useState(null);
   const [actionError, setActionError] = useState(null);
-  const [busy, setBusy]         = useState(null);  // user_id of in-flight action
+  const [busy, setBusy]           = useState(null);  // user_id of in-flight action
+
+  // Facility editor state
+  const [allFacilities, setAllFacilities]   = useState([]);
+  const [expandedEmpId, setExpandedEmpId]   = useState(null);
 
   const isActive = TABS[tab].is_active;
+
+  // Load facilities once
+  useEffect(() => {
+    getFacilities().then(setAllFacilities).catch(() => {});
+  }, []);
 
   useEffect(() => {
     setLoading(true);
     setError(null);
     setEmployees([]);
+    setExpandedEmpId(null);
     getUsers({ role: "employee", is_active: isActive })
       .then((data) => setEmployees(data.users))
       .catch((err) => setError(err.message ?? "無法載入員工列表"))
@@ -56,6 +185,7 @@ export default function AdminEmployeeReviewPage() {
     try {
       await enableUser(userId);
       setEmployees((prev) => prev.filter((u) => u.id !== userId));
+      if (expandedEmpId === userId) setExpandedEmpId(null);
     } catch (err) {
       setActionError(err.message ?? "核准失敗");
     } finally {
@@ -70,11 +200,16 @@ export default function AdminEmployeeReviewPage() {
     try {
       await deleteUser(userId);
       setEmployees((prev) => prev.filter((u) => u.id !== userId));
+      if (expandedEmpId === userId) setExpandedEmpId(null);
     } catch (err) {
       setActionError(err.message ?? "拒絕失敗");
     } finally {
       setBusy(null);
     }
+  }
+
+  function toggleExpand(empId) {
+    setExpandedEmpId((prev) => (prev === empId ? null : empId));
   }
 
   return (
@@ -117,7 +252,7 @@ export default function AdminEmployeeReviewPage() {
             style={{
               display: "grid",
               gridTemplateColumns: GRID_COLS,
-              minWidth: 700,
+              minWidth: 720,
               padding: "10px 20px",
               borderBottom: "1px solid var(--line)",
               color: "var(--muted)",
@@ -134,64 +269,82 @@ export default function AdminEmployeeReviewPage() {
             <span style={{ textAlign: "right" }}>操作</span>
           </div>
 
-          {employees.map((emp, idx) => (
-            <div
-              key={emp.id}
-              style={{
-                display: "grid",
-                gridTemplateColumns: GRID_COLS,
-                minWidth: 700,
-                alignItems: "center",
-                padding: "14px 20px",
-                borderBottom: idx < employees.length - 1 ? "1px solid var(--line)" : "none",
-              }}
-            >
-              <div>
-                <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>{emp.display_name}</p>
-                <p style={{ margin: "2px 0 0", fontSize: 12, color: "var(--muted)" }}>
-                  ID #{emp.id}
+          {employees.map((emp, idx) => {
+            const isExpanded = expandedEmpId === emp.id;
+            const isLast = idx === employees.length - 1;
+            return (
+              <div
+                key={emp.id}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: GRID_COLS,
+                  minWidth: 720,
+                  alignItems: "center",
+                  borderBottom: (!isLast || isExpanded) ? "1px solid var(--line)" : "none",
+                  flexWrap: "wrap",
+                }}
+              >
+                {/* Main row */}
+                <div style={{ padding: "14px 0 14px 20px" }}>
+                  <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>{emp.display_name}</p>
+                  <p style={{ margin: "2px 0 0", fontSize: 12, color: "var(--muted)" }}>
+                    ID #{emp.id}
+                  </p>
+                </div>
+
+                <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", padding: "14px 0" }}>
+                  {emp.email}
                 </p>
-              </div>
 
-              <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>{emp.email}</p>
+                <p style={{ margin: 0, fontSize: 13, textAlign: "center", fontFamily: "monospace", padding: "14px 0" }}>
+                  {emp.badge_code ?? "—"}
+                </p>
 
-              <p style={{ margin: 0, fontSize: 13, textAlign: "center", fontFamily: "monospace" }}>
-                {emp.badge_code ?? "—"}
-              </p>
+                <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center", padding: "14px 0" }}>
+                  {formatDate(emp.created_at)}
+                </p>
 
-              <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
-                {formatDate(emp.created_at)}
-              </p>
+                <div style={{ display: "flex", gap: 6, justifyContent: "flex-end", flexWrap: "wrap", padding: "14px 20px 14px 0" }}>
+                  {!isActive && (
+                    <>
+                      <button
+                        type="button"
+                        disabled={busy === emp.id}
+                        onClick={() => handleApprove(emp.id)}
+                        style={btnStyle("approve")}
+                      >
+                        核准
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busy === emp.id}
+                        onClick={() => handleReject(emp.id, emp.display_name)}
+                        style={btnStyle("reject")}
+                      >
+                        拒絕
+                      </button>
+                    </>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => toggleExpand(emp.id)}
+                    style={btnStyle("facility")}
+                  >
+                    {isExpanded ? "收起" : "指派廠區"}
+                  </button>
+                </div>
 
-              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-                {!isActive && (
-                  <>
-                    <button
-                      type="button"
-                      disabled={busy === emp.id}
-                      onClick={() => handleApprove(emp.id)}
-                      style={btnStyle("approve")}
-                    >
-                      核准
-                    </button>
-                    <button
-                      type="button"
-                      disabled={busy === emp.id}
-                      onClick={() => handleReject(emp.id, emp.display_name)}
-                      style={btnStyle("reject")}
-                    >
-                      拒絕
-                    </button>
-                  </>
+                {/* Inline facility editor */}
+                {isExpanded && (
+                  <FacilityEditor
+                    employeeId={emp.id}
+                    allFacilities={allFacilities}
+                    onClose={() => setExpandedEmpId(null)}
+                  />
                 )}
-                {isActive && (
-                  <span style={{ fontSize: 12, color: "var(--success)", fontWeight: 600 }}>
-                    ✓ 已啟用
-                  </span>
-                )}
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/frontend/src/pages/admin/AdminFacilitiesPage.jsx
+++ b/frontend/src/pages/admin/AdminFacilitiesPage.jsx
@@ -2,10 +2,13 @@ import { useEffect, useState } from "react";
 
 import {
   createFacility,
+  getEmployeeFacilities,
   getFacilities,
+  getUsers,
   getVendorApplications,
   getVendorFacilities,
   getVendorRecommendationLimit,
+  setEmployeeFacilities,
   setVendorFacilities,
   setVendorRecommendationLimit,
 } from "../../api/admin";
@@ -343,6 +346,162 @@ function VendorFacilitiesPanel() {
   );
 }
 
+// ── Panel C: 員工廠區指派 ─────────────────────────────────────────────────────
+
+function EmployeeFacilitiesPanel() {
+  const [employees, setEmployees] = useState([]);
+  const [empLoading, setEmpLoading] = useState(true);
+  const [empError, setEmpError] = useState(null);
+
+  const [allFacilities, setAllFacilities] = useState([]);
+  const [facLoading, setFacLoading] = useState(true);
+  const [facError, setFacError] = useState(null);
+
+  const [selectedEmployeeId, setSelectedEmployeeId] = useState("");
+  const [checkedIds, setCheckedIds] = useState(new Set());
+  const [assignLoading, setAssignLoading] = useState(false);
+  const [assignError, setAssignError] = useState(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+
+  // Load active employees
+  useEffect(() => {
+    let active = true;
+    setEmpLoading(true);
+    setEmpError(null);
+    getUsers({ role: "employee", is_active: true })
+      .then((data) => { if (active) setEmployees(data.users ?? []); })
+      .catch(() => { if (active) setEmpError("無法載入員工清單。"); })
+      .finally(() => { if (active) setEmpLoading(false); });
+    return () => { active = false; };
+  }, []);
+
+  // Load all facilities
+  useEffect(() => {
+    let active = true;
+    setFacLoading(true);
+    setFacError(null);
+    getFacilities()
+      .then((data) => { if (active) setAllFacilities(data); })
+      .catch(() => { if (active) setFacError("無法載入廠區清單。"); })
+      .finally(() => { if (active) setFacLoading(false); });
+    return () => { active = false; };
+  }, []);
+
+  // When employee changes, fetch current facility assignments
+  useEffect(() => {
+    if (!selectedEmployeeId) {
+      setCheckedIds(new Set());
+      return;
+    }
+    let active = true;
+    setAssignLoading(true);
+    setAssignError(null);
+    setSaveSuccess(false);
+    getEmployeeFacilities(Number(selectedEmployeeId))
+      .then((data) => { if (active) setCheckedIds(new Set(data.map((f) => f.id))); })
+      .catch(() => { if (active) setAssignError("無法載入員工已指派廠區。"); })
+      .finally(() => { if (active) setAssignLoading(false); });
+    return () => { active = false; };
+  }, [selectedEmployeeId]);
+
+  function toggleFacility(id) {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+    setSaveSuccess(false);
+  }
+
+  function handleSave(e) {
+    e.preventDefault();
+    if (!selectedEmployeeId) return;
+    setAssignLoading(true);
+    setAssignError(null);
+    setSaveSuccess(false);
+    setEmployeeFacilities(Number(selectedEmployeeId), Array.from(checkedIds))
+      .then(() => setSaveSuccess(true))
+      .catch(() => setAssignError("儲存失敗，請稍後再試。"))
+      .finally(() => setAssignLoading(false));
+  }
+
+  const isLoading = empLoading || facLoading;
+  const hasError = empError || facError;
+
+  return (
+    <article className="panel">
+      <p className="eyebrow">廠區管理</p>
+      <h2>員工所屬廠區</h2>
+
+      {isLoading && <p className="panel-copy">載入中…</p>}
+      {hasError && <p className="error-state">{empError ?? facError}</p>}
+
+      {!isLoading && !hasError && (
+        <>
+          <label style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 16 }}>
+            <span style={{ fontSize: "0.8rem" }}>選擇員工（已啟用）</span>
+            <select
+              className="form-input"
+              value={selectedEmployeeId}
+              onChange={(e) => setSelectedEmployeeId(e.target.value)}
+              style={{ maxWidth: 320 }}
+            >
+              <option value="">— 請選擇 —</option>
+              {employees.map((emp) => (
+                <option key={emp.id} value={emp.id}>
+                  {emp.display_name}
+                  {emp.badge_code ? `（${emp.badge_code}）` : ""}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          {selectedEmployeeId && (
+            <form onSubmit={handleSave}>
+              {assignLoading && <p className="panel-copy">載入中…</p>}
+              {!assignLoading && (
+                <>
+                  {allFacilities.length === 0 ? (
+                    <p className="panel-copy">尚無廠區可指派，請先在上方新增廠區。</p>
+                  ) : (
+                    <fieldset style={{ border: "none", padding: 0, marginBottom: 12 }}>
+                      <legend style={{ fontSize: "0.85rem", marginBottom: 8 }}>
+                        所屬廠區（可多選；空選表示不限廠區）
+                      </legend>
+                      <div style={{ display: "flex", flexWrap: "wrap", gap: "8px 20px" }}>
+                        {allFacilities.map((f) => (
+                          <label key={f.id} style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
+                            <input
+                              type="checkbox"
+                              checked={checkedIds.has(f.id)}
+                              onChange={() => toggleFacility(f.id)}
+                            />
+                            <span>{f.code}　{f.name}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </fieldset>
+                  )}
+                  <button
+                    type="submit"
+                    className="range-pill is-active"
+                    disabled={assignLoading}
+                  >
+                    儲存
+                  </button>
+                </>
+              )}
+              {assignError && <p className="error-state" style={{ marginTop: 8 }}>{assignError}</p>}
+              {saveSuccess && <p className="panel-copy" style={{ marginTop: 8, color: "var(--accent)" }}>已儲存。</p>}
+            </form>
+          )}
+        </>
+      )}
+    </article>
+  );
+}
+
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export default function AdminFacilitiesPage() {
@@ -350,6 +509,7 @@ export default function AdminFacilitiesPage() {
     <section className="dashboard-grid">
       <FacilitiesPanel />
       <VendorFacilitiesPanel />
+      <EmployeeFacilitiesPanel />
     </section>
   );
 }

--- a/frontend/src/pages/admin/AdminFacilitiesPage.jsx
+++ b/frontend/src/pages/admin/AdminFacilitiesPage.jsx
@@ -124,87 +124,54 @@ function FacilitiesPanel() {
   );
 }
 
-// ── Panel B: 商家服務廠區指派 ────────────────────────────────────────────────
+// ── Shared button style helper ────────────────────────────────────────────────
 
-function VendorFacilitiesPanel() {
-  const [vendors, setVendors] = useState([]);
-  const [vendorsLoading, setVendorsLoading] = useState(true);
-  const [vendorsError, setVendorsError] = useState(null);
+function inlineBtnStyle(variant) {
+  const base = {
+    padding: "5px 14px",
+    borderRadius: "var(--radius-md)",
+    border: "none",
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: "pointer",
+  };
+  if (variant === "save")
+    return { ...base, background: "rgba(47,125,74,0.12)", color: "var(--success)" };
+  if (variant === "config")
+    return { ...base, background: "rgba(47,100,200,0.10)", color: "#2b5cc8" };
+  return { ...base, background: "var(--line)", color: "var(--text)" };
+}
 
-  const [allFacilities, setAllFacilities] = useState([]);
-  const [facLoading, setFacLoading] = useState(true);
-  const [facError, setFacError] = useState(null);
+// ── Panel B: 商家服務廠區一覽 ─────────────────────────────────────────────────
 
-  const [selectedVendorId, setSelectedVendorId] = useState("");
-  const [checkedIds, setCheckedIds] = useState(new Set());
-  const [assignLoading, setAssignLoading] = useState(false);
-  const [assignError, setAssignError] = useState(null);
-  const [saveSuccess, setSaveSuccess] = useState(false);
+const VENDOR_GRID = "minmax(180px, 1fr) 1fr 120px";
+
+function VendorFacilityEditor({ vendorId, allFacilities, onClose, onSaved }) {
+  const [checkedIds, setCheckedIds]             = useState(new Set());
   const [recommendationLimit, setRecommendationLimit] = useState(3);
-  const [limitLoading, setLimitLoading] = useState(false);
-  const [limitError, setLimitError] = useState(null);
-  const [limitSuccess, setLimitSuccess] = useState(false);
+  const [loading, setLoading]                   = useState(true);
+  const [saving, setSaving]                     = useState(false);
+  const [error, setError]                       = useState(null);
+  const [success, setSuccess]                   = useState(false);
 
-  // Load approved vendors
   useEffect(() => {
     let active = true;
-    setVendorsLoading(true);
-    setVendorsError(null);
-    getVendorApplications("approved")
-      .then((data) => { if (active) setVendors(data); })
-      .catch(() => { if (active) setVendorsError("無法載入商家清單。"); })
-      .finally(() => { if (active) setVendorsLoading(false); });
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+    Promise.all([
+      getVendorFacilities(vendorId),
+      getVendorRecommendationLimit(vendorId),
+    ])
+      .then(([facs, limitData]) => {
+        if (!active) return;
+        setCheckedIds(new Set(facs.map((f) => f.id)));
+        setRecommendationLimit(limitData.daily_recommendation_limit ?? 3);
+      })
+      .catch(() => { if (active) setError("無法載入商家設定"); })
+      .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
-  }, []);
-
-  // Load all facilities
-  useEffect(() => {
-    let active = true;
-    setFacLoading(true);
-    setFacError(null);
-    getFacilities()
-      .then((data) => { if (active) setAllFacilities(data); })
-      .catch(() => { if (active) setFacError("無法載入廠區清單。"); })
-      .finally(() => { if (active) setFacLoading(false); });
-    return () => { active = false; };
-  }, []);
-
-  // When vendor changes, fetch its current facilities
-  useEffect(() => {
-    if (!selectedVendorId) {
-      setCheckedIds(new Set());
-      setRecommendationLimit(3);
-      return;
-    }
-    let active = true;
-    setAssignLoading(true);
-    setAssignError(null);
-    setSaveSuccess(false);
-    getVendorFacilities(Number(selectedVendorId))
-      .then((data) => {
-        if (active) setCheckedIds(new Set(data.map((f) => f.id)));
-      })
-      .catch(() => {
-        if (active) setAssignError("無法載入商家已指派廠區。");
-      })
-      .finally(() => {
-        if (active) setAssignLoading(false);
-      });
-    setLimitLoading(true);
-    setLimitError(null);
-    setLimitSuccess(false);
-    getVendorRecommendationLimit(Number(selectedVendorId))
-      .then((data) => {
-        if (active) setRecommendationLimit(data.daily_recommendation_limit ?? 3);
-      })
-      .catch(() => {
-        if (active) setLimitError("無法載入今日推薦上限");
-      })
-      .finally(() => {
-        if (active) setLimitLoading(false);
-      });
-    return () => { active = false; };
-  }, [selectedVendorId]);
+  }, [vendorId]);
 
   function toggleFacility(id) {
     setCheckedIds((prev) => {
@@ -213,134 +180,263 @@ function VendorFacilitiesPanel() {
       else next.add(id);
       return next;
     });
-    setSaveSuccess(false);
+    setSuccess(false);
   }
 
-  function handleSave(e) {
-    e.preventDefault();
-    if (!selectedVendorId) return;
-    setAssignLoading(true);
-    setAssignError(null);
-    setSaveSuccess(false);
-    setVendorFacilities(Number(selectedVendorId), Array.from(checkedIds))
-      .then(() => setSaveSuccess(true))
-      .catch(() => setAssignError("儲存失敗，請稍後再試。"))
-      .finally(() => setAssignLoading(false));
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      await Promise.all([
+        setVendorFacilities(vendorId, Array.from(checkedIds)),
+        setVendorRecommendationLimit(vendorId, recommendationLimit),
+      ]);
+      setSuccess(true);
+      onSaved?.();
+    } catch {
+      setError("儲存失敗，請稍後再試。");
+    } finally {
+      setSaving(false);
+    }
   }
 
-  function handleLimitSave(e) {
-    e.preventDefault();
-    if (!selectedVendorId) return;
-    setLimitLoading(true);
-    setLimitError(null);
-    setLimitSuccess(false);
-    setVendorRecommendationLimit(Number(selectedVendorId), Number(recommendationLimit))
-      .then((data) => {
-        setRecommendationLimit(data.daily_recommendation_limit);
-        setLimitSuccess(true);
+  return (
+    <div
+      style={{
+        gridColumn: "1 / -1",
+        padding: "14px 20px 16px",
+        borderTop: "1px dashed var(--line)",
+        background: "rgba(47,100,200,0.03)",
+      }}
+    >
+      {loading && <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>載入中…</p>}
+
+      {!loading && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          {/* Facility checkboxes */}
+          <div>
+            <p style={{ margin: "0 0 8px", fontSize: 13, fontWeight: 600, color: "#2b5cc8" }}>
+              服務廠區（可多選；空選表示不限廠區）
+            </p>
+            {allFacilities.length === 0 ? (
+              <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>
+                尚無廠區可指派，請先在廠區面板新增。
+              </p>
+            ) : (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "8px 24px" }}>
+                {allFacilities.map((f) => (
+                  <label
+                    key={f.id}
+                    style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", fontSize: 13 }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checkedIds.has(f.id)}
+                      onChange={() => toggleFacility(f.id)}
+                    />
+                    <span>{f.code}　{f.name}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Recommendation limit */}
+          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            <span style={{ fontSize: 13, fontWeight: 600 }}>今日推薦上限：</span>
+            <select
+              value={recommendationLimit}
+              onChange={(e) => { setRecommendationLimit(Number(e.target.value)); setSuccess(false); }}
+              style={{
+                padding: "5px 10px",
+                borderRadius: "var(--radius-md)",
+                border: "1px solid var(--line)",
+                background: "var(--surface-strong)",
+                fontSize: 13,
+                cursor: "pointer",
+              }}
+            >
+              <option value={1}>每天最多 1 道</option>
+              <option value={2}>每天最多 2 道</option>
+              <option value={3}>每天最多 3 道</option>
+            </select>
+          </div>
+
+          {/* Actions */}
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <button type="button" onClick={handleSave} disabled={saving} style={inlineBtnStyle("save")}>
+              {saving ? "儲存中…" : "儲存"}
+            </button>
+            <button type="button" onClick={onClose} style={inlineBtnStyle()}>
+              關閉
+            </button>
+            {success && (
+              <span style={{ fontSize: 13, color: "var(--success)", fontWeight: 600 }}>✓ 已儲存</span>
+            )}
+            {error && (
+              <span style={{ fontSize: 13, color: "var(--brand)" }}>{error}</span>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VendorFacilitiesPanel() {
+  const [vendors, setVendors]                   = useState([]);
+  const [allFacilities, setAllFacilities]       = useState([]);
+  const [facilityMap, setFacilityMap]           = useState({});  // vendor_id -> Facility[]
+  const [loading, setLoading]                   = useState(true);
+  const [error, setError]                       = useState(null);
+  const [expandedVendorId, setExpandedVendorId] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    Promise.all([getVendorApplications("approved"), getFacilities()])
+      .then(([vendorData, facilityData]) => {
+        if (!active) return;
+        setVendors(vendorData);
+        setAllFacilities(facilityData);
+        // Progressively load each vendor's facility assignments
+        vendorData.forEach((v) => {
+          getVendorFacilities(v.vendor_id)
+            .then((facs) => {
+              if (active) setFacilityMap((prev) => ({ ...prev, [v.vendor_id]: facs }));
+            })
+            .catch(() => {});
+        });
       })
-      .catch(() => setLimitError("儲存今日推薦上限失敗"))
-      .finally(() => setLimitLoading(false));
+      .catch(() => { if (active) setError("無法載入資料"); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, []);
+
+  function toggleExpand(vendorId) {
+    setExpandedVendorId((prev) => (prev === vendorId ? null : vendorId));
   }
 
-  const isLoading = vendorsLoading || facLoading;
-  const hasError = vendorsError || facError;
+  function refreshVendorFacilities(vendorId) {
+    getVendorFacilities(vendorId)
+      .then((facs) => setFacilityMap((prev) => ({ ...prev, [vendorId]: facs })))
+      .catch(() => {});
+  }
 
   return (
     <article className="panel">
       <p className="eyebrow">廠區管理</p>
       <h2>商家服務廠區</h2>
 
-      {isLoading && <p className="panel-copy">載入中…</p>}
-      {hasError && <p className="error-state">{vendorsError ?? facError}</p>}
+      {loading && <p className="panel-copy">載入中…</p>}
+      {error && <p className="error-state">{error}</p>}
 
-      {!isLoading && !hasError && (
-        <>
-          <label style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 16 }}>
-            <span style={{ fontSize: "0.8rem" }}>選擇商家（已核准）</span>
-            <select
-              className="form-input"
-              value={selectedVendorId}
-              onChange={(e) => setSelectedVendorId(e.target.value)}
-              style={{ maxWidth: 280 }}
-            >
-              <option value="">— 請選擇 —</option>
-              {vendors.map((v) => (
-                <option key={v.vendor_id} value={v.vendor_id}>
-                  {v.vendor_name}
-                </option>
-              ))}
-            </select>
-          </label>
+      {!loading && !error && vendors.length === 0 && (
+        <p className="panel-copy">目前沒有已核准的商家。</p>
+      )}
 
-          {selectedVendorId && (
-            <>
-            <form onSubmit={handleLimitSave} style={{ marginBottom: 18 }}>
-              <label style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 10, maxWidth: 280 }}>
-                <span style={{ fontSize: "0.8rem" }}>今日推薦上限</span>
-                <select
-                  className="form-input"
-                  value={recommendationLimit}
-                  onChange={(e) => {
-                    setRecommendationLimit(Number(e.target.value));
-                    setLimitSuccess(false);
-                  }}
-                  disabled={limitLoading}
-                >
-                  <option value={1}>每天最多 1 道</option>
-                  <option value={2}>每天最多 2 道</option>
-                  <option value={3}>每天最多 3 道</option>
-                </select>
-              </label>
-              <button
-                type="submit"
-                className="range-pill is-active"
-                disabled={limitLoading}
+      {!loading && !error && vendors.length > 0 && (
+        <div
+          style={{
+            border: "1px solid var(--line)",
+            borderRadius: "var(--radius-md)",
+            overflow: "hidden",
+            marginTop: 12,
+          }}
+        >
+          {/* Header */}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: VENDOR_GRID,
+              padding: "8px 16px",
+              background: "var(--surface-strong)",
+              borderBottom: "1px solid var(--line)",
+              fontSize: 12,
+              fontWeight: 600,
+              color: "var(--muted)",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+            }}
+          >
+            <span>商家名稱</span>
+            <span>服務廠區</span>
+            <span style={{ textAlign: "right" }}>操作</span>
+          </div>
+
+          {vendors.map((v, idx) => {
+            const isExpanded   = expandedVendorId === v.vendor_id;
+            const isLast       = idx === vendors.length - 1;
+            const vFacilities  = facilityMap[v.vendor_id];   // undefined = still loading
+
+            return (
+              <div
+                key={v.vendor_id}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: VENDOR_GRID,
+                  borderBottom: (!isLast || isExpanded) ? "1px solid var(--line)" : "none",
+                  alignItems: "center",
+                }}
               >
-                儲存推薦上限
-              </button>
-              {limitError && <p className="error-state" style={{ marginTop: 8 }}>{limitError}</p>}
-              {limitSuccess && <p className="panel-copy" style={{ marginTop: 8, color: "var(--accent)" }}>已儲存推薦上限</p>}
-            </form>
+                {/* Vendor name */}
+                <div style={{ padding: "12px 16px", fontSize: 14, fontWeight: 500 }}>
+                  {v.vendor_name}
+                </div>
 
-            <form onSubmit={handleSave}>
-              {assignLoading && <p className="panel-copy">載入中…</p>}
-              {!assignLoading && (
-                <>
-                  {allFacilities.length === 0 ? (
-                    <p className="panel-copy">尚無廠區可指派，請先在上方新增廠區。</p>
+                {/* Facility chips */}
+                <div style={{ padding: "12px 8px", fontSize: 13 }}>
+                  {vFacilities === undefined ? (
+                    <span style={{ color: "var(--muted)", fontSize: 12 }}>…</span>
+                  ) : vFacilities.length === 0 ? (
+                    <span style={{ color: "var(--muted)", fontSize: 12 }}>不限廠區</span>
                   ) : (
-                    <fieldset style={{ border: "none", padding: 0, marginBottom: 12 }}>
-                      <legend style={{ fontSize: "0.85rem", marginBottom: 8 }}>服務廠區（可多選）</legend>
-                      <div style={{ display: "flex", flexWrap: "wrap", gap: "8px 20px" }}>
-                        {allFacilities.map((f) => (
-                          <label key={f.id} style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
-                            <input
-                              type="checkbox"
-                              checked={checkedIds.has(f.id)}
-                              onChange={() => toggleFacility(f.id)}
-                            />
-                            <span>{f.code}　{f.name}</span>
-                          </label>
-                        ))}
-                      </div>
-                    </fieldset>
+                    <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+                      {vFacilities.map((f) => (
+                        <span
+                          key={f.id}
+                          style={{
+                            padding: "2px 9px",
+                            borderRadius: 99,
+                            fontSize: 12,
+                            fontWeight: 600,
+                            background: "rgba(47,100,200,0.10)",
+                            color: "#2b5cc8",
+                          }}
+                        >
+                          {f.code}
+                        </span>
+                      ))}
+                    </div>
                   )}
+                </div>
+
+                {/* Action */}
+                <div style={{ padding: "12px 16px", textAlign: "right" }}>
                   <button
-                    type="submit"
-                    className="range-pill is-active"
-                    disabled={assignLoading}
+                    type="button"
+                    onClick={() => toggleExpand(v.vendor_id)}
+                    style={inlineBtnStyle(isExpanded ? "default" : "config")}
                   >
-                    儲存
+                    {isExpanded ? "收起" : "設定"}
                   </button>
-                </>
-              )}
-              {assignError && <p className="error-state" style={{ marginTop: 8 }}>{assignError}</p>}
-              {saveSuccess && <p className="panel-copy" style={{ marginTop: 8, color: "var(--accent)" }}>已儲存。</p>}
-            </form>
-            </>
-          )}
-        </>
+                </div>
+
+                {/* Inline editor */}
+                {isExpanded && (
+                  <VendorFacilityEditor
+                    vendorId={v.vendor_id}
+                    allFacilities={allFacilities}
+                    onClose={() => setExpandedVendorId(null)}
+                    onSaved={() => refreshVendorFacilities(v.vendor_id)}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
       )}
     </article>
   );

--- a/frontend/src/pages/admin/AdminFacilitiesPage.jsx
+++ b/frontend/src/pages/admin/AdminFacilitiesPage.jsx
@@ -2,13 +2,10 @@ import { useEffect, useState } from "react";
 
 import {
   createFacility,
-  getEmployeeFacilities,
   getFacilities,
-  getUsers,
   getVendorApplications,
   getVendorFacilities,
   getVendorRecommendationLimit,
-  setEmployeeFacilities,
   setVendorFacilities,
   setVendorRecommendationLimit,
 } from "../../api/admin";
@@ -442,170 +439,13 @@ function VendorFacilitiesPanel() {
   );
 }
 
-// ── Panel C: 員工廠區指派 ─────────────────────────────────────────────────────
-
-function EmployeeFacilitiesPanel() {
-  const [employees, setEmployees] = useState([]);
-  const [empLoading, setEmpLoading] = useState(true);
-  const [empError, setEmpError] = useState(null);
-
-  const [allFacilities, setAllFacilities] = useState([]);
-  const [facLoading, setFacLoading] = useState(true);
-  const [facError, setFacError] = useState(null);
-
-  const [selectedEmployeeId, setSelectedEmployeeId] = useState("");
-  const [checkedIds, setCheckedIds] = useState(new Set());
-  const [assignLoading, setAssignLoading] = useState(false);
-  const [assignError, setAssignError] = useState(null);
-  const [saveSuccess, setSaveSuccess] = useState(false);
-
-  // Load active employees
-  useEffect(() => {
-    let active = true;
-    setEmpLoading(true);
-    setEmpError(null);
-    getUsers({ role: "employee", is_active: true })
-      .then((data) => { if (active) setEmployees(data.users ?? []); })
-      .catch(() => { if (active) setEmpError("無法載入員工清單。"); })
-      .finally(() => { if (active) setEmpLoading(false); });
-    return () => { active = false; };
-  }, []);
-
-  // Load all facilities
-  useEffect(() => {
-    let active = true;
-    setFacLoading(true);
-    setFacError(null);
-    getFacilities()
-      .then((data) => { if (active) setAllFacilities(data); })
-      .catch(() => { if (active) setFacError("無法載入廠區清單。"); })
-      .finally(() => { if (active) setFacLoading(false); });
-    return () => { active = false; };
-  }, []);
-
-  // When employee changes, fetch current facility assignments
-  useEffect(() => {
-    if (!selectedEmployeeId) {
-      setCheckedIds(new Set());
-      return;
-    }
-    let active = true;
-    setAssignLoading(true);
-    setAssignError(null);
-    setSaveSuccess(false);
-    getEmployeeFacilities(Number(selectedEmployeeId))
-      .then((data) => { if (active) setCheckedIds(new Set(data.map((f) => f.id))); })
-      .catch(() => { if (active) setAssignError("無法載入員工已指派廠區。"); })
-      .finally(() => { if (active) setAssignLoading(false); });
-    return () => { active = false; };
-  }, [selectedEmployeeId]);
-
-  function toggleFacility(id) {
-    setCheckedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-    setSaveSuccess(false);
-  }
-
-  function handleSave(e) {
-    e.preventDefault();
-    if (!selectedEmployeeId) return;
-    setAssignLoading(true);
-    setAssignError(null);
-    setSaveSuccess(false);
-    setEmployeeFacilities(Number(selectedEmployeeId), Array.from(checkedIds))
-      .then(() => setSaveSuccess(true))
-      .catch(() => setAssignError("儲存失敗，請稍後再試。"))
-      .finally(() => setAssignLoading(false));
-  }
-
-  const isLoading = empLoading || facLoading;
-  const hasError = empError || facError;
-
-  return (
-    <article className="panel">
-      <p className="eyebrow">廠區管理</p>
-      <h2>員工所屬廠區</h2>
-
-      {isLoading && <p className="panel-copy">載入中…</p>}
-      {hasError && <p className="error-state">{empError ?? facError}</p>}
-
-      {!isLoading && !hasError && (
-        <>
-          <label style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 16 }}>
-            <span style={{ fontSize: "0.8rem" }}>選擇員工（已啟用）</span>
-            <select
-              className="form-input"
-              value={selectedEmployeeId}
-              onChange={(e) => setSelectedEmployeeId(e.target.value)}
-              style={{ maxWidth: 320 }}
-            >
-              <option value="">— 請選擇 —</option>
-              {employees.map((emp) => (
-                <option key={emp.id} value={emp.id}>
-                  {emp.display_name}
-                  {emp.badge_code ? `（${emp.badge_code}）` : ""}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          {selectedEmployeeId && (
-            <form onSubmit={handleSave}>
-              {assignLoading && <p className="panel-copy">載入中…</p>}
-              {!assignLoading && (
-                <>
-                  {allFacilities.length === 0 ? (
-                    <p className="panel-copy">尚無廠區可指派，請先在上方新增廠區。</p>
-                  ) : (
-                    <fieldset style={{ border: "none", padding: 0, marginBottom: 12 }}>
-                      <legend style={{ fontSize: "0.85rem", marginBottom: 8 }}>
-                        所屬廠區（可多選；空選表示不限廠區）
-                      </legend>
-                      <div style={{ display: "flex", flexWrap: "wrap", gap: "8px 20px" }}>
-                        {allFacilities.map((f) => (
-                          <label key={f.id} style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer" }}>
-                            <input
-                              type="checkbox"
-                              checked={checkedIds.has(f.id)}
-                              onChange={() => toggleFacility(f.id)}
-                            />
-                            <span>{f.code}　{f.name}</span>
-                          </label>
-                        ))}
-                      </div>
-                    </fieldset>
-                  )}
-                  <button
-                    type="submit"
-                    className="range-pill is-active"
-                    disabled={assignLoading}
-                  >
-                    儲存
-                  </button>
-                </>
-              )}
-              {assignError && <p className="error-state" style={{ marginTop: 8 }}>{assignError}</p>}
-              {saveSuccess && <p className="panel-copy" style={{ marginTop: 8, color: "var(--accent)" }}>已儲存。</p>}
-            </form>
-          )}
-        </>
-      )}
-    </article>
-  );
-}
-
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export default function AdminFacilitiesPage() {
   return (
-    <section className="dashboard-grid">
+    <div style={{ display: "grid", gridTemplateColumns: "minmax(280px, 340px) 1fr", gap: 18, alignItems: "start" }}>
       <FacilitiesPanel />
       <VendorFacilitiesPanel />
-      <EmployeeFacilitiesPanel />
-    </section>
+    </div>
   );
 }

--- a/frontend/src/pages/admin/AdminPermissionsPage.jsx
+++ b/frontend/src/pages/admin/AdminPermissionsPage.jsx
@@ -61,7 +61,7 @@ function formatDate(iso) {
 // ── Inline facility editor (employee-only) ────────────────────────────────────
 
 function FacilityEditor({ employeeId, allFacilities, onClose }) {
-  const [checkedIds, setCheckedIds] = useState(new Set());
+  const [selectedId, setSelectedId] = useState("");   // "" = 不限廠區
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
@@ -72,27 +72,18 @@ function FacilityEditor({ employeeId, allFacilities, onClose }) {
     setError(null);
     setSuccess(false);
     getEmployeeFacilities(employeeId)
-      .then((data) => { if (active) setCheckedIds(new Set(data.map((f) => f.id))); })
+      .then((data) => { if (active) setSelectedId(data[0]?.id ?? ""); })
       .catch(() => { if (active) setError("無法載入廠區指派"); })
       .finally(() => { if (active) setLoading(false); });
     return () => { active = false; };
   }, [employeeId]);
-
-  function toggle(id) {
-    setCheckedIds((prev) => {
-      const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
-      return next;
-    });
-    setSuccess(false);
-  }
 
   async function handleSave() {
     setLoading(true);
     setError(null);
     setSuccess(false);
     try {
-      await setEmployeeFacilities(employeeId, Array.from(checkedIds));
+      await setEmployeeFacilities(employeeId, selectedId ? [Number(selectedId)] : []);
       setSuccess(true);
     } catch {
       setError("儲存失敗，請稍後再試");
@@ -110,51 +101,45 @@ function FacilityEditor({ employeeId, allFacilities, onClose }) {
         background: "rgba(47,100,200,0.03)",
       }}
     >
-      <p style={{ margin: "0 0 10px", fontSize: 13, fontWeight: 600, color: "#2b5cc8" }}>
-        指派廠區
-        <span style={{ marginLeft: 8, fontSize: 12, fontWeight: 400, color: "var(--muted)" }}>
-          （空選表示不限廠區）
-        </span>
-      </p>
+      <p style={{ margin: "0 0 10px", fontSize: 13, fontWeight: 600, color: "#2b5cc8" }}>指派廠區</p>
 
       {loading && <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>載入中…</p>}
 
-      {!loading && allFacilities.length === 0 && (
-        <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>尚未建立任何廠區。</p>
-      )}
-
-      {!loading && allFacilities.length > 0 && (
-        <>
-          <div style={{ display: "flex", flexWrap: "wrap", gap: "6px 20px", marginBottom: 12 }}>
+      {!loading && (
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <select
+            value={selectedId}
+            onChange={(e) => { setSelectedId(e.target.value); setSuccess(false); }}
+            style={{
+              padding: "6px 12px",
+              borderRadius: "var(--radius-md)",
+              border: "1px solid var(--line)",
+              background: "var(--surface-strong)",
+              fontSize: 13,
+              cursor: "pointer",
+              minWidth: 200,
+            }}
+          >
+            <option value="">— 不限廠區 —</option>
             {allFacilities.map((f) => (
-              <label
-                key={f.id}
-                style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", fontSize: 13 }}
-              >
-                <input
-                  type="checkbox"
-                  checked={checkedIds.has(f.id)}
-                  onChange={() => toggle(f.id)}
-                />
-                <span>{f.code}　{f.name}</span>
-              </label>
+              <option key={f.id} value={f.id}>
+                {f.code}　{f.name}
+              </option>
             ))}
-          </div>
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <button type="button" onClick={handleSave} disabled={loading} style={btnStyle("enable")}>
-              儲存
-            </button>
-            <button type="button" onClick={onClose} style={btnStyle("secondary")}>
-              關閉
-            </button>
-            {success && (
-              <span style={{ fontSize: 13, color: "var(--success)", fontWeight: 600 }}>✓ 已儲存</span>
-            )}
-            {error && (
-              <span style={{ fontSize: 13, color: "var(--brand)" }}>{error}</span>
-            )}
-          </div>
-        </>
+          </select>
+          <button type="button" onClick={handleSave} disabled={loading} style={btnStyle("enable")}>
+            儲存
+          </button>
+          <button type="button" onClick={onClose} style={btnStyle("secondary")}>
+            關閉
+          </button>
+          {success && (
+            <span style={{ fontSize: 13, color: "var(--success)", fontWeight: 600 }}>✓ 已儲存</span>
+          )}
+          {error && (
+            <span style={{ fontSize: 13, color: "var(--brand)" }}>{error}</span>
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/admin/AdminPermissionsPage.jsx
+++ b/frontend/src/pages/admin/AdminPermissionsPage.jsx
@@ -1,6 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "../../auth/AuthContext";
-import { deleteUser, disableUser, enableUser, getUsers } from "../../api/admin";
+import {
+  deleteUser,
+  disableUser,
+  enableUser,
+  getEmployeeFacilities,
+  getFacilities,
+  getUsers,
+  setEmployeeFacilities,
+} from "../../api/admin";
 
 const ROLES = ["", "admin", "employee", "vendor_manager", "committee_reviewer"];
 const ROLE_LABELS = {
@@ -10,7 +18,7 @@ const ROLE_LABELS = {
   vendor_manager: "Vendor Manager",
   committee_reviewer: "Committee Reviewer",
 };
-const USER_GRID_COLUMNS = "minmax(180px, 1fr) 120px 120px 110px 90px 120px 160px";
+const USER_GRID_COLUMNS = "minmax(180px, 1fr) 120px 120px 110px 90px 160px";
 
 function useUsers(search, role) {
   const [users, setUsers] = useState([]);
@@ -50,6 +58,110 @@ function formatDate(iso) {
   return new Date(iso).toLocaleDateString("zh-TW");
 }
 
+// ── Inline facility editor (employee-only) ────────────────────────────────────
+
+function FacilityEditor({ employeeId, allFacilities, onClose }) {
+  const [checkedIds, setCheckedIds] = useState(new Set());
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+    getEmployeeFacilities(employeeId)
+      .then((data) => { if (active) setCheckedIds(new Set(data.map((f) => f.id))); })
+      .catch(() => { if (active) setError("無法載入廠區指派"); })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [employeeId]);
+
+  function toggle(id) {
+    setCheckedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+    setSuccess(false);
+  }
+
+  async function handleSave() {
+    setLoading(true);
+    setError(null);
+    setSuccess(false);
+    try {
+      await setEmployeeFacilities(employeeId, Array.from(checkedIds));
+      setSuccess(true);
+    } catch {
+      setError("儲存失敗，請稍後再試");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        gridColumn: "1 / -1",
+        padding: "14px 20px 16px",
+        borderTop: "1px dashed var(--line)",
+        background: "rgba(47,100,200,0.03)",
+      }}
+    >
+      <p style={{ margin: "0 0 10px", fontSize: 13, fontWeight: 600, color: "#2b5cc8" }}>
+        指派廠區
+        <span style={{ marginLeft: 8, fontSize: 12, fontWeight: 400, color: "var(--muted)" }}>
+          （空選表示不限廠區）
+        </span>
+      </p>
+
+      {loading && <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>載入中…</p>}
+
+      {!loading && allFacilities.length === 0 && (
+        <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>尚未建立任何廠區。</p>
+      )}
+
+      {!loading && allFacilities.length > 0 && (
+        <>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "6px 20px", marginBottom: 12 }}>
+            {allFacilities.map((f) => (
+              <label
+                key={f.id}
+                style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", fontSize: 13 }}
+              >
+                <input
+                  type="checkbox"
+                  checked={checkedIds.has(f.id)}
+                  onChange={() => toggle(f.id)}
+                />
+                <span>{f.code}　{f.name}</span>
+              </label>
+            ))}
+          </div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <button type="button" onClick={handleSave} disabled={loading} style={btnStyle("enable")}>
+              儲存
+            </button>
+            <button type="button" onClick={onClose} style={btnStyle("secondary")}>
+              關閉
+            </button>
+            {success && (
+              <span style={{ fontSize: 13, color: "var(--success)", fontWeight: 600 }}>✓ 已儲存</span>
+            )}
+            {error && (
+              <span style={{ fontSize: 13, color: "var(--brand)" }}>{error}</span>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
 export default function AdminPermissionsPage() {
   const { user: self } = useAuth();
   const [search, setSearch] = useState("");
@@ -59,6 +171,14 @@ export default function AdminPermissionsPage() {
   const debounceRef = useRef(null);
 
   const { users, total, loading, error, setUsers } = useUsers(search, roleFilter);
+
+  // Facility state
+  const [allFacilities, setAllFacilities] = useState([]);
+  const [expandedEmpId, setExpandedEmpId] = useState(null);
+
+  useEffect(() => {
+    getFacilities().then(setAllFacilities).catch(() => {});
+  }, []);
 
   function handleSearchChange(e) {
     const val = e.target.value;
@@ -98,9 +218,14 @@ export default function AdminPermissionsPage() {
     try {
       await deleteUser(userId);
       setUsers((prev) => prev.filter((u) => u.id !== userId));
+      if (expandedEmpId === userId) setExpandedEmpId(null);
     } catch (err) {
       setActionError(err.message ?? "刪除失敗");
     }
+  }
+
+  function toggleExpand(empId) {
+    setExpandedEmpId((prev) => (prev === empId ? null : empId));
   }
 
   const isSelf = (userId) => self?.numericId === userId;
@@ -130,7 +255,7 @@ export default function AdminPermissionsPage() {
         />
         <select
           value={roleFilter}
-          onChange={(e) => setRoleFilter(e.target.value)}
+          onChange={(e) => { setRoleFilter(e.target.value); setExpandedEmpId(null); }}
           style={{
             padding: "8px 14px",
             borderRadius: "var(--radius-md)",
@@ -168,7 +293,7 @@ export default function AdminPermissionsPage() {
             style={{
               display: "grid",
               gridTemplateColumns: USER_GRID_COLUMNS,
-              minWidth: 900,
+              minWidth: 860,
               padding: "10px 20px",
               borderBottom: "1px solid var(--line)",
               color: "var(--muted)",
@@ -183,69 +308,81 @@ export default function AdminPermissionsPage() {
             <span style={{ textAlign: "center" }}>狀態</span>
             <span style={{ textAlign: "center" }}>建立日期</span>
             <span style={{ textAlign: "center" }}>Badge</span>
-            <span></span>
             <span style={{ textAlign: "right" }}>操作</span>
           </div>
 
-          {users.map((u, idx) => (
-            <div
-              key={u.id}
-              style={{
-                display: "grid",
-                gridTemplateColumns: USER_GRID_COLUMNS,
-                minWidth: 900,
-                alignItems: "center",
-                padding: "14px 20px",
-                borderBottom: idx < users.length - 1 ? "1px solid var(--line)" : "none",
-                opacity: u.is_active ? 1 : 0.55,
-              }}
-            >
-              <div>
-                <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>{u.display_name}</p>
-                <p style={{ margin: "2px 0 0", fontSize: 12, color: "var(--muted)" }}>{u.email}</p>
+          {users.map((u, idx) => {
+            const isExpanded = expandedEmpId === u.id;
+            const isLast = idx === users.length - 1;
+            return (
+              <div
+                key={u.id}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: USER_GRID_COLUMNS,
+                  minWidth: 860,
+                  alignItems: "center",
+                  borderBottom: (!isLast || isExpanded) ? "1px solid var(--line)" : "none",
+                  opacity: u.is_active ? 1 : 0.55,
+                }}
+              >
+                <div style={{ padding: "14px 0 14px 20px" }}>
+                  <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>{u.display_name}</p>
+                  <p style={{ margin: "2px 0 0", fontSize: 12, color: "var(--muted)" }}>{u.email}</p>
+                </div>
+                <p style={{ margin: 0, fontSize: 13, textAlign: "center" }}>{ROLE_LABELS[u.role] ?? u.role}</p>
+                <div style={{ textAlign: "center" }}>
+                  <StatusBadge isActive={u.is_active} />
+                </div>
+                <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
+                  {formatDate(u.created_at)}
+                </p>
+                <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
+                  {u.badge_code || "-"}
+                </p>
+                <div style={{ display: "flex", gap: 6, justifyContent: "flex-end", flexWrap: "wrap", padding: "14px 20px 14px 0" }}>
+                  {u.role === "employee" && (
+                    <button
+                      type="button"
+                      onClick={() => toggleExpand(u.id)}
+                      style={btnStyle(isExpanded ? "secondary" : "facility")}
+                    >
+                      {isExpanded ? "收起" : "指派廠區"}
+                    </button>
+                  )}
+                  {!isSelf(u.id) && u.is_active && (
+                    <button onClick={() => handleDisable(u.id, u.email)} style={btnStyle("secondary")}>
+                      停用
+                    </button>
+                  )}
+                  {!isSelf(u.id) && !u.is_active && (
+                    <button onClick={() => handleEnable(u.id)} style={btnStyle("enable")}>
+                      啟用
+                    </button>
+                  )}
+                  {isSelf(u.id) && (
+                    <span style={{ fontSize: 12, color: "var(--muted)", alignSelf: "center" }}>
+                      (自己)
+                    </span>
+                  )}
+                  {!isSelf(u.id) && (
+                    <button onClick={() => handleDelete(u.id, u.email)} style={btnStyle("danger")}>
+                      刪除
+                    </button>
+                  )}
+                </div>
+
+                {/* Inline facility editor — employee only */}
+                {isExpanded && (
+                  <FacilityEditor
+                    employeeId={u.id}
+                    allFacilities={allFacilities}
+                    onClose={() => setExpandedEmpId(null)}
+                  />
+                )}
               </div>
-              <p style={{ margin: 0, fontSize: 13, textAlign: "center" }}>{ROLE_LABELS[u.role] ?? u.role}</p>
-              <div style={{ textAlign: "center" }}>
-                <StatusBadge isActive={u.is_active} />
-              </div>
-              <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>{formatDate(u.created_at)}</p>
-              <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
-                {u.badge_code || "-"}
-              </p>
-              <div />
-              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-                {!isSelf(u.id) && u.is_active && (
-                  <button
-                    onClick={() => handleDisable(u.id, u.email)}
-                    style={btnStyle("secondary")}
-                  >
-                    停用
-                  </button>
-                )}
-                {!isSelf(u.id) && !u.is_active && (
-                  <button
-                    onClick={() => handleEnable(u.id)}
-                    style={btnStyle("enable")}
-                  >
-                    啟用
-                  </button>
-                )}
-                {isSelf(u.id) && (
-                  <span style={{ fontSize: 12, color: "var(--muted)", alignSelf: "center" }}>
-                    (自己)
-                  </span>
-                )}
-                {!isSelf(u.id) && (
-                  <button
-                    onClick={() => handleDelete(u.id, u.email)}
-                    style={btnStyle("danger")}
-                  >
-                    刪除
-                  </button>
-                )}
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>
@@ -266,6 +403,9 @@ function btnStyle(variant) {
   }
   if (variant === "enable") {
     return { ...base, background: "rgba(47,125,74,0.12)", color: "var(--success)" };
+  }
+  if (variant === "facility") {
+    return { ...base, background: "rgba(47,100,200,0.10)", color: "#2b5cc8" };
   }
   return { ...base, background: "var(--line)", color: "var(--text)" };
 }

--- a/frontend/src/pages/admin/AdminPermissionsPage.jsx
+++ b/frontend/src/pages/admin/AdminPermissionsPage.jsx
@@ -1,14 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useAuth } from "../../auth/AuthContext";
-import {
-  deleteUser,
-  disableUser,
-  enableUser,
-  getEmployeeFacilities,
-  getFacilities,
-  getUsers,
-  setEmployeeFacilities,
-} from "../../api/admin";
+import { deleteUser, disableUser, enableUser, getUsers } from "../../api/admin";
 
 const ROLES = ["", "admin", "employee", "vendor_manager", "committee_reviewer"];
 const ROLE_LABELS = {
@@ -18,7 +10,7 @@ const ROLE_LABELS = {
   vendor_manager: "Vendor Manager",
   committee_reviewer: "Committee Reviewer",
 };
-const USER_GRID_COLUMNS = "minmax(180px, 1fr) 120px 120px 110px 90px 160px";
+const USER_GRID_COLUMNS = "minmax(180px, 1fr) 120px 120px 110px 90px 120px 160px";
 
 function useUsers(search, role) {
   const [users, setUsers] = useState([]);
@@ -58,95 +50,6 @@ function formatDate(iso) {
   return new Date(iso).toLocaleDateString("zh-TW");
 }
 
-// ── Inline facility editor (employee-only) ────────────────────────────────────
-
-function FacilityEditor({ employeeId, allFacilities, onClose }) {
-  const [selectedId, setSelectedId] = useState("");   // "" = 不限廠區
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [success, setSuccess] = useState(false);
-
-  useEffect(() => {
-    let active = true;
-    setLoading(true);
-    setError(null);
-    setSuccess(false);
-    getEmployeeFacilities(employeeId)
-      .then((data) => { if (active) setSelectedId(data[0]?.id ?? ""); })
-      .catch(() => { if (active) setError("無法載入廠區指派"); })
-      .finally(() => { if (active) setLoading(false); });
-    return () => { active = false; };
-  }, [employeeId]);
-
-  async function handleSave() {
-    setLoading(true);
-    setError(null);
-    setSuccess(false);
-    try {
-      await setEmployeeFacilities(employeeId, selectedId ? [Number(selectedId)] : []);
-      setSuccess(true);
-    } catch {
-      setError("儲存失敗，請稍後再試");
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  return (
-    <div
-      style={{
-        gridColumn: "1 / -1",
-        padding: "14px 20px 16px",
-        borderTop: "1px dashed var(--line)",
-        background: "rgba(47,100,200,0.03)",
-      }}
-    >
-      <p style={{ margin: "0 0 10px", fontSize: 13, fontWeight: 600, color: "#2b5cc8" }}>指派廠區</p>
-
-      {loading && <p style={{ margin: 0, fontSize: 13, color: "var(--muted)" }}>載入中…</p>}
-
-      {!loading && (
-        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
-          <select
-            value={selectedId}
-            onChange={(e) => { setSelectedId(e.target.value); setSuccess(false); }}
-            style={{
-              padding: "6px 12px",
-              borderRadius: "var(--radius-md)",
-              border: "1px solid var(--line)",
-              background: "var(--surface-strong)",
-              fontSize: 13,
-              cursor: "pointer",
-              minWidth: 200,
-            }}
-          >
-            <option value="">— 不限廠區 —</option>
-            {allFacilities.map((f) => (
-              <option key={f.id} value={f.id}>
-                {f.code}　{f.name}
-              </option>
-            ))}
-          </select>
-          <button type="button" onClick={handleSave} disabled={loading} style={btnStyle("enable")}>
-            儲存
-          </button>
-          <button type="button" onClick={onClose} style={btnStyle("secondary")}>
-            關閉
-          </button>
-          {success && (
-            <span style={{ fontSize: 13, color: "var(--success)", fontWeight: 600 }}>✓ 已儲存</span>
-          )}
-          {error && (
-            <span style={{ fontSize: 13, color: "var(--brand)" }}>{error}</span>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ── Page ─────────────────────────────────────────────────────────────────────
-
 export default function AdminPermissionsPage() {
   const { user: self } = useAuth();
   const [search, setSearch] = useState("");
@@ -156,14 +59,6 @@ export default function AdminPermissionsPage() {
   const debounceRef = useRef(null);
 
   const { users, total, loading, error, setUsers } = useUsers(search, roleFilter);
-
-  // Facility state
-  const [allFacilities, setAllFacilities] = useState([]);
-  const [expandedEmpId, setExpandedEmpId] = useState(null);
-
-  useEffect(() => {
-    getFacilities().then(setAllFacilities).catch(() => {});
-  }, []);
 
   function handleSearchChange(e) {
     const val = e.target.value;
@@ -203,14 +98,9 @@ export default function AdminPermissionsPage() {
     try {
       await deleteUser(userId);
       setUsers((prev) => prev.filter((u) => u.id !== userId));
-      if (expandedEmpId === userId) setExpandedEmpId(null);
     } catch (err) {
       setActionError(err.message ?? "刪除失敗");
     }
-  }
-
-  function toggleExpand(empId) {
-    setExpandedEmpId((prev) => (prev === empId ? null : empId));
   }
 
   const isSelf = (userId) => self?.numericId === userId;
@@ -240,7 +130,7 @@ export default function AdminPermissionsPage() {
         />
         <select
           value={roleFilter}
-          onChange={(e) => { setRoleFilter(e.target.value); setExpandedEmpId(null); }}
+          onChange={(e) => setRoleFilter(e.target.value)}
           style={{
             padding: "8px 14px",
             borderRadius: "var(--radius-md)",
@@ -278,7 +168,7 @@ export default function AdminPermissionsPage() {
             style={{
               display: "grid",
               gridTemplateColumns: USER_GRID_COLUMNS,
-              minWidth: 860,
+              minWidth: 900,
               padding: "10px 20px",
               borderBottom: "1px solid var(--line)",
               color: "var(--muted)",
@@ -293,81 +183,60 @@ export default function AdminPermissionsPage() {
             <span style={{ textAlign: "center" }}>狀態</span>
             <span style={{ textAlign: "center" }}>建立日期</span>
             <span style={{ textAlign: "center" }}>Badge</span>
+            <span></span>
             <span style={{ textAlign: "right" }}>操作</span>
           </div>
 
-          {users.map((u, idx) => {
-            const isExpanded = expandedEmpId === u.id;
-            const isLast = idx === users.length - 1;
-            return (
-              <div
-                key={u.id}
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: USER_GRID_COLUMNS,
-                  minWidth: 860,
-                  alignItems: "center",
-                  borderBottom: (!isLast || isExpanded) ? "1px solid var(--line)" : "none",
-                  opacity: u.is_active ? 1 : 0.55,
-                }}
-              >
-                <div style={{ padding: "14px 0 14px 20px" }}>
-                  <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>{u.display_name}</p>
-                  <p style={{ margin: "2px 0 0", fontSize: 12, color: "var(--muted)" }}>{u.email}</p>
-                </div>
-                <p style={{ margin: 0, fontSize: 13, textAlign: "center" }}>{ROLE_LABELS[u.role] ?? u.role}</p>
-                <div style={{ textAlign: "center" }}>
-                  <StatusBadge isActive={u.is_active} />
-                </div>
-                <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
-                  {formatDate(u.created_at)}
-                </p>
-                <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
-                  {u.badge_code || "-"}
-                </p>
-                <div style={{ display: "flex", gap: 6, justifyContent: "flex-end", flexWrap: "wrap", padding: "14px 20px 14px 0" }}>
-                  {u.role === "employee" && (
-                    <button
-                      type="button"
-                      onClick={() => toggleExpand(u.id)}
-                      style={btnStyle(isExpanded ? "secondary" : "facility")}
-                    >
-                      {isExpanded ? "收起" : "指派廠區"}
-                    </button>
-                  )}
-                  {!isSelf(u.id) && u.is_active && (
-                    <button onClick={() => handleDisable(u.id, u.email)} style={btnStyle("secondary")}>
-                      停用
-                    </button>
-                  )}
-                  {!isSelf(u.id) && !u.is_active && (
-                    <button onClick={() => handleEnable(u.id)} style={btnStyle("enable")}>
-                      啟用
-                    </button>
-                  )}
-                  {isSelf(u.id) && (
-                    <span style={{ fontSize: 12, color: "var(--muted)", alignSelf: "center" }}>
-                      (自己)
-                    </span>
-                  )}
-                  {!isSelf(u.id) && (
-                    <button onClick={() => handleDelete(u.id, u.email)} style={btnStyle("danger")}>
-                      刪除
-                    </button>
-                  )}
-                </div>
-
-                {/* Inline facility editor — employee only */}
-                {isExpanded && (
-                  <FacilityEditor
-                    employeeId={u.id}
-                    allFacilities={allFacilities}
-                    onClose={() => setExpandedEmpId(null)}
-                  />
+          {users.map((u, idx) => (
+            <div
+              key={u.id}
+              style={{
+                display: "grid",
+                gridTemplateColumns: USER_GRID_COLUMNS,
+                minWidth: 900,
+                alignItems: "center",
+                padding: "14px 20px",
+                borderBottom: idx < users.length - 1 ? "1px solid var(--line)" : "none",
+                opacity: u.is_active ? 1 : 0.55,
+              }}
+            >
+              <div>
+                <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>{u.display_name}</p>
+                <p style={{ margin: "2px 0 0", fontSize: 12, color: "var(--muted)" }}>{u.email}</p>
+              </div>
+              <p style={{ margin: 0, fontSize: 13, textAlign: "center" }}>{ROLE_LABELS[u.role] ?? u.role}</p>
+              <div style={{ textAlign: "center" }}>
+                <StatusBadge isActive={u.is_active} />
+              </div>
+              <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>{formatDate(u.created_at)}</p>
+              <p style={{ margin: 0, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
+                {u.badge_code || "-"}
+              </p>
+              <div />
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+                {!isSelf(u.id) && u.is_active && (
+                  <button onClick={() => handleDisable(u.id, u.email)} style={btnStyle("secondary")}>
+                    停用
+                  </button>
+                )}
+                {!isSelf(u.id) && !u.is_active && (
+                  <button onClick={() => handleEnable(u.id)} style={btnStyle("enable")}>
+                    啟用
+                  </button>
+                )}
+                {isSelf(u.id) && (
+                  <span style={{ fontSize: 12, color: "var(--muted)", alignSelf: "center" }}>
+                    (自己)
+                  </span>
+                )}
+                {!isSelf(u.id) && (
+                  <button onClick={() => handleDelete(u.id, u.email)} style={btnStyle("danger")}>
+                    刪除
+                  </button>
                 )}
               </div>
-            );
-          })}
+            </div>
+          ))}
         </div>
       )}
     </div>
@@ -388,9 +257,6 @@ function btnStyle(variant) {
   }
   if (variant === "enable") {
     return { ...base, background: "rgba(47,125,74,0.12)", color: "var(--success)" };
-  }
-  if (variant === "facility") {
-    return { ...base, background: "rgba(47,100,200,0.10)", color: "#2b5cc8" };
   }
   return { ...base, background: "var(--line)", color: "var(--text)" };
 }


### PR DESCRIPTION
## Changes

### Backend
- Add `GET /admin/employees/{id}/facilities` — fetch employee facility assignments
- Add `PUT /admin/employees/{id}/facilities` — update employee facility assignments (with audit log)
- Add `EmployeeFacilitiesUpdate` schema
- Implement employee facility methods in `InMemoryFacilityRepository`
- Implement employee facility methods in `PostgresFacilityRepository` via `employee_facilities` join table

### Frontend
- **AdminEmployeeReviewPage**: add inline expandable facility editor per employee row; supports multi-facility checkbox selection; empty selection means unrestricted
- **AdminFacilitiesPage**: redesign vendor facilities panel as a full overview table showing all vendors with their assigned facility chips; inline editor expands per row for facility assignment and daily recommendation limit; remove standalone employee facility panel (functionality moved to employee review page)
- **api/admin.js**: add `getEmployeeFacilities` / `setEmployeeFacilities`