### PR TITLE
feat(observability): per-request access log to Loki (skip /health & /metrics)

### DIFF
--- a/backend/core/observability.py
+++ b/backend/core/observability.py
@@ -31,6 +31,7 @@ import logging
 import logging.handlers
 import os
 import socket
+import time
 import uuid
 from contextvars import ContextVar
 from queue import Queue
@@ -45,6 +46,16 @@ from starlette.responses import Response
 _request_id_ctx: ContextVar[str] = ContextVar("request_id", default="-")
 
 _LOGGING_CONFIGURED = False
+
+# One compact access-log line per request flows to Loki via the root logger.
+# Without it the backend emits almost nothing at runtime (uvicorn's own access
+# logs use `uvicorn.access`, which does not propagate to root), so Grafana
+# Explore stays empty. See issue #183.
+_access_logger = logging.getLogger("backend.request")
+
+# Scrape/health endpoints are hit every 15-30s per replica; logging them would
+# bury real traffic and bloat Loki. Excluded from the per-request access log.
+_ACCESS_LOG_SKIP_PATHS = frozenset({"/health", "/metrics"})
 
 # Container hostname (Docker sets it to the container id). Resolved once at
 # import. Exposed per-response as `X-Served-By` so that when the backend runs
@@ -137,13 +148,38 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
         incoming = request.headers.get("x-request-id")
         request_id = incoming if incoming else uuid.uuid4().hex
         token = _request_id_ctx.set(request_id)
+        start = time.perf_counter()
         try:
             response = await call_next(request)
+            # Emit inside the context so RequestIDFilter tags the line with this
+            # request's id. Skip scrape/health noise.
+            if request.url.path not in _ACCESS_LOG_SKIP_PATHS:
+                self._log_access(request, response.status_code, start)
         finally:
             _request_id_ctx.reset(token)
         response.headers["X-Request-ID"] = request_id
         response.headers["X-Served-By"] = _SERVED_BY
         return response
+
+    @staticmethod
+    def _log_access(request: Request, status_code: int, start: float) -> None:
+        """One compact JSON access line per request (fields in body, not labels)."""
+        if status_code >= 500:
+            level = logging.ERROR
+        elif status_code >= 400:
+            level = logging.WARNING
+        else:
+            level = logging.INFO
+        _access_logger.log(
+            level,
+            "request",
+            extra={
+                "method": request.method,
+                "path": request.url.path,
+                "status_code": status_code,
+                "duration_ms": round((time.perf_counter() - start) * 1000, 2),
+            },
+        )
 
 
 def _build_loki_handler(

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -145,6 +145,22 @@ def test_middleware_access_log_warns_on_4xx() -> None:
     assert cap.records[0].levelno == logging.WARNING
 
 
+def test_middleware_access_log_errors_on_5xx() -> None:
+    from starlette.responses import Response as StarletteResponse
+
+    cap, lg = _capture_access_logs()
+    _add_temp_route("/_obs_test/boom", lambda: StarletteResponse(status_code=503))
+    try:
+        TestClient(app).get("/_obs_test/boom")
+    finally:
+        _drop_temp_route("/_obs_test/boom")
+        lg.removeHandler(cap)
+
+    assert len(cap.records) == 1
+    assert cap.records[0].status_code == 503
+    assert cap.records[0].levelno == logging.ERROR
+
+
 # ---------------------------------------------------------------------------
 # JsonFormatter
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -66,6 +66,86 @@ def test_middleware_unique_per_request() -> None:
 
 
 # ---------------------------------------------------------------------------
+# RequestIDMiddleware — per-request access logging (issue #183)
+# ---------------------------------------------------------------------------
+class _CaptureHandler(logging.Handler):
+    """Collect records emitted to the access logger, independent of root state."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _capture_access_logs():
+    """Attach a capture handler to the 'backend.request' access logger."""
+    cap = _CaptureHandler()
+    lg = logging.getLogger("backend.request")
+    lg.addHandler(cap)
+    lg.setLevel(logging.INFO)
+    return cap, lg
+
+
+def _add_temp_route(path: str, fn) -> None:
+    from fastapi import APIRouter
+
+    router = APIRouter()
+    router.get(path)(fn)
+    app.include_router(router)
+
+
+def _drop_temp_route(path: str) -> None:
+    app.router.routes = [
+        r for r in app.router.routes if getattr(r, "path", "") != path
+    ]
+
+
+def test_middleware_emits_one_access_log_per_request() -> None:
+    cap, lg = _capture_access_logs()
+    _add_temp_route("/_obs_test/ping", lambda: {"ok": "1"})
+    try:
+        TestClient(app).get("/_obs_test/ping")
+    finally:
+        _drop_temp_route("/_obs_test/ping")
+        lg.removeHandler(cap)
+
+    assert len(cap.records) == 1, "expected exactly one access log line per request"
+    rec = cap.records[0]
+    assert rec.method == "GET"
+    assert rec.path == "/_obs_test/ping"
+    assert rec.status_code == 200
+    assert isinstance(rec.duration_ms, (int, float))
+    assert rec.duration_ms >= 0
+    assert rec.levelno == logging.INFO
+
+
+def test_middleware_skips_health_and_metrics() -> None:
+    cap, lg = _capture_access_logs()
+    try:
+        client = TestClient(app)
+        client.get("/health")
+        client.get("/metrics")
+    finally:
+        lg.removeHandler(cap)
+
+    assert cap.records == [], "/health and /metrics must not produce access logs"
+
+
+def test_middleware_access_log_warns_on_4xx() -> None:
+    cap, lg = _capture_access_logs()
+    try:
+        TestClient(app).get("/_obs_test/no-such-route-xyz")
+    finally:
+        lg.removeHandler(cap)
+
+    assert len(cap.records) == 1
+    assert cap.records[0].status_code == 404
+    assert cap.records[0].levelno == logging.WARNING
+
+
+# ---------------------------------------------------------------------------
 # JsonFormatter
 # ---------------------------------------------------------------------------
 def test_json_formatter_stable_field_shape() -> None:


### PR DESCRIPTION
Closes #183

## What

Add one compact structured access-log line per request in `RequestIDMiddleware`, so the backend produces a continuous runtime log stream in Loki (Grafana Explore was empty because the backend previously only logged at startup; uvicorn's `uvicorn.access` logs do not propagate to the root logger).

- Emitted via a dedicated `backend.request` logger through the root handlers (stdout JSON + Loki).
- Fields in the JSON **body** (not Loki labels, to avoid cardinality blowup): `method`, `path`, `status_code`, `duration_ms`. `request_id` is injected by the existing `RequestIDFilter`.
- Level reflects status: `INFO` for <400, `WARNING` for 4xx, `ERROR` for 5xx.
- `/health` and `/metrics` are **excluded** — they are scraped every 15-30s per replica and would drown real traffic and bloat Loki.

## Tests

- one access line per normal request, with the expected fields and `INFO` level
- `/health` and `/metrics` produce no access line
- 4xx logs at `WARNING`

Full suite: 413 passed, 58 skipped.