### PR TITLE
feat(vendor-ui): localize and refine vendor interface

### DIFF
--- a/frontend/src/layout/navigation.js
+++ b/frontend/src/layout/navigation.js
@@ -23,7 +23,7 @@ export const navigationByRole = {
   ],
   admin: [
     { label: "統計儀表板", to: "/admin/stats" },
-    { label: "員工審核", to: "/admin/employees" },
+    { label: "員工審核與廠區設定", to: "/admin/employees" },
     { label: "商家審核", to: "/admin/vendors" },
     { label: "廠區管理", to: "/admin/facilities" },
     { label: "權限管理", to: "/admin/permissions" },

--- a/frontend/src/layout/navigation.js
+++ b/frontend/src/layout/navigation.js
@@ -15,11 +15,11 @@ export const navigationByRole = {
     { label: "通知", to: "/notifications" },
   ],
   vendor_manager: [
-    { label: "Dashboard", to: "/vendor" },
-    { label: "Menu Management", to: "/vendor/menu" },
-    { label: "Orders", to: "/vendor/orders" },
-    { label: "Badge Pickup", to: "/vendor/pickup" },
-    { label: "Revenue", to: "/vendor/revenue" },
+    { label: "首頁", to: "/vendor" },
+    { label: "菜單管理", to: "/vendor/menu" },
+    { label: "訂單管理", to: "/vendor/orders" },
+    { label: "取餐管理", to: "/vendor/pickup" },
+    { label: "營收報表", to: "/vendor/revenue" },
   ],
   admin: [
     { label: "統計儀表板", to: "/admin/stats" },

--- a/frontend/src/pages/vendor/VendorBadgePickupPage.jsx
+++ b/frontend/src/pages/vendor/VendorBadgePickupPage.jsx
@@ -248,84 +248,131 @@ export function VendorBadgePickupPage() {
         </div>
       </div>
 
-      <form onSubmit={handleLookup} style={{ display: "flex", gap: "0.75rem", alignItems: "flex-end", flexWrap: "wrap" }}>
-        <label className="field" style={{ flex: "1 1 220px" }}>
-          <span>員工編號</span>
+      <form onSubmit={handleLookup} style={{ display: "grid", gap: "1rem", marginTop: 24 }}>
+        <div className="search-bar" style={{ margin: 0 }}>
+          <span className="search-icon" aria-hidden="true">🏷️</span>
           <input
             autoFocus
+            className="search-input"
             onChange={(e) => setInput(e.target.value)}
-            placeholder="例如 EMP-0001"
+            placeholder="輸入員工編號，例如 EMP-0001"
             type="text"
             value={input}
+            style={{ fontSize: "1.05rem", minHeight: 52 }}
           />
-        </label>
-        <button className="button-primary" disabled={loading || !input.trim()} type="submit">
-          {loading ? "查詢中..." : "查詢"}
-        </button>
-        {scanning ? (
-          <button className="button-secondary" onClick={stopScan} type="button">
-            停止掃描
+        </div>
+        <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+          <button
+            className="primary-button"
+            disabled={loading || !input.trim()}
+            type="submit"
+          >
+            {loading ? "查詢中..." : "查詢"}
           </button>
-        ) : (
-          <button className="button-secondary" onClick={startScan} type="button">
-            掃描 QR
-          </button>
-        )}
+          {scanning ? (
+            <button className="ghost-button" onClick={stopScan} type="button">
+              停止掃描
+            </button>
+          ) : (
+            <button className="ghost-button" onClick={startScan} type="button">
+              📷 掃描 QR
+            </button>
+          )}
+        </div>
       </form>
 
-      {scanMsg ? <p className="panel-copy">{scanMsg}</p> : null}
+      {scanMsg && <p className="panel-copy" style={{ marginTop: 8 }}>{scanMsg}</p>}
 
-      {scanning ? (
-        <div style={{ marginTop: "0.75rem" }}>
+      {scanning && (
+        <div style={{ marginTop: "1rem" }}>
           <video
             ref={videoRef}
             muted
             playsInline
             style={{ width: "100%", maxWidth: 320, borderRadius: 8, background: "#000" }}
           />
-          <p className="panel-copy">將員工工牌 QR 對準鏡頭，辨識後自動查詢。</p>
+          <p className="panel-copy" style={{ marginTop: 8 }}>將員工工牌 QR 對準鏡頭，辨識後自動查詢。</p>
         </div>
-      ) : null}
+      )}
 
-      {error ? <p className="form-error">{error}</p> : null}
+      {/* 分隔線：有查詢結果或錯誤時才顯示 */}
+      {(error || status || orders.length > 0) && (
+        <hr style={{ border: "none", borderTop: "1px solid var(--line)", margin: "24px 0" }} />
+      )}
+
+      {error && <p className="error-state">{error}</p>}
 
       {status === "not_found" ? (
         <p className="panel-copy">查無此員工編號。</p>
       ) : status === "empty" ? (
         <p className="panel-copy">此員工今日在本店無待領訂單。</p>
       ) : orders.length > 0 ? (
-        <ul className="data-list">
+        <div style={{ display: "grid", gap: 12 }}>
+          <p style={{ margin: 0, fontWeight: 700, fontSize: 15 }}>
+            {orders[0].masked_name ?? "（未提供）"}
+            <span style={{ marginLeft: 8, color: "var(--muted)", fontSize: 13, fontWeight: 500 }}>
+              {orders[0].employee_badge_code ?? badgeCode}
+            </span>
+          </p>
           {orders.map((order) => (
-            <li className="data-row" key={order.id}>
-              <div>
-                <p className="data-title">
-                  {order.masked_name ?? "（未提供）"} · {order.employee_badge_code ?? badgeCode}
+            <div
+              key={order.id}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: 16,
+                padding: "14px 18px",
+                border: "1px solid var(--line)",
+                borderRadius: "var(--radius-md)",
+                background: order.status === "delivered"
+                  ? "rgba(47,125,74,0.05)"
+                  : "rgba(255,255,255,0.55)",
+                flexWrap: "wrap",
+              }}
+            >
+              <div style={{ display: "grid", gap: 4 }}>
+                <p style={{ margin: 0, fontWeight: 600, fontSize: 14 }}>
+                  取餐碼 <span style={{ color: "var(--brand)", letterSpacing: "0.05em" }}>{order.pickup_code}</span>
                 </p>
-                <p className="data-subtitle">
-                  取餐碼 {order.pickup_code} · {formatItems(order.items)} · {STATUS_LABELS[order.status] ?? order.status}
+                <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>
+                  {formatItems(order.items)}
                 </p>
               </div>
-              <div className="data-actions">
-                {order.status === "delivered" ? (
-                  <span className="panel-copy">已領餐</span>
-                ) : !isToday(order.meal_date) ? (
-                  <button className="button-secondary" disabled type="button" title={`此訂單為 ${order.meal_date} 的餐點，無法今日取餐`}>
-                    非今日餐點
-                  </button>
-                ) : (
-                  <button
-                    className="button-primary"
-                    disabled={working === order.id}
-                    onClick={() => handleConfirm(order.id)}
-                    type="button"
-                  >
-                    {working === order.id ? "處理中..." : "確認領餐"}
-                  </button>
-                )}
+              <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+                <span style={{
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: order.status === "delivered" ? "var(--success)" : "var(--muted)",
+                }}>
+                  {STATUS_LABELS[order.status] ?? order.status}
+                </span>
+                {order.status === "delivered" ? null
+                  : !isToday(order.meal_date) ? (
+                    <button
+                      className="ghost-button"
+                      disabled
+                      type="button"
+                      title={`此訂單為 ${order.meal_date} 的餐點，無法今日取餐`}
+                      style={{ minHeight: 38, padding: "0 14px", fontSize: 13 }}
+                    >
+                      非今日餐點
+                    </button>
+                  ) : (
+                    <button
+                      className="primary-button"
+                      disabled={working === order.id}
+                      onClick={() => handleConfirm(order.id)}
+                      type="button"
+                      style={{ minHeight: 38, padding: "0 18px", fontSize: 13 }}
+                    >
+                      {working === order.id ? "處理中..." : "確認領餐"}
+                    </button>
+                  )}
               </div>
-            </li>
+            </div>
           ))}
-        </ul>
+        </div>
       ) : null}
     </section>
   );

--- a/frontend/src/pages/vendor/VendorHomePage.jsx
+++ b/frontend/src/pages/vendor/VendorHomePage.jsx
@@ -1,24 +1,182 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getMyOrders, getMyProfile, getVendorRevenue } from "../../api/vendor";
+import { useAuth } from "../../auth/AuthContext";
+import { useFacility } from "../../facility/FacilityContext";
+import { todayIso } from "../../utils/date";
+import { formatMoney } from "../../utils/format";
+
+const ORDER_STATS = [
+  { status: "pending",   label: "待確認", badgeClass: "badge-status-pending" },
+  { status: "confirmed", label: "已確認", badgeClass: "badge-status-confirmed" },
+  { status: "preparing", label: "準備中", badgeClass: "badge-status-preparing" },
+  { status: "ready",     label: "可取餐", badgeClass: "badge-status-ready" },
+];
+
 export default function VendorHomePage() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const { selectedFacilityId } = useFacility();
+
+  const [vendorName, setVendorName] = useState(null);
+  const [orders, setOrders] = useState([]);
+  const [ordersLoading, setOrdersLoading] = useState(true);
+  const [revenue, setRevenue] = useState(null);
+  const [revenueLoading, setRevenueLoading] = useState(true);
+
+  useEffect(() => {
+    getMyProfile().then((p) => setVendorName(p.name)).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    setOrdersLoading(true);
+    getMyOrders({ facilityId: selectedFacilityId })
+      .then((data) => { if (alive) setOrders(data); })
+      .catch(() => { if (alive) setOrders([]); })
+      .finally(() => { if (alive) setOrdersLoading(false); });
+    return () => { alive = false; };
+  }, [selectedFacilityId]);
+
+  useEffect(() => {
+    let alive = true;
+    const today = todayIso();
+    setRevenueLoading(true);
+    getVendorRevenue({ facilityId: selectedFacilityId, today, start: today, end: today })
+      .then((data) => { if (alive) setRevenue(data); })
+      .catch(() => { if (alive) setRevenue(null); })
+      .finally(() => { if (alive) setRevenueLoading(false); });
+    return () => { alive = false; };
+  }, [selectedFacilityId]);
+
+  const today = useMemo(() => todayIso(), []);
+  const todayOrders = useMemo(
+    () => orders.filter((o) => o.meal_date === today && o.status !== "cancelled"),
+    [orders, today],
+  );
+  const pendingCount = useMemo(
+    () => todayOrders.filter((o) => o.status === "pending").length,
+    [todayOrders],
+  );
+  const countByStatus = useMemo(() => {
+    const counts = {};
+    for (const o of todayOrders) {
+      counts[o.status] = (counts[o.status] ?? 0) + 1;
+    }
+    return counts;
+  }, [todayOrders]);
+
   return (
     <section className="dashboard-grid">
       <article className="panel hero-banner">
         <p className="eyebrow">Vendor Workspace</p>
-        <h2>Operations need fast visibility into menus, stock, and incoming orders.</h2>
-        <p className="panel-copy">
-          This branch establishes where vendor-only pages live and how access is enforced.
+        <h2>歡迎回來，{vendorName ?? user?.name ?? "廠商"}</h2>
+        <p className="panel-copy" style={{ marginTop: 12 }}>
+          管理今日訂單、更新菜單，掌握即時營收狀況。
         </p>
+        <button
+          className="primary-button inline-button"
+          style={{ marginTop: 24 }}
+          onClick={() => navigate("/vendor/orders")}
+          type="button"
+        >
+          查看今日訂單 →
+        </button>
       </article>
+
+      {/* 待確認訂單 */}
       <article className="panel">
-        <h3>Current focus</h3>
-        <p className="panel-copy">
-          Signed-in layout, navigation, and role-aware route boundaries.
-        </p>
+        <h3>待確認訂單</h3>
+
+        {ordersLoading && (
+          <p className="panel-copy" style={{ marginTop: 8 }}>載入中...</p>
+        )}
+
+        {!ordersLoading && pendingCount === 0 && (
+          <p className="panel-copy" style={{ marginTop: 8 }}>目前沒有待確認訂單</p>
+        )}
+
+        {!ordersLoading && pendingCount > 0 && (
+          <div style={{ display: "grid", gap: 16, marginTop: 12 }}>
+            <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+              <span
+                style={{
+                  fontSize: "2.8rem",
+                  fontWeight: 800,
+                  color: "var(--brand)",
+                  lineHeight: 1,
+                }}
+              >
+                {pendingCount}
+              </span>
+              <span style={{ color: "var(--muted)", fontSize: 14 }}>筆尚未確認</span>
+            </div>
+            <button
+              className="primary-button inline-button"
+              type="button"
+              onClick={() => navigate("/vendor/orders")}
+            >
+              前往確認 →
+            </button>
+          </div>
+        )}
+
+        {/* 今日其他狀態摘要 */}
+        {!ordersLoading && todayOrders.length > 0 && (
+          <div style={{ display: "grid", gap: 8, marginTop: 20 }}>
+            {ORDER_STATS.filter(({ status }) => status !== "pending").map(({ status, label, badgeClass }) => {
+              const count = countByStatus[status] ?? 0;
+              if (count === 0) return null;
+              return (
+                <div
+                  key={status}
+                  style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}
+                >
+                  <span style={{ fontSize: 13, color: "var(--muted)" }}>{label}</span>
+                  <span className={`badge ${badgeClass}`}>{count} 筆</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
       </article>
+
+      {/* 今日營收 */}
       <article className="panel">
-        <h3>Next branch</h3>
-        <p className="panel-copy">
-          `feat/vendor-menu-management` should implement menu CRUD screens.
-        </p>
+        <h3>今日營收</h3>
+
+        {revenueLoading && (
+          <p className="panel-copy" style={{ marginTop: 8 }}>載入中...</p>
+        )}
+
+        {!revenueLoading && !revenue && (
+          <p className="panel-copy" style={{ marginTop: 8 }}>暫時無法取得</p>
+        )}
+
+        {!revenueLoading && revenue && (
+          <div style={{ display: "grid", gap: 16, marginTop: 12 }}>
+            <div>
+              <p style={{ color: "var(--muted)", fontSize: 13, margin: 0 }}>總金額</p>
+              <p style={{ fontSize: "2rem", fontWeight: 800, margin: "4px 0 0" }}>
+                {formatMoney(revenue.summary?.revenue_cents ?? 0)}
+              </p>
+            </div>
+            <div>
+              <p style={{ color: "var(--muted)", fontSize: 13, margin: 0 }}>已完成訂單</p>
+              <p style={{ fontSize: "1.4rem", fontWeight: 700, margin: "4px 0 0" }}>
+                {revenue.summary?.order_count ?? 0} 筆
+              </p>
+            </div>
+            <button
+              className="ghost-button"
+              type="button"
+              style={{ justifySelf: "start" }}
+              onClick={() => navigate("/vendor/revenue")}
+            >
+              查看完整報表 →
+            </button>
+          </div>
+        )}
       </article>
     </section>
   );

--- a/frontend/src/pages/vendor/VendorMenuSchedulePage.jsx
+++ b/frontend/src/pages/vendor/VendorMenuSchedulePage.jsx
@@ -375,12 +375,21 @@ export default function VendorMenuSchedulePage() {
     });
   }
 
+  const backButton = (
+    <button className="back-button" type="button" onClick={() => navigate("/vendor/menu")}>
+      ← 返回菜單
+    </button>
+  );
+
   if (menuLoading) {
     return (
       <div>
-        <div className="page-header">
-          <p className="eyebrow">Vendor · Menu</p>
-          <h2>每日排程</h2>
+        <div className="page-header" style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between" }}>
+          <div>
+            <p className="eyebrow">Vendor · Menu</p>
+            <h2>每日排程</h2>
+          </div>
+          {backButton}
         </div>
         <p className="loading-state">載入中…</p>
       </div>
@@ -390,21 +399,21 @@ export default function VendorMenuSchedulePage() {
   if (!item) {
     return (
       <div>
-        <div className="page-header">
-          <p className="eyebrow">Vendor · Menu</p>
-          <h2>每日排程</h2>
+        <div className="page-header" style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between" }}>
+          <div>
+            <p className="eyebrow">Vendor · Menu</p>
+            <h2>每日排程</h2>
+          </div>
+          {backButton}
         </div>
         <p className="error-state">找不到此餐點。</p>
-        <button className="ghost-button" type="button" onClick={() => navigate("/vendor/menu")}>
-          返回菜單
-        </button>
       </div>
     );
   }
 
   return (
     <div>
-      <div className="page-header" style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between" }}>
+      <div className="page-header" style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", marginBottom: 24 }}>
         <div>
           <p className="eyebrow">Vendor · Menu</p>
           <h2>每日排程 — {item.name}</h2>
@@ -414,9 +423,7 @@ export default function VendorMenuSchedulePage() {
             {formatPrice(item.price_cents)} · 今日推薦每日最多 {recommendationLimit} 道
           </p>
         </div>
-        <button className="ghost-button" type="button" onClick={() => navigate("/vendor/menu")}>
-          返回菜單
-        </button>
+        {backButton}
       </div>
 
       {scheduleError && <p className="error-state">{scheduleError}</p>}

--- a/frontend/src/pages/vendor/VendorOrdersPage.jsx
+++ b/frontend/src/pages/vendor/VendorOrdersPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { batchUpdateOrderStatus, getMyOrders } from "../../api/vendor";
 import { useFacility } from "../../facility/FacilityContext";
@@ -25,6 +25,7 @@ const STATUS_COLOR = {
 
 const ALL_STATUSES = ["pending", "confirmed", "preparing", "ready", "delivered", "cancelled"];
 
+/** Target statuses available in the batch action dropdown (terminal states excluded). */
 const BATCH_STATUS_OPTIONS = [
   { value: "confirmed", label: "確認訂單" },
   { value: "preparing", label: "開始備餐" },
@@ -71,6 +72,7 @@ function itemsSummary(items) {
   return items.length > 1 ? `${first} 等 ${items.length} 項` : first;
 }
 
+/** Indeterminate checkbox that reflects partial selection state. */
 function SelectAllCheckbox({ checked, indeterminate, onChange }) {
   const ref = useRef(null);
   useEffect(() => {
@@ -98,10 +100,12 @@ export default function VendorOrdersPage() {
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  // multi-select state
   const [selectedIds, setSelectedIds] = useState(new Set());
   const [batchStatus, setBatchStatus] = useState("confirmed");
   const [batchLoading, setBatchLoading] = useState(false);
-  const [batchResult, setBatchResult] = useState(null);
+  const [batchResult, setBatchResult] = useState(null); // { succeeded, failed, failures: [{order_id, error}] }
 
   useEffect(() => {
     setFacilityFilter(selectedFacilityId != null ? String(selectedFacilityId) : "");
@@ -134,12 +138,22 @@ export default function VendorOrdersPage() {
     return facility ? facility.name : `#${facilityId}`;
   }
 
+  // Group orders by status for display; skip empty groups
+  const groupedOrders = useMemo(
+    () =>
+      ALL_STATUSES
+        .map((status) => ({ status, orders: orders.filter((o) => o.status === status) }))
+        .filter((g) => g.orders.length > 0),
+    [orders],
+  );
+
   const totalRevenue = orders.reduce((sum, order) => sum + order.total_price_cents, 0);
   const totalItems = orders.reduce(
     (sum, order) => sum + order.items.reduce((s, item) => s + item.quantity, 0),
     0,
   );
 
+  // --- selection helpers ---
   const allSelected = orders.length > 0 && selectedIds.size === orders.length;
   const someSelected = selectedIds.size > 0 && selectedIds.size < orders.length;
   const gridColumns = showAllFacilities
@@ -160,12 +174,28 @@ export default function VendorOrdersPage() {
     setBatchResult(null);
   }
 
+  function toggleGroupSelect(groupOrders) {
+    const groupIds = groupOrders.map((o) => o.id);
+    const allGroupSelected = groupIds.every((id) => selectedIds.has(id));
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allGroupSelected) {
+        groupIds.forEach((id) => next.delete(id));
+      } else {
+        groupIds.forEach((id) => next.add(id));
+      }
+      return next;
+    });
+    setBatchResult(null);
+  }
+
   async function refreshOrders() {
     const fresh = await getMyOrders(currentOrderQuery());
     setOrders(fresh);
     return fresh;
   }
 
+  // --- batch action ---
   async function handleBatchAction() {
     if (selectedIds.size === 0) return;
     setBatchLoading(true);
@@ -175,10 +205,12 @@ export default function VendorOrdersPage() {
       setBatchResult({
         succeeded: res.succeeded,
         failed: res.failed,
-        failures: res.results.filter((result) => !result.success),
+        failures: res.results.filter((r) => !r.success),
       });
+      // Refresh order list so statuses are up-to-date
       await refreshOrders();
-      const failedIds = new Set(res.results.filter((result) => !result.success).map((result) => result.order_id));
+      // Deselect successfully updated orders
+      const failedIds = new Set(res.results.filter((r) => !r.success).map((r) => r.order_id));
       setSelectedIds(failedIds);
     } catch (err) {
       setBatchResult({ error: err.message ?? "批量操作失敗" });
@@ -198,9 +230,10 @@ export default function VendorOrdersPage() {
       <div className="page-header">
         <FacilityScopeLabel label="Orders facility" />
         <p className="eyebrow">Vendor · Orders</p>
-        <h2>訂單查詢</h2>
+        <h2>訂單管理</h2>
       </div>
 
+      {/* 篩選列 */}
       <div style={{ display: "flex", gap: 10, marginBottom: 20, flexWrap: "wrap", alignItems: "center" }}>
         <select value={facilityFilter} onChange={(e) => setFacilityFilter(e.target.value)} style={selectStyle}>
           <option value="">全部廠區</option>
@@ -251,6 +284,7 @@ export default function VendorOrdersPage() {
 
       {!loading && !error && orders.length > 0 && (
         <>
+          {/* ── Summary cards ── */}
           <div style={{ display: "flex", gap: 16, marginBottom: 24 }}>
             <div className="panel" style={{ flex: 1, padding: "16px 20px" }}>
               <p style={{ margin: 0, color: "var(--muted)", fontSize: 13 }}>訂單數</p>
@@ -266,6 +300,7 @@ export default function VendorOrdersPage() {
             </div>
           </div>
 
+          {/* ── Batch action bar ── */}
           {selectedIds.size > 0 && (
             <div
               className="panel"
@@ -280,7 +315,9 @@ export default function VendorOrdersPage() {
                 borderColor: "rgba(47,100,200,0.2)",
               }}
             >
-              <span style={{ fontWeight: 600, fontSize: 14 }}>已選取 {selectedIds.size} 筆訂單</span>
+              <span style={{ fontWeight: 600, fontSize: 14 }}>
+                已選取 {selectedIds.size} 筆訂單
+              </span>
               <span style={{ color: "var(--muted)", fontSize: 13 }}>→ 批量更新為</span>
               <select
                 value={batchStatus}
@@ -318,10 +355,7 @@ export default function VendorOrdersPage() {
                 {batchLoading ? "套用中..." : "套用"}
               </button>
               <button
-                onClick={() => {
-                  setSelectedIds(new Set());
-                  setBatchResult(null);
-                }}
+                onClick={() => { setSelectedIds(new Set()); setBatchResult(null); }}
                 disabled={batchLoading}
                 style={{
                   padding: "6px 12px",
@@ -336,6 +370,7 @@ export default function VendorOrdersPage() {
                 取消選取
               </button>
 
+              {/* Result feedback */}
               {batchResult && !batchResult.error && (
                 <span style={{ marginLeft: "auto", fontSize: 13 }}>
                   {batchResult.succeeded > 0 && (
@@ -348,7 +383,7 @@ export default function VendorOrdersPage() {
                       ✗ {batchResult.failed} 筆失敗
                       {batchResult.failures.length > 0 && (
                         <span style={{ fontWeight: 400, marginLeft: 4 }}>
-                          (訂單 #{batchResult.failures.map((failure) => failure.order_id).join(", #")}
+                          (訂單 #{batchResult.failures.map((f) => f.order_id).join(", #")}
                           {" — "}
                           {batchResult.failures[0].error})
                         </span>
@@ -365,7 +400,9 @@ export default function VendorOrdersPage() {
             </div>
           )}
 
+          {/* ── Orders table ── */}
           <div className="panel" style={{ padding: 0, overflow: "hidden" }}>
+            {/* Header */}
             <div
               style={{
                 display: "grid",
@@ -394,62 +431,97 @@ export default function VendorOrdersPage() {
               <span />
             </div>
 
-            {orders.map((order, idx) => {
-              const isSelected = selectedIds.has(order.id);
+            {/* Rows — grouped by status */}
+            {groupedOrders.map((group, gIdx) => {
+              const groupIds = group.orders.map((o) => o.id);
+              const groupAllSelected = groupIds.length > 0 && groupIds.every((id) => selectedIds.has(id));
+              const groupSomeSelected = groupIds.some((id) => selectedIds.has(id)) && !groupAllSelected;
               return (
-                <div
-                  key={order.id}
-                  style={{
-                    display: "grid",
-                    gridTemplateColumns: gridColumns,
-                    alignItems: "center",
-                    width: "100%",
-                    padding: "14px 20px",
-                    borderBottom: idx < orders.length - 1 ? "1px solid var(--line)" : "none",
-                    background: isSelected ? "rgba(47,100,200,0.05)" : "transparent",
-                    cursor: "pointer",
-                    transition: "background 120ms ease",
-                    boxSizing: "border-box",
-                  }}
-                  onClick={() => navigate(`/vendor/orders/${order.id}`)}
-                  onMouseEnter={(e) => {
-                    if (!isSelected) e.currentTarget.style.background = "rgba(23,33,43,0.03)";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.background = isSelected
-                      ? "rgba(47,100,200,0.05)"
-                      : "transparent";
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={isSelected}
-                    onChange={() => toggleSelect(order.id)}
-                    onClick={(e) => e.stopPropagation()}
-                    style={{ width: 16, height: 16, cursor: "pointer" }}
-                  />
-                  <div>
-                    <p style={{ margin: 0, fontSize: 13, fontWeight: 600 }}>{order.meal_date ?? "—"}</p>
-                    <p style={{ margin: "2px 0 0", fontSize: 11, color: "var(--muted)" }}>#{order.id}</p>
+                <div key={group.status}>
+                  {/* Group header */}
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: gridColumns,
+                      alignItems: "center",
+                      padding: "7px 20px",
+                      borderTop: gIdx > 0 ? "2px solid var(--line)" : undefined,
+                      borderBottom: "1px solid var(--line)",
+                      background: "rgba(23,33,43,0.025)",
+                    }}
+                  >
+                    <SelectAllCheckbox
+                      checked={groupAllSelected}
+                      indeterminate={groupSomeSelected}
+                      onChange={() => toggleGroupSelect(group.orders)}
+                    />
+                    <div style={{ gridColumn: "2 / -1", display: "flex", alignItems: "center", gap: 8 }}>
+                      <StatusBadge status={group.status} />
+                      <span style={{ fontSize: 12, color: "var(--muted)" }}>{group.orders.length} 筆</span>
+                    </div>
                   </div>
-                  <p style={{ margin: 0, fontWeight: 700, fontSize: 13 }}>
-                    {order.pickup_code ?? "—"}
-                  </p>
-                  {showAllFacilities && (
-                    <p style={{ margin: 0, fontSize: 12, color: "var(--muted)" }}>
-                      {facilityName(order.facility_id)}
-                    </p>
-                  )}
-                  <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>
-                    {itemsSummary(order.items)}
-                  </p>
-                  <p style={{ margin: 0, textAlign: "right", fontWeight: 600 }}>
-                    {formatMoney(order.total_price_cents)}
-                  </p>
-                  <div style={{ textAlign: "right" }}>
-                    <StatusBadge status={order.status} />
-                  </div>
-                  <p style={{ margin: 0, textAlign: "right", color: "var(--muted)", fontSize: 16 }}>›</p>
+
+                  {/* Orders in this group */}
+                  {group.orders.map((order, idx) => {
+                    const isSelected = selectedIds.has(order.id);
+                    return (
+                      <div
+                        key={order.id}
+                        style={{
+                          display: "grid",
+                          gridTemplateColumns: gridColumns,
+                          alignItems: "center",
+                          width: "100%",
+                          padding: "14px 20px",
+                          borderBottom: idx < group.orders.length - 1 ? "1px solid var(--line)" : "none",
+                          background: isSelected ? "rgba(47,100,200,0.05)" : "transparent",
+                          cursor: "pointer",
+                          transition: "background 120ms ease",
+                          boxSizing: "border-box",
+                        }}
+                        onClick={() => navigate(`/vendor/orders/${order.id}`)}
+                        onMouseEnter={(e) => {
+                          if (!isSelected) e.currentTarget.style.background = "rgba(23,33,43,0.03)";
+                        }}
+                        onMouseLeave={(e) => {
+                          e.currentTarget.style.background = isSelected
+                            ? "rgba(47,100,200,0.05)"
+                            : "transparent";
+                        }}
+                      >
+                        {/* Checkbox — stops propagation so click doesn't navigate */}
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => toggleSelect(order.id)}
+                          onClick={(e) => e.stopPropagation()}
+                          style={{ width: 16, height: 16, cursor: "pointer" }}
+                        />
+                        <div>
+                          <p style={{ margin: 0, fontSize: 13, fontWeight: 600 }}>{order.meal_date ?? "—"}</p>
+                          <p style={{ margin: "2px 0 0", fontSize: 11, color: "var(--muted)" }}>#{order.id}</p>
+                        </div>
+                        <p style={{ margin: 0, fontWeight: 700, fontSize: 13 }}>
+                          {order.pickup_code ?? "—"}
+                        </p>
+                        {showAllFacilities && (
+                          <p style={{ margin: 0, fontSize: 12, color: "var(--muted)" }}>
+                            {facilityName(order.facility_id)}
+                          </p>
+                        )}
+                        <p style={{ margin: 0, fontWeight: 500, fontSize: 14 }}>
+                          {itemsSummary(order.items)}
+                        </p>
+                        <p style={{ margin: 0, textAlign: "right", fontWeight: 600 }}>
+                          {formatMoney(order.total_price_cents)}
+                        </p>
+                        <div style={{ textAlign: "right" }}>
+                          <StatusBadge status={order.status} />
+                        </div>
+                        <p style={{ margin: 0, textAlign: "right", color: "var(--muted)", fontSize: 16 }}>›</p>
+                      </div>
+                    );
+                  })}
                 </div>
               );
             })}

--- a/frontend/src/pages/vendor/VendorRevenuePage.jsx
+++ b/frontend/src/pages/vendor/VendorRevenuePage.jsx
@@ -6,8 +6,8 @@ import FacilityScopeLabel from "../../facility/FacilityScopeLabel";
 import { formatMoney } from "../../utils/format";
 
 const RANGES = [
-  { days: 7, label: "Last 7 days" },
-  { days: 30, label: "Last 30 days" },
+  { days: 7, label: "最近 7 天" },
+  { days: 30, label: "最近 30 天" },
 ];
 
 function todayIso() {
@@ -27,13 +27,13 @@ function presetRange(days) {
 }
 
 function quotaText(value) {
-  if (value == null) return "Unlimited";
+  if (value == null) return "不限量";
   return String(value);
 }
 
 function remainingText(value) {
-  if (value == null) return "Unlimited";
-  if (value === 0) return "Sold out";
+  if (value == null) return "不限量";
+  if (value === 0) return "已售完";
   return String(value);
 }
 
@@ -64,7 +64,7 @@ export default function VendorRevenuePage() {
 
   useEffect(() => {
     if (rangeInvalid) {
-      setError("Start date must be on or before end date.");
+      setError("開始日期不可晚於結束日期");
       setLoading(false);
       setDashboard(null);
       return undefined;
@@ -82,7 +82,7 @@ export default function VendorRevenuePage() {
         if (active) setDashboard(data);
       })
       .catch((err) => {
-        if (active) setError(err.message ?? "Unable to load revenue data");
+        if (active) setError(err.message ?? "無法載入營收資料");
       })
       .finally(() => {
         if (active) setLoading(false);
@@ -102,8 +102,8 @@ export default function VendorRevenuePage() {
     <div>
       <div className="page-header">
         <FacilityScopeLabel label="Revenue facility" />
-        <p className="eyebrow">Vendor / Revenue</p>
-        <h2>Sales dashboard</h2>
+        <p className="eyebrow">Vendor · Revenue</p>
+        <h2>營收報表</h2>
       </div>
 
       <div className="range-pills" role="group" aria-label="Revenue range" style={{ marginBottom: 12 }}>
@@ -127,7 +127,7 @@ export default function VendorRevenuePage() {
         style={{ display: "flex", gap: 12, alignItems: "flex-end", flexWrap: "wrap", marginBottom: 20 }}
       >
         <label style={{ display: "flex", flexDirection: "column", fontSize: 12 }}>
-          <span>Start</span>
+          <span>開始日期</span>
           <input
             type="date"
             value={startDate}
@@ -136,7 +136,7 @@ export default function VendorRevenuePage() {
           />
         </label>
         <label style={{ display: "flex", flexDirection: "column", fontSize: 12 }}>
-          <span>End</span>
+          <span>結束日期</span>
           <input
             type="date"
             value={endDate}
@@ -147,22 +147,22 @@ export default function VendorRevenuePage() {
         </label>
       </div>
 
-      {loading && <p className="loading-state">Loading revenue data...</p>}
+      {loading && <p className="loading-state">載入營收資料中...</p>}
       {error && <p className="error-state">{error}</p>}
 
       {dashboard && !loading && !error && (
         <section style={{ display: "grid", gap: 18 }}>
           <article className="panel stat-cards">
             <div className="stat-card">
-              <span>Orders</span>
+              <span>訂單數</span>
               <strong>{numberText(dashboard.summary.order_count)}</strong>
             </div>
             <div className="stat-card">
-              <span>Items sold</span>
+              <span>售出份數</span>
               <strong>{numberText(dashboard.summary.quantity_sold)}</strong>
             </div>
             <div className="stat-card">
-              <span>Revenue</span>
+              <span>營收</span>
               <strong>{formatMoney(dashboard.summary.revenue_cents)}</strong>
             </div>
           </article>
@@ -185,18 +185,18 @@ export default function VendorRevenuePage() {
                   marginBottom: 12,
                 }}
               >
-                <h3 style={{ margin: 0 }}>Today stock</h3>
+                <h3 style={{ margin: 0 }}>今日庫存</h3>
                 <p className="panel-copy" style={{ margin: 0 }}>{dashboard.today}</p>
               </div>
               <div style={{ overflowX: "auto" }}>
                 <table className="data-table">
                   <thead>
                     <tr>
-                      <th>Item</th>
-                      <th>Quota</th>
-                      <th>Sold</th>
-                      <th>Remaining</th>
-                      <th>Revenue</th>
+                      <th>餐點</th>
+                      <th>配額</th>
+                      <th>已售</th>
+                      <th>剩餘</th>
+                      <th>營收</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -211,7 +211,7 @@ export default function VendorRevenuePage() {
                     ))}
                     {dashboard.today_items.length === 0 && (
                       <tr>
-                        <td colSpan={5} className="table-empty">No menu items yet.</td>
+                        <td colSpan={5} className="table-empty">今日尚無菜單</td>
                       </tr>
                     )}
                   </tbody>
@@ -230,19 +230,19 @@ export default function VendorRevenuePage() {
                   marginBottom: 12,
                 }}
               >
-                <h3 style={{ margin: 0 }}>Dish sales</h3>
+                <h3 style={{ margin: 0 }}>餐點銷售</h3>
                 <p className="panel-copy" style={{ margin: 0 }}>
-                  {dashboard.start} to {dashboard.end}
+                  {dashboard.start} 至 {dashboard.end}
                 </p>
               </div>
               <div style={{ overflowX: "auto" }}>
                 <table className="data-table">
                   <thead>
                     <tr>
-                      <th>Item</th>
-                      <th>Orders</th>
-                      <th>Sold</th>
-                      <th>Revenue</th>
+                      <th>餐點</th>
+                      <th>訂單數</th>
+                      <th>售出份數</th>
+                      <th>營收</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -256,7 +256,7 @@ export default function VendorRevenuePage() {
                     ))}
                     {dashboard.period_items.length === 0 && (
                       <tr>
-                        <td colSpan={4} className="table-empty">No sales in this range.</td>
+                        <td colSpan={4} className="table-empty">此期間無銷售紀錄</td>
                       </tr>
                     )}
                   </tbody>


### PR DESCRIPTION
## Summary

Refines the vendor-facing UI with functional improvements and full Traditional Chinese localization.

## Changes

- **Navigation** — added `/admin/facilities` route and cleaned up vendor/admin nav entries in `navigation.js`
- **VendorHomePage** — expanded with stats panels and localized all labels
- **VendorOrdersPage** — batch status update bar, grouped order list by status, summary cards (訂單數 / 總份數 / 預估收入), and full i18n
- **VendorBadgePickupPage** — improved pickup confirmation flow and localized labels
- **VendorRevenuePage** — localized and minor layout cleanup
- **VendorMenuSchedulePage** — localized strings

## Testing

Tested manually against local stack. No backend changes.