### PR TITLE
feat(auth-ui): refine login and register auth screens

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -8,17 +8,18 @@ export default function LoginPage() {
   const location = useLocation();
   const { isAuthenticated, user, login } = useAuth();
 
-  const [email, setEmail]       = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
-  const [error, setError]       = useState(null);
-  const [loading, setLoading]   = useState(false);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   if (isAuthenticated && user) {
     return <Navigate replace to={roleHomePath[user.role] ?? "/"} />;
   }
 
   const nextPath = location.state?.from?.pathname;
+  const errorId = error ? "login-error-message" : undefined;
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -30,10 +31,10 @@ export default function LoginPage() {
     } catch (err) {
       setError(
         err.code === "invalid_credentials"
-          ? "Invalid email or password."
+          ? "電子郵件或密碼錯誤。"
           : err.code === "account_disabled"
-          ? "Your account is pending admin approval. Please contact your administrator."
-          : "Login failed. Please try again.",
+            ? "您的帳號尚待管理員審核，請聯繫您的管理員。"
+            : "登入失敗，請稍後再試。",
       );
     } finally {
       setLoading(false);
@@ -41,68 +42,76 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="login-shell">
-      <section className="hero-panel">
-        <p className="eyebrow">Corporate Meal Ordering System</p>
-        <h1>Frontline lunch operations, split by role and kept under control.</h1>
+    <div className="login-shell login-screen">
+      <section className="hero-panel login-hero-panel">
+        <div className="login-brand-mark">
+          <span className="login-brand-dot" aria-hidden="true" />
+          <p className="eyebrow">企業訂餐系統</p>
+        </div>
+        <h1>Enjoy your meal!</h1>
         <p className="hero-copy">
-          Sign in with your corporate account to browse menus, place orders,
-          and manage your workspace.
+          讓員工訂餐、廠商接單與管理審核都回到同一個清楚的工作流程！
         </p>
-        <div className="hero-grid">
-          <article className="metric-card">
-            <strong>3 roles</strong>
-            <span>Employee, vendor, admin</span>
-          </article>
-          <article className="metric-card">
-            <strong>Protected</strong>
-            <span>Unauthenticated users are redirected</span>
-          </article>
-          <article className="metric-card">
-            <strong>Role aware</strong>
-            <span>Each role lands in its own workspace</span>
-          </article>
+
+        <div className="login-hero-points" aria-label="系統功能重點">
+          <span className="login-feature-pill">員工訂餐</span>
+          <span className="login-feature-pill">廠商接單</span>
+          <span className="login-feature-pill">管理審核</span>
+        </div>
+
+        <div className="login-hero-note">
+          <strong>今日也能快速開始</strong>
+          <p>使用公司帳號登入後，即可繼續處理你的訂餐、菜單或後台管理工作。</p>
         </div>
       </section>
 
-      <section className="login-panel">
-        <div>
-          <p className="eyebrow">Sign In</p>
-          <h2>Enter your credentials</h2>
+      <section className="login-panel login-form-panel">
+        <div className="login-form-header">
+          <p className="eyebrow">登入</p>
+          <h2>歡迎回來</h2>
+          <p className="panel-copy">
+            使用公司註冊的電子郵件與密碼登入。
+          </p>
         </div>
 
-        <form onSubmit={handleSubmit} style={{ display: "grid", gap: 16 }}>
-          <label style={{ display: "grid", gap: 6 }}>
-            <span style={{ fontWeight: 600, fontSize: 14 }}>Email</span>
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <label className="auth-field">
+            <span className="field-label">電子郵件</span>
             <input
               className="form-input"
+              id="login-email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              placeholder="you@corpmeal.local"
+              placeholder="name@company.com"
               autoComplete="email"
+              aria-describedby={errorId}
+              aria-invalid={Boolean(error)}
             />
           </label>
-          <label style={{ display: "grid", gap: 6 }}>
-            <span style={{ fontWeight: 600, fontSize: 14 }}>Password</span>
+          <label className="auth-field">
+            <span className="field-label">密碼</span>
             <span className="pw-field">
               <input
                 className="form-input"
+                id="login-password"
                 type={showPassword ? "text" : "password"}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 placeholder="••••••••"
                 autoComplete="current-password"
+                aria-describedby={errorId}
+                aria-invalid={Boolean(error)}
               />
               <button
                 type="button"
                 className="pw-toggle"
                 onClick={() => setShowPassword((s) => !s)}
-                aria-label={showPassword ? "Hide password" : "Show password"}
+                aria-label={showPassword ? "隱藏密碼" : "顯示密碼"}
                 aria-pressed={showPassword}
-                title={showPassword ? "Hide password" : "Show password"}
+                title={showPassword ? "隱藏密碼" : "顯示密碼"}
               >
                 {showPassword ? (
                   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -118,18 +127,26 @@ export default function LoginPage() {
               </button>
             </span>
           </label>
-          {error && <p className="error-state" style={{ margin: 0 }}>{error}</p>}
+          <div className="auth-row">
+            <Link className="text-link subtle-link" to="/register">
+              還沒有帳號？立即註冊
+            </Link>
+            <span className="subtle-copy">帳號未啟用請聯繫管理員</span>
+          </div>
+          {error && (
+            <p
+              id={errorId}
+              className="error-state"
+              role="alert"
+              aria-live="polite"
+            >
+              {error}
+            </p>
+          )}
           <button className="primary-button" type="submit" disabled={loading}>
-            {loading ? "Signing in…" : "Sign In"}
+            {loading ? "登入中…" : "登入"}
           </button>
         </form>
-
-        <p style={{ marginTop: 20, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
-          Don't have an account?{" "}
-          <Link to="/register" style={{ color: "var(--accent)", fontWeight: 600 }}>
-            Create one
-          </Link>
-        </p>
       </section>
     </div>
   );

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -4,85 +4,59 @@ import { useAuth } from "../auth/AuthContext";
 import { roleHomePath } from "../layout/navigation";
 
 const ROLE_OPTIONS = [
-  { value: "employee",       label: "Employee",       desc: "Browse menus and place orders" },
-  { value: "vendor_manager", label: "Vendor Manager", desc: "Manage your restaurant and menu" },
+  { value: "employee", label: "員工", desc: "瀏覽菜單、完成每日訂餐與查看取餐碼" },
+  { value: "vendor_manager", label: "廠商", desc: "管理菜單、接單流程與供餐資訊" },
 ];
 
 function PendingApprovalScreen({ displayName }) {
   return (
-    <div className="login-shell">
-      <section className="hero-panel">
-        <p className="eyebrow">Corporate Meal Ordering System</p>
-        <h1>Account created — one step away.</h1>
+    <div className="login-shell login-screen">
+      <section className="hero-panel login-hero-panel">
+        <div className="login-brand-mark">
+          <span className="login-brand-dot" aria-hidden="true" />
+          <p className="eyebrow">企業訂餐系統</p>
+        </div>
+        <h1>帳號已建立</h1>
         <p className="hero-copy">
-          Employee accounts require admin approval before you can browse
-          menus and place orders. Your administrator will review your
-          request shortly.
+          你的註冊資料已送出。完成管理員審核後，就能使用這組帳號登入系統。
         </p>
-        <div className="hero-grid">
-          <article className="metric-card">
-            <strong>Step 1 ✓</strong>
-            <span>Account registered</span>
-          </article>
-          <article className="metric-card">
-            <strong>Step 2 ⏳</strong>
-            <span>Admin approval pending</span>
-          </article>
+        <div className="login-hero-points" aria-label="註冊流程狀態">
+          <span className="login-feature-pill">完成註冊</span>
+          <span className="login-feature-pill">等待審核</span>
+        </div>
+        <div className="login-hero-note">
+          <strong>下一步</strong>
+          <p>管理員啟用帳號後，你就可以回到登入頁使用電子郵件與密碼登入。</p>
         </div>
       </section>
 
-      <section className="login-panel">
-        <div>
-          <p className="eyebrow">Pending Approval</p>
-          <h2>Hi {displayName}, you're almost in!</h2>
+      <section className="login-panel login-form-panel">
+        <div className="login-form-header">
+          <p className="eyebrow">待審核</p>
+          <h2>{displayName}，差一步就完成了</h2>
+          <p className="panel-copy">
+            你的帳號目前正等待管理員審核。審核完成前，系統不會開放登入。
+          </p>
         </div>
 
-        <div style={{ display: "grid", gap: 16 }}>
-          <div
-            style={{
-              padding: "20px 24px",
-              borderRadius: "var(--radius-md)",
-              background: "rgba(47, 125, 74, 0.08)",
-              border: "1px solid rgba(47, 125, 74, 0.25)",
-              display: "grid",
-              gap: 8,
-            }}
-          >
-            <p style={{ margin: 0, fontWeight: 700, color: "var(--success)", fontSize: 15 }}>
-              ✓ Account created successfully
-            </p>
-            <p style={{ margin: 0, fontSize: 13, color: "var(--text)", lineHeight: 1.6 }}>
-              Your employee account has been registered and is now awaiting
-              admin activation. You won't be able to sign in until an
-              administrator approves your account.
-            </p>
+        <div className="pending-panel-stack">
+          <div className="success-state pending-state-card">
+            <strong>✓ 帳號建立成功</strong>
+            <span>你的員工帳號已建立，接下來只需等待管理員啟用。</span>
           </div>
 
-          <div
-            style={{
-              padding: "16px 20px",
-              borderRadius: "var(--radius-md)",
-              background: "var(--surface-alt, rgba(0,0,0,0.04))",
-              fontSize: 13,
-              color: "var(--muted)",
-              lineHeight: 1.7,
-            }}
-          >
-            <strong style={{ color: "var(--text)", display: "block", marginBottom: 4 }}>
-              What happens next?
-            </strong>
-            An admin will review your registration and activate your account.
-            Once approved, you can sign in with the email and password you
-            just set.
+          <div className="pending-info-card">
+            <strong>接下來會發生什麼？</strong>
+            <p>管理員會審核你的申請並啟用帳號。啟用完成後，你就能使用剛設定的電子郵件與密碼登入。</p>
           </div>
         </div>
 
-        <p style={{ marginTop: 24, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
-          Already approved?{" "}
-          <Link to="/login" style={{ color: "var(--accent)", fontWeight: 600 }}>
-            Sign in
+        <div className="login-support-inline">
+          <span>已經啟用了？</span>
+          <Link className="text-link subtle-link" to="/login">
+            返回登入
           </Link>
-        </p>
+        </div>
       </section>
     </div>
   );
@@ -93,13 +67,13 @@ export default function RegisterPage() {
   const { isAuthenticated, user, register } = useAuth();
 
   const [displayName, setDisplayName] = useState("");
-  const [email, setEmail]             = useState("");
-  const [role, setRole]               = useState("employee");
-  const [password, setPassword]       = useState("");
-  const [confirm, setConfirm]         = useState("");
-  const [error, setError]             = useState(null);
-  const [loading, setLoading]         = useState(false);
-  const [pendingName, setPendingName] = useState(null);  // non-null → show pending screen
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState("employee");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [pendingName, setPendingName] = useState(null);
 
   if (isAuthenticated && user) {
     return <Navigate replace to={roleHomePath[user.role] ?? "/"} />;
@@ -114,11 +88,11 @@ export default function RegisterPage() {
     setError(null);
 
     if (password !== confirm) {
-      setError("Passwords do not match.");
+      setError("兩次輸入的密碼不一致。");
       return;
     }
     if (password.length < 8) {
-      setError("Password must be at least 8 characters.");
+      setError("密碼至少需要 8 個字元。");
       return;
     }
 
@@ -126,8 +100,6 @@ export default function RegisterPage() {
     try {
       const u = await register(email, password, displayName, role);
       if (!u.isActive) {
-        // Employee accounts start inactive — show the pending approval screen
-        // instead of navigating into the app (all API calls would 403 anyway).
         setPendingName(u.name);
       } else {
         navigate(roleHomePath[u.role] ?? "/", { replace: true });
@@ -135,8 +107,8 @@ export default function RegisterPage() {
     } catch (err) {
       setError(
         err.code === "email_taken"
-          ? "An account with this email already exists."
-          : "Registration failed. Please try again.",
+          ? "這個電子郵件已經被註冊。"
+          : "註冊失敗，請稍後再試。",
       );
     } finally {
       setLoading(false);
@@ -144,74 +116,73 @@ export default function RegisterPage() {
   }
 
   return (
-    <div className="login-shell">
-      <section className="hero-panel">
-        <p className="eyebrow">Corporate Meal Ordering System</p>
-        <h1>Join your team's meal ordering workspace.</h1>
+    <div className="login-shell login-screen">
+      <section className="hero-panel login-hero-panel">
+        <div className="login-brand-mark">
+          <span className="login-brand-dot" aria-hidden="true" />
+          <p className="eyebrow">企業訂餐系統</p>
+        </div>
+        <h1>Create your account</h1>
         <p className="hero-copy">
-          Create an account to start ordering lunch or managing your
-          restaurant on the platform.
+          建立帳號後，你就能開始加入企業訂餐流程，或管理你的供餐工作台。
         </p>
-        <div className="hero-grid">
+        <div className="login-role-list">
           {ROLE_OPTIONS.map((r) => (
-            <article className="metric-card" key={r.value}>
+            <article className="metric-card login-role-card" key={r.value}>
               <strong>{r.label}</strong>
               <span>{r.desc}</span>
             </article>
           ))}
         </div>
+        <div className="login-hero-note">
+          <strong>註冊前提醒</strong>
+          <p>員工帳號通常需要管理員啟用後才能登入。若你是廠商，請確認使用正確的角色建立帳號。</p>
+        </div>
       </section>
 
-      <section className="login-panel">
-        <div>
-          <p className="eyebrow">Create Account</p>
-          <h2>Fill in your details</h2>
+      <section className="login-panel login-form-panel">
+        <div className="login-form-header">
+          <p className="eyebrow">註冊</p>
+          <h2>建立新帳號</h2>
+          <p className="panel-copy">
+            填寫基本資料並選擇你的角色。完成後即可等待啟用或直接進入系統。
+          </p>
         </div>
 
-        <form onSubmit={handleSubmit} style={{ display: "grid", gap: 16 }}>
-          <label style={{ display: "grid", gap: 6 }}>
-            <span style={{ fontWeight: 600, fontSize: 14 }}>Display Name</span>
+        <form className="auth-form" onSubmit={handleSubmit}>
+          <label className="auth-field">
+            <span className="field-label">姓名</span>
             <input
               className="form-input"
               type="text"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
               required
-              placeholder="Your name"
+              placeholder="請輸入姓名"
               autoComplete="name"
             />
           </label>
 
-          <label style={{ display: "grid", gap: 6 }}>
-            <span style={{ fontWeight: 600, fontSize: 14 }}>Email</span>
+          <label className="auth-field">
+            <span className="field-label">電子郵件</span>
             <input
               className="form-input"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
-              placeholder="you@company.com"
+              placeholder="name@company.com"
               autoComplete="email"
             />
           </label>
 
-          <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
-            <legend style={{ fontWeight: 600, fontSize: 14, marginBottom: 8 }}>Role</legend>
-            <div style={{ display: "flex", gap: 12 }}>
+          <fieldset className="register-role-group">
+            <legend className="field-label register-role-legend">角色</legend>
+            <div className="register-role-options">
               {ROLE_OPTIONS.map((r) => (
                 <label
                   key={r.value}
-                  style={{
-                    flex: 1,
-                    display: "grid",
-                    gridTemplateColumns: "auto 1fr",
-                    gap: "4px 8px",
-                    alignItems: "start",
-                    padding: "10px 12px",
-                    border: `2px solid ${role === r.value ? "var(--accent)" : "var(--border)"}`,
-                    borderRadius: 8,
-                    cursor: "pointer",
-                  }}
+                  className={`register-role-option ${role === r.value ? "register-role-option-selected" : ""}`}
                 >
                   <input
                     type="radio"
@@ -219,55 +190,56 @@ export default function RegisterPage() {
                     value={r.value}
                     checked={role === r.value}
                     onChange={() => setRole(r.value)}
-                    style={{ marginTop: 2 }}
+                    className="register-role-radio"
                   />
-                  <span style={{ fontWeight: 600, fontSize: 14 }}>{r.label}</span>
-                  <span />
-                  <span style={{ fontSize: 12, color: "var(--muted)" }}>{r.desc}</span>
+                  <span className="register-role-copy">
+                    <strong>{r.label}</strong>
+                    <span>{r.desc}</span>
+                  </span>
                 </label>
               ))}
             </div>
           </fieldset>
 
-          <label style={{ display: "grid", gap: 6 }}>
-            <span style={{ fontWeight: 600, fontSize: 14 }}>Password</span>
+          <label className="auth-field">
+            <span className="field-label">密碼</span>
             <input
               className="form-input"
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              placeholder="Min. 8 characters"
+              placeholder="至少 8 個字元"
               autoComplete="new-password"
             />
           </label>
 
-          <label style={{ display: "grid", gap: 6 }}>
-            <span style={{ fontWeight: 600, fontSize: 14 }}>Confirm Password</span>
+          <label className="auth-field">
+            <span className="field-label">確認密碼</span>
             <input
               className="form-input"
               type="password"
               value={confirm}
               onChange={(e) => setConfirm(e.target.value)}
               required
-              placeholder="••••••••"
+              placeholder="再次輸入密碼"
               autoComplete="new-password"
             />
           </label>
 
-          {error && <p className="error-state" style={{ margin: 0 }}>{error}</p>}
+          {error && <p className="error-state">{error}</p>}
 
           <button className="primary-button" type="submit" disabled={loading}>
-            {loading ? "Creating account…" : "Create Account"}
+            {loading ? "建立中…" : "建立帳號"}
           </button>
         </form>
 
-        <p style={{ marginTop: 20, fontSize: 13, color: "var(--muted)", textAlign: "center" }}>
-          Already have an account?{" "}
-          <Link to="/login" style={{ color: "var(--accent)", fontWeight: 600 }}>
-            Sign in
+        <div className="login-support-inline">
+          <span>已經有帳號？</span>
+          <Link className="text-link subtle-link" to="/login">
+            返回登入
           </Link>
-        </p>
+        </div>
       </section>
     </div>
   );

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -123,6 +123,157 @@ p {
   line-height: 1.15;
 }
 
+.login-screen {
+  grid-template-columns: minmax(0, 1.05fr) minmax(360px, 440px);
+  gap: 30px;
+}
+
+.login-hero-panel {
+  display: grid;
+  align-content: center;
+  gap: 0;
+  min-height: 620px;
+  padding: 48px;
+  background:
+    radial-gradient(circle at top right, rgba(255, 255, 255, 0.72), transparent 26%),
+    linear-gradient(160deg, rgba(255, 249, 242, 0.96) 0%, rgba(247, 237, 223, 0.92) 100%);
+  overflow: hidden;
+  position: relative;
+}
+
+.login-hero-panel h1 {
+  max-width: none;
+  margin-top: 18px;
+  font-size: clamp(2.3rem, 4vw, 4.3rem);
+  line-height: 0.98;
+  letter-spacing: -0.04em;
+}
+
+.login-hero-points {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 28px;
+}
+
+.login-brand-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.login-brand-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--brand) 0%, #d77431 100%);
+  box-shadow: 0 0 0 8px rgba(200, 92, 44, 0.12);
+}
+
+.login-feature-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(200, 92, 44, 0.16);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.login-hero-note {
+  display: grid;
+  gap: 8px;
+  max-width: 40rem;
+  margin-top: 30px;
+  padding: 22px 24px;
+  border: 1px solid rgba(200, 92, 44, 0.12);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.52);
+  box-shadow: 0 18px 40px rgba(78, 49, 23, 0.08);
+}
+
+.login-hero-note strong {
+  font-size: 0.92rem;
+  color: var(--brand-deep);
+}
+
+.login-hero-note p {
+  color: var(--muted);
+  line-height: 1.65;
+}
+
+.login-form-panel {
+  gap: 22px;
+  align-content: start;
+  align-self: center;
+  max-width: 460px;
+  width: 100%;
+  padding: 36px 34px;
+  background: rgba(255, 252, 247, 0.9);
+  box-shadow: 0 24px 60px rgba(78, 49, 23, 0.12);
+}
+
+.login-form-header {
+  display: grid;
+  gap: 8px;
+}
+
+.auth-form {
+  display: grid;
+  gap: 16px;
+}
+
+.auth-field {
+  display: grid;
+  gap: 6px;
+}
+
+.auth-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-top: 4px;
+}
+
+.subtle-copy {
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.text-link {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.text-link:hover {
+  text-decoration: underline;
+}
+
+.subtle-link {
+  font-size: 0.9rem;
+}
+
+.login-support-inline {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  padding-top: 4px;
+  border-top: 1px solid rgba(200, 92, 44, 0.12);
+  font-size: 0.9rem;
+}
+
+.login-support-inline>span:first-child {
+  color: var(--text);
+  font-weight: 700;
+}
+
 .role-picker {
   display: grid;
   gap: 14px;
@@ -766,8 +917,15 @@ p {
 }
 
 @keyframes modal-in {
-  from { transform: translateY(14px); opacity: 0; }
-  to   { transform: translateY(0);    opacity: 1; }
+  from {
+    transform: translateY(14px);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 
 .modal-photo {
@@ -992,7 +1150,8 @@ p {
   border-radius: var(--radius-md);
   background: rgba(200, 92, 44, 0.08);
   color: var(--brand-deep);
-  text-align: center;
+  text-align: left;
+  line-height: 1.6;
 }
 
 .compact-state {
@@ -1424,6 +1583,7 @@ p {
 }
 
 @media (max-width: 1080px) {
+
   .login-shell,
   .dashboard-grid,
   .random-meal-layout,
@@ -1438,9 +1598,18 @@ p {
   .nav-list {
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
+
+  .login-form-panel {
+    max-width: none;
+  }
+
+  .login-hero-panel {
+    min-height: auto;
+  }
 }
 
 @media (max-width: 720px) {
+
   .login-shell,
   .app-shell {
     padding: 14px;
@@ -1456,6 +1625,33 @@ p {
 
   .hero-grid {
     grid-template-columns: 1fr;
+  }
+
+  .login-screen {
+    gap: 18px;
+  }
+
+  .login-hero-panel {
+    padding: 28px 22px;
+  }
+
+  .login-hero-panel h1 {
+    margin-top: 14px;
+    font-size: clamp(2rem, 10vw, 2.8rem);
+  }
+
+  .login-hero-points {
+    margin-top: 22px;
+  }
+
+  .auth-row {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .login-support-inline {
+    flex-direction: column;
+    align-items: start;
   }
 
   .topbar {

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -274,6 +274,112 @@ p {
   font-weight: 700;
 }
 
+.login-role-list {
+  display: grid;
+  gap: 14px;
+  margin-top: 28px;
+}
+
+.login-role-card {
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.register-role-group {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  border: none;
+}
+
+.register-role-legend {
+  margin-bottom: 0;
+}
+
+.register-role-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.register-role-option {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px 12px;
+  align-items: start;
+  padding: 14px 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.62);
+  cursor: pointer;
+  transition: transform 140ms ease, border-color 140ms ease, background 140ms ease, box-shadow 140ms ease;
+}
+
+.register-role-option:hover,
+.register-role-option-selected {
+  transform: translateY(-1px);
+  border-color: rgba(200, 92, 44, 0.4);
+  background: rgba(255, 247, 238, 0.95);
+  box-shadow: 0 12px 28px rgba(78, 49, 23, 0.08);
+}
+
+.register-role-radio {
+  margin: 3px 0 0;
+  accent-color: var(--brand);
+}
+
+.register-role-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.register-role-copy strong {
+  font-size: 0.95rem;
+}
+
+.register-role-copy span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.6;
+}
+
+.pending-panel-stack {
+  display: grid;
+  gap: 16px;
+}
+
+.pending-state-card {
+  display: grid;
+  gap: 8px;
+  justify-content: start;
+  margin-top: 0;
+}
+
+.pending-state-card span {
+  color: var(--text);
+  font-weight: 500;
+  line-height: 1.6;
+}
+
+.pending-info-card {
+  display: grid;
+  gap: 8px;
+  padding: 18px 20px;
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.56);
+  border: 1px solid var(--line);
+}
+
+.pending-info-card strong {
+  font-size: 0.92rem;
+}
+
+.pending-info-card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.65;
+}
+
 .role-picker {
   display: grid;
   gap: 14px;
@@ -1652,6 +1758,10 @@ p {
   .login-support-inline {
     flex-direction: column;
     align-items: start;
+  }
+
+  .register-role-options {
+    grid-template-columns: 1fr;
   }
 
   .topbar {


### PR DESCRIPTION
## What changed
- redesigned the login page to use a cleaner two-panel auth layout with a stronger form hierarchy
- refreshed the register page to match the same auth UI language and converted the role picker into card-style options
- updated the pending-approval state so post-registration messaging feels consistent with the rest of the auth flow
- moved auth-page presentation details out of inline JSX styles and into shared CSS

## Why
- the previous login and register screens mixed older copy, inline styling, and inconsistent layout patterns
- the auth flow needed a more cohesive visual system so login, registration, and approval states feel like one product experience
- the register page also needed a lower vertical footprint on desktop, so the role options now sit side-by-side

## User impact
- login and registration should feel more polished and easier to scan
- error and support messaging is clearer during auth flows
- role selection on registration is more compact on desktop while still stacking on small screens

## Validation
- `npm run build`