### PR TITLE
fix(admin-billing): refine page layout harmony

### DIFF
--- a/frontend/src/pages/admin/AdminBillingPage.jsx
+++ b/frontend/src/pages/admin/AdminBillingPage.jsx
@@ -64,23 +64,30 @@ export default function AdminBillingPage() {
   }
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel">
-        <p className="eyebrow">福委會結帳</p>
+    <section className="billing-layout">
+      <article className="panel billing-summary-panel">
+        <div className="billing-summary-head">
+          <p className="eyebrow">福委會結帳</p>
+          <span className="billing-month-badge">
+            {year} 年 {month} 月
+          </span>
+        </div>
         <h2>月度商家應收帳款</h2>
-        <div className="range-pills" role="group" aria-label="月份">
-          <label>
-            年
+        <p className="panel-copy billing-summary-copy">
+          選擇結帳月份後，可直接檢視各商家訂單、餐點數量與應收總額，並匯出 CSV。
+        </p>
+        <div className="billing-filter-grid" role="group" aria-label="月份">
+          <label className="field billing-filter-field">
+            <span className="field-label">年份</span>
             <input
               type="number"
               value={year}
               onChange={(e) => setYear(Number(e.target.value))}
               className="form-input"
-              style={{ width: 90, marginLeft: 6 }}
             />
           </label>
-          <label style={{ marginLeft: 12 }}>
-            月
+          <label className="field billing-filter-field">
+            <span className="field-label">月份</span>
             <input
               type="number"
               min="1"
@@ -88,37 +95,43 @@ export default function AdminBillingPage() {
               value={month}
               onChange={(e) => setMonth(Number(e.target.value))}
               className="form-input"
-              style={{ width: 70, marginLeft: 6 }}
             />
           </label>
           <a
-            className="range-pill"
+            className="range-pill billing-download-link"
             href="#"
             onClick={handleCsvDownload}
-            style={{ marginLeft: 12, textDecoration: "none" }}
           >
             下載 CSV
           </a>
         </div>
-        {csvError && <p className="error-state" style={{ marginTop: 8 }}>{csvError}</p>}
+        {csvError && <p className="error-state" style={{ marginTop: 12 }}>{csvError}</p>}
       </article>
 
       {loading && (
-        <article className="panel">
+        <article className="panel billing-table-panel">
           <p className="panel-copy">載入中…</p>
         </article>
       )}
       {error && (
-        <article className="panel">
+        <article className="panel billing-table-panel">
           <p className="error-state">{error}</p>
         </article>
       )}
 
       {!loading && !error && (
-        <article className="panel">
-          <h3>
-            {year} 年 {month} 月
-          </h3>
+        <article className="panel billing-table-panel">
+          <div className="billing-table-head">
+            <div>
+              <p className="eyebrow">帳款總覽</p>
+              <h3>
+                {year} 年 {month} 月
+              </h3>
+            </div>
+            <p className="panel-copy billing-table-meta">
+              共 {rows.length} 間商家
+            </p>
+          </div>
           <table className="data-table">
             <thead>
               <tr>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1271,6 +1271,79 @@ p {
   align-items: start;
 }
 
+.billing-layout {
+  display: grid;
+  grid-template-columns: minmax(300px, 420px) minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.billing-summary-panel,
+.billing-table-panel {
+  display: grid;
+  gap: 18px;
+}
+
+.billing-summary-panel {
+  min-height: 100%;
+}
+
+.billing-summary-head,
+.billing-table-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.billing-month-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid rgba(200, 92, 44, 0.18);
+  border-radius: 999px;
+  background: rgba(200, 92, 44, 0.08);
+  color: var(--brand-deep);
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.billing-summary-copy {
+  margin-top: -4px;
+}
+
+.billing-filter-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 14px;
+}
+
+.billing-filter-field {
+  gap: 8px;
+}
+
+.billing-download-link {
+  display: inline-flex;
+  grid-column: 1 / -1;
+  justify-content: center;
+  align-items: center;
+  min-height: 48px;
+  font-size: 0.88rem;
+  text-decoration: none;
+}
+
+.billing-table-head {
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(91, 76, 63, 0.08);
+}
+
+.billing-table-meta {
+  align-self: center;
+  font-size: 0.88rem;
+}
+
 .random-meal-controls {
   display: grid;
   gap: 18px;
@@ -1691,6 +1764,7 @@ p {
 @media (max-width: 1080px) {
 
   .login-shell,
+  .billing-layout,
   .dashboard-grid,
   .random-meal-layout,
   .app-shell {
@@ -1735,6 +1809,10 @@ p {
 
   .login-screen {
     gap: 18px;
+  }
+
+  .billing-filter-grid {
+    grid-template-columns: 1fr;
   }
 
   .login-hero-panel {


### PR DESCRIPTION
## Summary
- replace the shared dashboard grid on the admin billing page with a dedicated two-column billing layout
- reorganize the billing summary card so the month context, filters, and CSV action read more cleanly
- add page-specific billing styles to improve spacing, hierarchy, and responsive behavior

## Testing
- npm run build