### PR TITLE
feat(vendor-revenue): align date inputs with project form style

### DIFF
--- a/frontend/src/pages/vendor/VendorRevenuePage.jsx
+++ b/frontend/src/pages/vendor/VendorRevenuePage.jsx
@@ -126,23 +126,27 @@ export default function VendorRevenuePage() {
         aria-label="Custom date range"
         style={{ display: "flex", gap: 12, alignItems: "flex-end", flexWrap: "wrap", marginBottom: 20 }}
       >
-        <label style={{ display: "flex", flexDirection: "column", fontSize: 12 }}>
-          <span>開始日期</span>
+        <label style={{ display: "grid", gap: 6 }}>
+          <span style={{ fontWeight: 600, fontSize: 14 }}>開始日期</span>
           <input
+            className="date-input"
             type="date"
             value={startDate}
             max={endDate}
             onChange={(event) => setStartDate(event.target.value)}
+            style={{ width: "auto" }}
           />
         </label>
-        <label style={{ display: "flex", flexDirection: "column", fontSize: 12 }}>
-          <span>結束日期</span>
+        <label style={{ display: "grid", gap: 6 }}>
+          <span style={{ fontWeight: 600, fontSize: 14 }}>結束日期</span>
           <input
+            className="date-input"
             type="date"
             value={endDate}
             min={startDate}
             max={todayIso()}
             onChange={(event) => setEndDate(event.target.value)}
+            style={{ width: "auto" }}
           />
         </label>
       </div>


### PR DESCRIPTION
## Summary

Date inputs on the vendor revenue page were using bare `<input>` elements with inline styles, inconsistent with the rest of the project.

## Changes

- Applied `.date-input` class (used throughout the project)
- Updated label style to `fontWeight: 600, fontSize: 14` to match other form labels
- Changed layout from `flexDirection: column` to `display: grid, gap: 6` consistent with other form fields