### PR TITLE
feat(admin-stats): refresh dashboard UI

### DIFF
--- a/frontend/src/pages/admin/AdminStatsPage.jsx
+++ b/frontend/src/pages/admin/AdminStatsPage.jsx
@@ -20,6 +20,10 @@ function sharePct(part, total) {
   return `${((part / total) * 100).toFixed(1)}%`;
 }
 
+function numberText(value) {
+  return new Intl.NumberFormat("en-US").format(value ?? 0);
+}
+
 export default function AdminStatsPage() {
   const [stats, setStats] = useState(null);
   const [error, setError] = useState(null);
@@ -48,126 +52,200 @@ export default function AdminStatsPage() {
 
   const totalRevenue = stats?.summary.total_revenue_cents ?? 0;
   const totalMeals = stats?.summary.total_quantity ?? 0;
+  const topVendor = stats?.vendor_ranking[0] ?? null;
+  const topFacility = stats?.facility_distribution[0] ?? null;
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel">
-        <p className="eyebrow">營運概況</p>
-        <h2>訂餐總覽</h2>
-        {stats && (
-          <p className="panel-copy">
-            {stats.start} → {stats.end}
+    <section className="dashboard-grid admin-stats-page">
+      <article className="panel admin-stats-hero">
+        <div className="admin-stats-hero-copy">
+          <p className="eyebrow">營運概況</p>
+          <h2>訂餐總覽</h2>
+          <p className="panel-copy admin-stats-range-text">
+            {stats ? `${stats.start} → ${stats.end}` : "正在載入選定區間的訂餐統計資料"}
           </p>
-        )}
-        <div className="range-pills" role="group" aria-label="日期區間">
-          {RANGES.map((r) => (
-            <button
-              key={r.days}
-              type="button"
-              className={`range-pill${rangeDays === r.days ? " is-active" : ""}`}
-              onClick={() => setRangeDays(r.days)}
-              aria-pressed={rangeDays === r.days}
-            >
-              {r.label}
-            </button>
-          ))}
+        </div>
+        <div className="admin-stats-hero-side">
+          <div className="range-pills admin-stats-range-pills" role="group" aria-label="日期區間">
+            {RANGES.map((r) => (
+              <button
+                key={r.days}
+                type="button"
+                className={`range-pill${rangeDays === r.days ? " is-active" : ""}`}
+                onClick={() => setRangeDays(r.days)}
+                aria-pressed={rangeDays === r.days}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+          <div className="admin-stats-highlights" aria-label="重點摘要">
+            <div className="admin-stats-highlight">
+              <span>營收最高商家</span>
+              <strong>{topVendor?.vendor_name ?? "—"}</strong>
+            </div>
+            <div className="admin-stats-highlight">
+              <span>訂單最多廠區</span>
+              <strong>{topFacility?.facility_name ?? "未指派"}</strong>
+            </div>
+          </div>
         </div>
       </article>
 
       {loading && (
-        <article className="panel">
+        <article className="panel admin-stats-feedback">
           <p className="panel-copy">載入中…</p>
         </article>
       )}
       {error && (
-        <article className="panel">
+        <article className="panel admin-stats-feedback">
           <p className="error-state">{error}</p>
         </article>
       )}
 
       {stats && !loading && !error && (
         <>
-          <article className="panel stat-cards">
-            <div className="stat-card">
+          <article className="panel stat-cards admin-stats-metrics">
+            <div className="stat-card admin-stat-card">
               <span>訂單數</span>
-              <strong>{stats.summary.order_count}</strong>
+              <strong>{numberText(stats.summary.order_count)}</strong>
+              <small>總交易筆數</small>
             </div>
-            <div className="stat-card">
+            <div className="stat-card admin-stat-card">
               <span>營收</span>
               <strong>{formatMoney(totalRevenue)}</strong>
+              <small>區間累積營收</small>
             </div>
-            <div className="stat-card">
+            <div className="stat-card admin-stat-card">
               <span>餐點數</span>
-              <strong>{totalMeals}</strong>
+              <strong>{numberText(totalMeals)}</strong>
+              <small>總售出份數</small>
             </div>
-            <div className="stat-card">
+            <div className="stat-card admin-stat-card">
               <span>活躍商家</span>
-              <strong>{stats.summary.active_vendor_count}</strong>
+              <strong>{numberText(stats.summary.active_vendor_count)}</strong>
+              <small>此區間有接單的商家</small>
             </div>
           </article>
 
-          <article className="panel">
-            <h3>商家排行</h3>
-            <table className="data-table">
-              <thead>
-                <tr>
-                  <th>商家</th>
-                  <th>訂單</th>
-                  <th>餐點</th>
-                  <th>營收</th>
-                  <th>佔比</th>
-                </tr>
-              </thead>
-              <tbody>
-                {stats.vendor_ranking.map((v) => (
-                  <tr key={v.vendor_id}>
-                    <td>{v.vendor_name}</td>
-                    <td>{v.order_count}</td>
-                    <td>{v.quantity}</td>
-                    <td>{formatMoney(v.revenue_cents)}</td>
-                    <td>{sharePct(v.revenue_cents, totalRevenue)}</td>
-                  </tr>
-                ))}
-                {stats.vendor_ranking.length === 0 && (
+          <article className="panel admin-stats-table-panel">
+            <div className="admin-stats-section-head">
+              <div>
+                <p className="eyebrow">Vendor Performance</p>
+                <h3>商家排行</h3>
+              </div>
+              <p className="panel-copy">
+                依營收排序，共 {numberText(stats.vendor_ranking.length)} 間商家
+              </p>
+            </div>
+            <div className="admin-stats-table-wrap">
+              <table className="data-table admin-stats-table">
+                <thead>
                   <tr>
-                    <td colSpan={5} className="table-empty">
-                      此區間無資料
-                    </td>
+                    <th>商家</th>
+                    <th>訂單</th>
+                    <th>餐點</th>
+                    <th>營收</th>
+                    <th>佔比</th>
                   </tr>
-                )}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {stats.vendor_ranking.map((v, index) => (
+                    <tr key={v.vendor_id}>
+                      <td>
+                        <div className="admin-stats-entity">
+                          <span className="admin-stats-rank">{String(index + 1).padStart(2, "0")}</span>
+                          <div className="admin-stats-entity-copy">
+                            <strong>{v.vendor_name}</strong>
+                            <small>{sharePct(v.revenue_cents, totalRevenue)} 的總營收佔比</small>
+                          </div>
+                        </div>
+                      </td>
+                      <td>{numberText(v.order_count)}</td>
+                      <td>{numberText(v.quantity)}</td>
+                      <td>{formatMoney(v.revenue_cents)}</td>
+                      <td>
+                        <div className="admin-stats-share-cell">
+                          <span>{sharePct(v.revenue_cents, totalRevenue)}</span>
+                          <div className="admin-stats-share-track" aria-hidden="true">
+                            <div
+                              className="admin-stats-share-fill"
+                              style={{ width: totalRevenue ? `${(v.revenue_cents / totalRevenue) * 100}%` : "0%" }}
+                            />
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                  {stats.vendor_ranking.length === 0 && (
+                    <tr>
+                      <td colSpan={5} className="table-empty">
+                        此區間無資料
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
           </article>
 
-          <article className="panel">
-            <h3>廠區分布</h3>
-            <table className="data-table">
-              <thead>
-                <tr>
-                  <th>廠區</th>
-                  <th>訂單</th>
-                  <th>餐點</th>
-                  <th>佔比</th>
-                </tr>
-              </thead>
-              <tbody>
-                {stats.facility_distribution.map((f) => (
-                  <tr key={f.facility_id ?? "none"}>
-                    <td>{f.facility_name ?? "未指派"}</td>
-                    <td>{f.order_count}</td>
-                    <td>{f.quantity}</td>
-                    <td>{sharePct(f.quantity, totalMeals)}</td>
-                  </tr>
-                ))}
-                {stats.facility_distribution.length === 0 && (
+          <article className="panel admin-stats-table-panel">
+            <div className="admin-stats-section-head">
+              <div>
+                <p className="eyebrow">Facility Mix</p>
+                <h3>廠區分布</h3>
+              </div>
+              <p className="panel-copy">
+                依餐點數統計，共 {numberText(stats.facility_distribution.length)} 個廠區分組
+              </p>
+            </div>
+            <div className="admin-stats-table-wrap">
+              <table className="data-table admin-stats-table">
+                <thead>
                   <tr>
-                    <td colSpan={4} className="table-empty">
-                      此區間無資料
-                    </td>
+                    <th>廠區</th>
+                    <th>訂單</th>
+                    <th>餐點</th>
+                    <th>佔比</th>
                   </tr>
-                )}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {stats.facility_distribution.map((f, index) => (
+                    <tr key={f.facility_id ?? "none"}>
+                      <td>
+                        <div className="admin-stats-entity">
+                          <span className="admin-stats-rank">{String(index + 1).padStart(2, "0")}</span>
+                          <div className="admin-stats-entity-copy">
+                            <strong>{f.facility_name ?? "未指派"}</strong>
+                            <small>{sharePct(f.quantity, totalMeals)} 的餐點量佔比</small>
+                          </div>
+                        </div>
+                      </td>
+                      <td>{numberText(f.order_count)}</td>
+                      <td>{numberText(f.quantity)}</td>
+                      <td>
+                        <div className="admin-stats-share-cell">
+                          <span>{sharePct(f.quantity, totalMeals)}</span>
+                          <div className="admin-stats-share-track" aria-hidden="true">
+                            <div
+                              className="admin-stats-share-fill"
+                              style={{ width: totalMeals ? `${(f.quantity / totalMeals) * 100}%` : "0%" }}
+                            />
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                  {stats.facility_distribution.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="table-empty">
+                        此區間無資料
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
           </article>
         </>
       )}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1608,10 +1608,97 @@ p {
    Admin stats dashboard  (feat/analytics/order-aggregation-monitoring)
    ============================================================ */
 
+.admin-stats-page {
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  align-items: start;
+}
+
+.admin-stats-hero,
+.admin-stats-feedback,
+.admin-stats-metrics {
+  grid-column: 1 / -1;
+}
+
+.admin-stats-table-panel {
+  grid-column: span 6;
+  display: grid;
+  gap: 18px;
+}
+
+.admin-stats-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(320px, 0.95fr);
+  gap: 24px;
+  padding: 34px;
+  background:
+    radial-gradient(circle at top right, rgba(240, 180, 90, 0.28), transparent 34%),
+    linear-gradient(145deg, rgba(255, 252, 246, 0.92), rgba(249, 242, 232, 0.9));
+}
+
+.admin-stats-hero-copy {
+  display: grid;
+  gap: 12px;
+  align-content: start;
+}
+
+.admin-stats-range-text {
+  max-width: 52ch;
+}
+
+.admin-stats-hero-side {
+  display: grid;
+  gap: 18px;
+  align-content: start;
+  justify-items: end;
+}
+
+.admin-stats-range-pills {
+  margin-top: 0;
+  justify-content: flex-end;
+}
+
+.admin-stats-highlights {
+  display: grid;
+  gap: 12px;
+  width: min(100%, 360px);
+}
+
+.admin-stats-highlight {
+  display: grid;
+  gap: 6px;
+  padding: 18px 20px;
+  border: 1px solid rgba(200, 92, 44, 0.14);
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.admin-stats-highlight span,
+.admin-stat-card small,
+.admin-stats-entity-copy small {
+  color: var(--muted);
+}
+
+.admin-stats-highlight span {
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.admin-stats-highlight strong {
+  font-size: 1.08rem;
+  line-height: 1.35;
+}
+
 .stat-cards {
   display: flex;
   flex-wrap: wrap;
   gap: 14px;
+}
+
+.admin-stats-metrics {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.24), transparent),
+    rgba(255, 250, 241, 0.72);
 }
 
 .stat-card {
@@ -1637,6 +1724,18 @@ p {
   font-weight: 800;
   color: var(--text);
   line-height: 1.1;
+}
+
+.admin-stat-card {
+  gap: 8px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 247, 238, 0.68));
+}
+
+.admin-stat-card small {
+  font-size: 0.83rem;
+  line-height: 1.5;
 }
 
 /* Date-range presets on the stats dashboard */
@@ -1678,6 +1777,90 @@ p {
 .pw-toggle:focus-visible {
   outline: 2px solid var(--brand);
   outline-offset: 2px;
+}
+
+.admin-stats-section-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: end;
+  flex-wrap: wrap;
+}
+
+.admin-stats-section-head h3 {
+  margin-top: 8px;
+  margin-bottom: 0;
+}
+
+.admin-stats-table-wrap {
+  overflow-x: auto;
+}
+
+.admin-stats-table {
+  min-width: 620px;
+}
+
+.admin-stats-table td {
+  vertical-align: middle;
+}
+
+.admin-stats-entity {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 220px;
+}
+
+.admin-stats-rank {
+  display: inline-grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 36px;
+  border-radius: 12px;
+  background: rgba(240, 180, 90, 0.18);
+  color: var(--brand-deep);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.admin-stats-entity-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.admin-stats-entity-copy strong {
+  font-size: 0.96rem;
+  line-height: 1.35;
+}
+
+.admin-stats-entity-copy small {
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.admin-stats-share-cell {
+  display: grid;
+  gap: 8px;
+}
+
+.admin-stats-share-cell span {
+  font-weight: 700;
+}
+
+.admin-stats-share-track {
+  width: 100%;
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(23, 33, 43, 0.08);
+}
+
+.admin-stats-share-fill {
+  height: 100%;
+  min-width: 6px;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), var(--brand));
 }
 
 /* Daily-orders column chart (inline SVG) */
@@ -1775,6 +1958,26 @@ p {
     gap: 18px;
   }
 
+  .admin-stats-page {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-stats-table-panel {
+    grid-column: 1 / -1;
+  }
+
+  .admin-stats-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-stats-hero-side {
+    justify-items: start;
+  }
+
+  .admin-stats-range-pills {
+    justify-content: flex-start;
+  }
+
   .nav-list {
     grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
@@ -1813,6 +2016,10 @@ p {
 
   .billing-filter-grid {
     grid-template-columns: 1fr;
+  }
+
+  .admin-stats-table {
+    min-width: 560px;
   }
 
   .login-hero-panel {


### PR DESCRIPTION
## Summary

The admin stats page was functionally correct, but its layout and visual hierarchy were too generic for a dashboard view.

## Changes

- Reworked the stats page into a clearer three-part layout: summary hero, KPI cards, and two analytics sections
- Added top-level highlights for the highest-revenue vendor and busiest facility while keeping the same data source and behavior
- Refined the KPI cards with clearer supporting labels and improved spacing
- Upgraded the vendor ranking and facility distribution tables with rank badges, share bars, and better responsive overflow handling
- Added page-specific admin stats styles in `global.css` without changing shared behavior on other pages

## Testing

- `npm run build`
