### PR TITLE
fix(ci): gate build-push on unit tests passing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
           fi
 
   build-push:
-    needs: [integration, meta, frontend-test]
+    needs: [unit, integration, meta, frontend-test]
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## What

Add `unit` to the `build-push` job's `needs` list:

```yaml
build-push:
  needs: [unit, integration, meta, frontend-test]   # was: [integration, meta, frontend-test]
```

## Why

`build-push` previously only depended on `integration`, `meta` and `frontend-test`. Because no job depended on `unit`, a failing `unit` job did **not** block the deploy chain (`build-push` → `deploy-staging` / `deploy-preview`, and the prod path via `promote`). The workflow run showed red, but images were still built and deployed.

This makes the unit suite a real gate: a unit failure now blocks packaging and deployment, consistent with how integration and frontend tests already behave. The prod path is covered transitively, since `promote` re-tags the `sha-*` image produced by `build-push` on merge to main.

## Risk

Minimal — single-line change to the `needs` graph, no logic change.